### PR TITLE
fix: episode number extraction for titles with numbers

### DIFF
--- a/internal/api/episodes.go
+++ b/internal/api/episodes.go
@@ -92,17 +92,15 @@ func parseEpisodes(doc *goquery.Document) []Episode {
 // Returns:
 // - int: the parsed episode number.
 // - error: an error if the string cannot be converted to an integer.
-func parseEpisodeNumber(episodeNum string) (int, error) {
-	// Regular expression to find the first sequence of digits in the episode number string.
-	numRe := regexp.MustCompile(`\d+`)
-	numStr := numRe.FindString(episodeNum)
-	// If no digits are found, default to "1".
-	if numStr == "" {
-		numStr = "1"
+func parseEpisodeNumber(episodeStr string) (int, error) {
+	re := regexp.MustCompile(`(?i)epis[oó]dio\s+(\d+)`)
+	matches := re.FindStringSubmatch(episodeStr)
+	if len(matches) >= 2 {
+		return strconv.Atoi(matches[1])
 	}
-	// Convert the string to an integer and return it.
-	return strconv.Atoi(numStr)
+	return 1, nil
 }
+
 
 // sortEpisodesByNum sorts a slice of Episode structs in ascending order by the episode number.
 //

--- a/internal/player/scraper.go
+++ b/internal/player/scraper.go
@@ -156,12 +156,13 @@ func SelectEpisodeWithFuzzyFinder(episodes []api.Episode) (string, string, error
 
 // ExtractEpisodeNumber extracts the numeric part of an episode string
 func ExtractEpisodeNumber(episodeStr string) string {
-	numRe := regexp.MustCompile(`\d+`)
-	numStr := numRe.FindString(episodeStr)
-	if numStr == "" {
-		return "1"
+	numRe := regexp.MustCompile(`(?i)epis[oó]dio\s+(\d+)`)
+	matches := numRe.FindStringSubmatch(episodeStr)
+
+	if len(matches) >= 2 {
+		return matches[1]
 	}
-	return numStr
+	return "1"
 }
 
 // GetVideoURLForEpisode gets the video URL for a given episode URL


### PR DESCRIPTION
## Corrige falha ao assistir animes com números no título (ex: "86")
Evita capturar o número do título do anime como se fosse o número do episódio.

### Testado com:
- Anime "86 Eighty Six"
- Animes com título comum (sem número)

Closes #82