### PR TITLE
refactor: migrate to registry-based EpisodeProvider Strategy pattern

### DIFF
--- a/internal/api/allanime_enhanced.go
+++ b/internal/api/allanime_enhanced.go
@@ -5,54 +5,22 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/alvarorichard/Goanime/internal/api/providers"
 	"github.com/alvarorichard/Goanime/internal/models"
 	"github.com/alvarorichard/Goanime/internal/scraper"
 	"github.com/alvarorichard/Goanime/internal/util"
 )
 
-// GetEpisodeStreamURLEnhanced gets streaming URL with AllAnime navigation support
+// GetEpisodeStreamURLEnhanced gets streaming URL with AllAnime navigation support.
+// Uses the provider registry for source detection, then applies AllAnime-specific
+// direct resolution when applicable.
 func GetEpisodeStreamURLEnhanced(episode *models.Episode, anime *models.Anime, quality string) (string, error) {
-	// Determine source type and use appropriate method
-	sourceName := "Unknown"
-	scraperType := scraper.AllAnimeType // Default
-
-	// Enhanced source detection like in enhanced.go
-	if anime.Source != "" {
-		sourceName = anime.Source
-		if strings.Contains(anime.Source, "AllAnime") {
-			scraperType = scraper.AllAnimeType
-		} else if strings.Contains(anime.Source, "AnimeFire") {
-			scraperType = scraper.AnimefireType
-		}
-	} else if strings.Contains(anime.Name, "[AllAnime]") {
-		// Priority 1: Name tag detection
-		scraperType = scraper.AllAnimeType
-		sourceName = "AllAnime"
-	} else if strings.Contains(anime.Name, "[AnimeFire]") {
-		// Priority 2: AnimeFire tag detection
-		scraperType = scraper.AnimefireType
-		sourceName = "Animefire.io"
-	} else if len(anime.URL) < 30 && strings.ContainsAny(anime.URL, "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789") && !strings.Contains(anime.URL, "http") {
-		// Priority 3: URL analysis for AllAnime (short IDs)
-		scraperType = scraper.AllAnimeType
-		sourceName = "AllAnime"
-	} else if strings.Contains(anime.URL, "animefire") {
-		// Priority 4: URL analysis for AnimeFire
-		scraperType = scraper.AnimefireType
-		sourceName = "Animefire.io"
-	} else if strings.Contains(anime.URL, "allanime") {
-		// Priority 5: AllAnime full URLs
-		scraperType = scraper.AllAnimeType
-		sourceName = "AllAnime"
-	}
-
 	util.Debug("Enhanced episode URL fetch",
-		"source", sourceName,
+		"source", providers.ResolveSourceName(anime),
 		"episode", episode.Number,
 		"quality", quality)
 
-	// Use AllAnime enhanced navigation if applicable
-	if scraperType == scraper.AllAnimeType {
+	if providers.IsAllAnime(anime) {
 		url, metadata, err := GetAllAnimeEpisodeURLDirect(anime, episode.Number, quality)
 		if err != nil {
 			return "", fmt.Errorf("failed to get AllAnime episode URL: %w", err)
@@ -66,7 +34,6 @@ func GetEpisodeStreamURLEnhanced(episode *models.Episode, anime *models.Anime, q
 		return url, nil
 	}
 
-	// Fallback to regular enhanced API
 	return GetEpisodeStreamURL(episode, anime, quality)
 }
 

--- a/internal/api/enhanced.go
+++ b/internal/api/enhanced.go
@@ -4,53 +4,46 @@ package api
 import (
 	"errors"
 	"fmt"
-	"math"
-	"os"
 	"sort"
 	"strings"
+
 	"sync"
 
-	"charm.land/huh/v2/spinner"
+	"github.com/alvarorichard/Goanime/internal/api/providers"
 	"github.com/alvarorichard/Goanime/internal/models"
 	"github.com/alvarorichard/Goanime/internal/scraper"
 	"github.com/alvarorichard/Goanime/internal/util"
 	"github.com/ktr0731/go-fuzzyfinder"
-	"github.com/manifoldco/promptui"
-	"golang.org/x/term"
 )
 
-// Cached terminal detection (checked once, reused)
-var (
-	stdoutIsTerminal     bool
-	stdoutIsTerminalOnce sync.Once
-)
+var initProvidersOnce sync.Once
 
-func isStdoutTerminal() bool {
-	stdoutIsTerminalOnce.Do(func() {
-		fd := os.Stdout.Fd()
-		stdoutIsTerminal = fd <= math.MaxInt && term.IsTerminal(int(fd))
+// initProviders injects dependencies into providers that cannot import the api package
+// directly (to avoid circular imports). Called lazily on first use.
+func initProviders() {
+	initProvidersOnce.Do(func() {
+		p := providers.ForSourceName("allanime")
+		if ap, ok := p.(*providers.AllAnimeProvider); ok {
+			ap.SetAniSkipFunc(GetAndParseAniSkipData)
+		}
 	})
-	return stdoutIsTerminal
-}
-
-// runWithSpinner runs the action with a spinner if stdout is a terminal,
-// otherwise runs the action directly. This ensures CI and non-interactive
-// environments work correctly since huh/v2 spinner may skip the Action
-// callback when no terminal is attached.
-func runWithSpinner(title string, action func()) {
-	if isStdoutTerminal() {
-		_ = spinner.New().
-			Title(title).
-			Type(spinner.Dots).
-			Action(action).
-			Run()
-	} else {
-		action()
-	}
 }
 
 // ErrBackToSearch is returned when user selects the back option to search again
 var ErrBackToSearch = errors.New("back to search requested")
+
+// sourceToScraperType maps CLI --source values to scraper types.
+var sourceToScraperType = map[string]scraper.ScraperType{
+	"allanime":   scraper.AllAnimeType,
+	"animefire":  scraper.AnimefireType,
+	"animedrive": scraper.AnimeDriveType,
+	"flixhq":     scraper.FlixHQType,
+	"movie":      scraper.FlixHQType,
+	"tv":         scraper.FlixHQType,
+	"9anime":     scraper.NineAnimeType,
+	"nineanime":  scraper.NineAnimeType,
+	"goyabu":     scraper.GoyabuType,
+}
 
 // Enhanced search that supports multiple sources - always searches both Animefire.io and allanime simultaneously
 func SearchAnimeEnhanced(name string, source string) (*models.Anime, error) {
@@ -59,38 +52,16 @@ func SearchAnimeEnhanced(name string, source string) (*models.Anime, error) {
 	var scraperType *scraper.ScraperType
 	isPTBR := false
 
-	// If a specific source is requested, honor it
-	if strings.ToLower(source) == "allanime" {
-		t := scraper.AllAnimeType
-		scraperType = &t
-		util.Debug("Searching specific source", "source", "AllAnime")
-	} else if strings.ToLower(source) == "animefire" {
-		t := scraper.AnimefireType
-		scraperType = &t
-		util.Debug("Searching specific source", "source", "AnimeFire")
-	} else if strings.ToLower(source) == "animedrive" {
-		t := scraper.AnimeDriveType
-		scraperType = &t
-		util.Debug("Searching specific source", "source", "AnimeDrive")
-	} else if strings.ToLower(source) == "flixhq" || strings.ToLower(source) == "movie" || strings.ToLower(source) == "tv" {
-		t := scraper.FlixHQType
-		scraperType = &t
-		util.Debug("Searching specific source", "source", "FlixHQ")
-	} else if strings.ToLower(source) == "9anime" || strings.ToLower(source) == "nineanime" {
-		t := scraper.NineAnimeType
-		scraperType = &t
-		util.Debug("Searching specific source", "source", "9Anime")
-	} else if strings.ToLower(source) == "goyabu" {
-		t := scraper.GoyabuType
-		scraperType = &t
-		util.Debug("Searching specific source", "source", "Goyabu")
-	} else if strings.ToLower(source) == "ptbr" || strings.ToLower(source) == "pt-br" {
-		// Search only PT-BR sources (AnimeFire + Goyabu) via dedicated method
+	lowerSource := strings.ToLower(source)
+	if lowerSource == "ptbr" || lowerSource == "pt-br" {
 		isPTBR = true
 		util.Debug("Searching all PT-BR sources (AnimeFire + Goyabu)")
+	} else if st, ok := sourceToScraperType[lowerSource]; ok {
+		scraperType = &st
+		util.Debug("Searching specific source", "source", lowerSource)
+	} else if lowerSource != "" {
+		util.Debug("Unknown source, searching all", "source", lowerSource)
 	} else {
-		// Default behavior: search all sources simultaneously (including FlixHQ)
-		scraperType = nil
 		util.Debug("Searching all sources", "query", name)
 	}
 
@@ -98,7 +69,7 @@ func SearchAnimeEnhanced(name string, source string) (*models.Anime, error) {
 	util.Debug("Searching for anime/media", "query", name)
 	var animes []*models.Anime
 	var searchErr error
-	runWithSpinner("Searching for anime...", func() {
+	util.RunWithSpinner("Searching for anime...", func() {
 		if isPTBR {
 			animes, searchErr = scraperManager.SearchAnimePTBR(name)
 		} else {
@@ -238,287 +209,62 @@ func SearchAnimeEnhanced(name string, source string) (*models.Anime, error) {
 	return selectedAnime, nil
 }
 
-// Enhanced episode fetching that works with different sources
+// Enhanced episode fetching that works with different sources.
+// Delegates to the appropriate EpisodeProvider via the registry.
 func GetAnimeEpisodesEnhanced(anime *models.Anime) ([]models.Episode, error) {
-	// Check if this is a FlixHQ movie/TV show
-	if anime.Source == "FlixHQ" || anime.MediaType == models.MediaTypeMovie || anime.MediaType == models.MediaTypeTV {
-		return GetFlixHQEpisodes(anime)
-	}
+	initProviders()
 
-	// Check if this is a 9Anime source
-	if anime.Source == "9Anime" {
-		return GetNineAnimeEpisodes(anime)
-	}
+	provider := providers.ForSource(anime)
+	sourceName := providers.ResolveSourceName(anime)
 
-	// Determine source type from multiple indicators with enhanced logic
-	var sourceName string
+	util.Debug("Getting episodes", "source", provider.Name(), "resolved", sourceName)
 
-	// Priority 1: Check the Source field (most reliable)
-	if anime.Source == "AllAnime" {
-		sourceName = "AllAnime"
-	} else if strings.Contains(anime.Source, "AnimeFire") {
-		sourceName = "Animefire.io"
-	} else if anime.Source == "AnimeDrive" {
-		sourceName = "AnimeDrive"
-	} else if anime.Source == "Goyabu" {
-		sourceName = "Goyabu"
-	} else if strings.Contains(anime.Name, "[English]") {
-		// Priority 2: Check language tags
-		// Need to disambiguate between AllAnime and 9Anime both tagged [English]
-		// 9Anime source is already set above, so remaining [English] = AllAnime
-		sourceName = "AllAnime"
-		anime.Source = "AllAnime" // Update source field
-	} else if strings.Contains(anime.Name, "[PT-BR]") || strings.Contains(anime.Name, "[Português]") {
-		// AnimeFire or AnimeDrive = Portuguese
-		// Check URL to determine which one
-		if strings.Contains(anime.URL, "animesdrive") {
-			sourceName = "AnimeDrive"
-			anime.Source = "AnimeDrive"
-		} else if strings.Contains(anime.URL, "goyabu") {
-			sourceName = "Goyabu"
-			anime.Source = "Goyabu"
-		} else {
-			sourceName = "Animefire.io"
-			anime.Source = "Animefire.io"
-		}
-	} else if strings.Contains(anime.URL, "allanime") || (len(anime.URL) < 30 && strings.ContainsAny(anime.URL, "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789") && !strings.Contains(anime.URL, "http")) {
-		// Priority 3: URL analysis for AllAnime (short IDs or allanime URLs)
-		sourceName = "AllAnime"
-		anime.Source = "AllAnime" // Update source field
-	} else if strings.Contains(anime.URL, "animefire") {
-		// Priority 4: URL analysis for AnimeFire
-		sourceName = "Animefire.io"
-		anime.Source = "Animefire.io" // Update source field
-	} else if strings.Contains(anime.URL, "animesdrive") {
-		// Priority 5: URL analysis for AnimeDrive
-		sourceName = "AnimeDrive"
-		anime.Source = "AnimeDrive" // Update source field
-	} else {
-		// Default to AllAnime for unknown sources
-		sourceName = "AllAnime (default)"
-		anime.Source = "AllAnime"
-	}
-
-	cleanName := strings.TrimSpace(strings.ReplaceAll(strings.ReplaceAll(anime.Name, "[English]", ""), "[PT-BR]", ""))
-
-	util.Debug("Getting episodes", "source", sourceName, "anime", cleanName)
-
-	scraperManager := scraper.NewScraperManager()
-	var episodes []models.Episode
-	var err error
-
-	// Use different approaches based on source
-	if strings.Contains(sourceName, "AllAnime") {
-		scraperInstance, scErr := scraperManager.GetScraper(scraper.AllAnimeType)
-		if scErr != nil {
-			return nil, fmt.Errorf("failed to get AllAnime scraper: %w", scErr)
-		}
-
-		// Cast to AllAnime client to access enhanced features
-		if allAnimeClient, ok := scraperInstance.(*scraper.AllAnimeClient); ok && anime.MalID > 0 {
-			episodes, err = allAnimeClient.GetAnimeEpisodesWithAniSkip(anime.URL, anime.MalID, GetAndParseAniSkipData)
-			util.Debug("AniSkip integration enabled", "malID", anime.MalID)
-		} else {
-			episodes, err = scraperInstance.GetAnimeEpisodes(anime.URL)
-		}
-	} else if sourceName == "AnimeDrive" {
-		scraperInstance, scErr := scraperManager.GetScraper(scraper.AnimeDriveType)
-		if scErr != nil {
-			return nil, fmt.Errorf("failed to get AnimeDrive scraper: %w", scErr)
-		}
-		episodes, err = scraperInstance.GetAnimeEpisodes(anime.URL)
-	} else if sourceName == "Animefire.io" {
-		scraperInstance, scErr := scraperManager.GetScraper(scraper.AnimefireType)
-		if scErr != nil {
-			return nil, fmt.Errorf("failed to get AnimeFire scraper: %w", scErr)
-		}
-		episodes, err = scraperInstance.GetAnimeEpisodes(anime.URL)
-	} else if sourceName == "Goyabu" {
-		scraperInstance, scErr := scraperManager.GetScraper(scraper.GoyabuType)
-		if scErr != nil {
-			return nil, fmt.Errorf("failed to get Goyabu scraper: %w", scErr)
-		}
-		episodes, err = scraperInstance.GetAnimeEpisodes(anime.URL)
-	} else {
-		// For others, use the original API function
-		episodes, err = GetAnimeEpisodes(anime.URL)
-	}
-
+	episodes, err := provider.FetchEpisodes(anime)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get episodes from %s: %w", sourceName, err)
+		return nil, fmt.Errorf("failed to get episodes from %s: %w", provider.Name(), err)
 	}
 
 	if len(episodes) > 0 {
-		util.Debug("Episodes found", "count", len(episodes), "source", sourceName)
-
-		// Provide additional info for user based on source (debug only)
-		if strings.Contains(sourceName, "AllAnime") {
-			util.Debug("Source info", "type", "AllAnime", "quality", "high")
-		} else if sourceName == "AnimeDrive" {
-			util.Debug("Source info", "type", "AnimeDrive", "features", "multiple qualities")
-		} else {
-			util.Debug("Source info", "type", "Animefire.io", "features", "dubbed/subtitled")
-		}
+		util.Debug("Episodes found", "count", len(episodes), "source", provider.Name())
 	} else {
-		util.Warn("No episodes found", "source", sourceName)
+		util.Warn("No episodes found", "source", provider.Name())
 	}
 
 	return episodes, nil
 }
 
-// Enhanced episode URL fetching with improved source detection
+// Enhanced episode URL fetching with improved source detection.
+// Delegates to the appropriate EpisodeProvider via the registry.
 func GetEpisodeStreamURL(episode *models.Episode, anime *models.Anime, quality string) (string, error) {
-	// Clear any previous subtitles
+	initProviders()
+
 	util.ClearGlobalSubtitles()
 
-	// Track anime source globally for subtitle selection and other source-specific behavior
 	if anime != nil && anime.Source != "" {
 		util.SetGlobalAnimeSource(anime.Source)
 	}
 
-	// Check if this is FlixHQ content
-	if anime.Source == "FlixHQ" || anime.MediaType == models.MediaTypeMovie || anime.MediaType == models.MediaTypeTV {
-		streamURL, subtitles, err := GetFlixHQStreamURL(anime, episode, quality)
-		if err != nil {
-			return "", err
-		}
+	provider := providers.ForSource(anime)
 
-		// Store subtitles globally for playback
-		if len(subtitles) > 0 && !util.GlobalNoSubs {
-			var subInfos []util.SubtitleInfo
-			for _, sub := range subtitles {
-				subInfos = append(subInfos, util.SubtitleInfo{
-					URL:      sub.URL,
-					Language: sub.Language,
-					Label:    sub.Label,
-				})
-			}
-			util.SetGlobalSubtitles(subInfos)
-		}
-
-		return streamURL, nil
-	}
-
-	// Check if this is 9Anime content
-	if anime.Source == "9Anime" {
-		return GetNineAnimeStreamURL(anime, episode, quality)
-	}
-
-	scraperManager := scraper.NewScraperManager()
-
-	// Determine source type with enhanced logic
-	var scraperType scraper.ScraperType
-	var sourceName string
-
-	// Priority 1: Check the Source field (most reliable)
-	if anime.Source == "AllAnime" {
-		scraperType = scraper.AllAnimeType
-		sourceName = "AllAnime"
-	} else if strings.Contains(anime.Source, "AnimeFire") {
-		scraperType = scraper.AnimefireType
-		sourceName = "Animefire.io"
-	} else if anime.Source == "AnimeDrive" {
-		scraperType = scraper.AnimeDriveType
-		sourceName = "AnimeDrive"
-	} else if anime.Source == "Goyabu" {
-		scraperType = scraper.GoyabuType
-		sourceName = "Goyabu"
-	} else if strings.Contains(anime.Name, "[English]") {
-		// Priority 2: Check language tags (AllAnime = English)
-		scraperType = scraper.AllAnimeType
-		sourceName = "AllAnime"
-	} else if strings.Contains(anime.Name, "[PT-BR]") || strings.Contains(anime.Name, "[Português]") {
-		// AnimeFire, Goyabu, or AnimeDrive = Portuguese
-		// Check URL to determine which one
-		if strings.Contains(anime.URL, "animesdrive") {
-			scraperType = scraper.AnimeDriveType
-			sourceName = "AnimeDrive"
-		} else if strings.Contains(anime.URL, "goyabu") {
-			scraperType = scraper.GoyabuType
-			sourceName = "Goyabu"
-		} else {
-			scraperType = scraper.AnimefireType
-			sourceName = "Animefire.io"
-		}
-	} else if len(anime.URL) < 30 && strings.ContainsAny(anime.URL, "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789") && !strings.Contains(anime.URL, "http") {
-		// Priority 3: URL analysis for AllAnime (short IDs)
-		scraperType = scraper.AllAnimeType
-		sourceName = "AllAnime"
-	} else if strings.Contains(anime.URL, "animefire") {
-		// Priority 4: URL analysis for AnimeFire
-		scraperType = scraper.AnimefireType
-		sourceName = "Animefire.io"
-	} else if strings.Contains(anime.URL, "animesdrive") {
-		// Priority 5: URL analysis for AnimeDrive
-		scraperType = scraper.AnimeDriveType
-		sourceName = "AnimeDrive"
-	} else if strings.Contains(anime.URL, "goyabu") {
-		// Priority 5b: URL analysis for Goyabu
-		scraperType = scraper.GoyabuType
-		sourceName = "Goyabu"
-	} else if strings.Contains(anime.URL, "allanime") {
-		// Priority 6: AllAnime full URLs
-		scraperType = scraper.AllAnimeType
-		sourceName = "AllAnime"
-	} else {
-		// Default to AllAnime
-		scraperType = scraper.AllAnimeType
-		sourceName = "AllAnime (default)"
-	}
-
-	util.Debug("Getting stream URL", "source", sourceName, "episode", episode.Number)
-
-	util.Debug("Source details",
-		"scraperType", scraperType,
-		"animeURL", anime.URL,
-		"episodeURL", episode.URL,
-		"episodeNumber", episode.Number,
-		"quality", quality)
-
-	scraperInstance, err := scraperManager.GetScraper(scraperType)
-	if err != nil {
-		return "", fmt.Errorf("failed to get scraper for %s: %w", sourceName, err)
-	}
+	util.Debug("Getting stream URL", "source", provider.Name(), "episode", episode.Number)
 
 	if quality == "" {
 		quality = "best"
 	}
 
-	var streamURL string
-	var streamErr error
-
-	// Handle different scraper types with appropriate parameters
-	switch scraperType {
-	case scraper.AllAnimeType:
-		util.Debug("Processing through AllAnime")
-		streamURL, _, streamErr = scraperInstance.GetStreamURL(anime.URL, episode.Number, quality)
-	case scraper.AnimeDriveType:
-		util.Debug("Processing through AnimeDrive")
-		// Use "auto" to skip interactive server selection (this runs inside a spinner)
-		streamURL, _, streamErr = scraperInstance.GetStreamURL(episode.URL, "auto")
-	case scraper.GoyabuType:
-		util.Debug("Processing through Goyabu")
-		streamURL, _, streamErr = scraperInstance.GetStreamURL(episode.URL)
-	default:
-		util.Debug("Processing through Animefire.io")
-		streamURL, _, streamErr = scraperInstance.GetStreamURL(episode.URL, quality)
-	}
-
-	if streamErr != nil {
-		// Propagate back request error without wrapping
-		if errors.Is(streamErr, scraper.ErrBackRequested) {
-			return "", streamErr
+	streamURL, err := provider.GetStreamURL(episode, anime, quality)
+	if err != nil {
+		if errors.Is(err, scraper.ErrBackRequested) {
+			return "", err
 		}
-		return "", fmt.Errorf("failed to get stream URL from %s: %w", sourceName, streamErr)
+		return "", fmt.Errorf("failed to get stream URL from %s: %w", provider.Name(), err)
 	}
 
 	if streamURL == "" {
-		return "", fmt.Errorf("empty stream URL returned from %s", sourceName)
+		return "", fmt.Errorf("empty stream URL returned from %s", provider.Name())
 	}
 
-	util.Debug("Stream URL obtained", "source", sourceName)
-	util.Debug("Stream URL details", "url", streamURL)
-
+	util.Debug("Stream URL obtained", "source", provider.Name())
 	return streamURL, nil
 }
 
@@ -612,350 +358,6 @@ func downloadFromURL(_ string, _ string) error {
 // Legacy wrapper functions to maintain compatibility
 func SearchAnimeWithSource(name string, source string) (*models.Anime, error) {
 	return SearchAnimeEnhanced(name, source)
-}
-
-// GetNineAnimeEpisodes handles episode fetching for 9anime sources
-func GetNineAnimeEpisodes(anime *models.Anime) ([]models.Episode, error) {
-	nineAnimeClient := scraper.NewNineAnimeClient()
-
-	// anime.URL contains the 9anime anime ID
-	animeID := anime.URL
-	util.Debug("Getting 9Anime episodes", "animeID", animeID)
-
-	episodes, err := nineAnimeClient.GetAnimeEpisodes(animeID)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get episodes from 9Anime: %w", err)
-	}
-
-	util.Debug("9Anime episodes loaded", "count", len(episodes))
-	return episodes, nil
-}
-
-// GetNineAnimeStreamURL gets the stream URL for 9anime content
-func GetNineAnimeStreamURL(anime *models.Anime, episode *models.Episode, quality string) (string, error) {
-	util.ClearGlobalSubtitles()
-	util.SetGlobalAnimeSource("9Anime")
-
-	nineAnimeClient := scraper.NewNineAnimeClient()
-
-	// episode.URL / episode.DataID contains the episode data-id
-	episodeID := episode.DataID
-	if episodeID == "" {
-		episodeID = episode.URL
-	}
-
-	util.Debug("Getting 9Anime stream", "episodeID", episodeID, "quality", quality)
-
-	// Use the unified GetStreamURL which tries multiple servers automatically
-	streamURL, metadata, err := nineAnimeClient.GetStreamURL(episodeID, "sub")
-	if err != nil {
-		return "", fmt.Errorf("failed to get stream URL from 9Anime: %w", err)
-	}
-
-	// Store referer globally for mpv playback
-	if referer, ok := metadata["referer"]; ok && referer != "" {
-		util.SetGlobalReferer(referer)
-	}
-
-	// Store subtitles globally for playback
-	if subtitleURLs, ok := metadata["subtitles"]; ok && subtitleURLs != "" && !util.GlobalNoSubs {
-		subURLs := strings.Split(subtitleURLs, ",")
-		var subLabels []string
-		if labels, ok := metadata["subtitle_labels"]; ok {
-			subLabels = strings.Split(labels, ",")
-		}
-
-		var subInfos []util.SubtitleInfo
-		for i, subURL := range subURLs {
-			label := "Unknown"
-			lang := "unknown"
-			if i < len(subLabels) {
-				label = subLabels[i]
-				// Try to extract language code from label
-				labelLower := strings.ToLower(label)
-				if strings.Contains(labelLower, "english") {
-					lang = "eng"
-				} else if strings.Contains(labelLower, "portuguese") {
-					lang = "por"
-				} else if strings.Contains(labelLower, "spanish") {
-					lang = "spa"
-				} else if strings.Contains(labelLower, "japanese") {
-					lang = "jpn"
-				} else if strings.Contains(labelLower, "french") {
-					lang = "fre"
-				} else if strings.Contains(labelLower, "german") {
-					lang = "ger"
-				} else if strings.Contains(labelLower, "italian") {
-					lang = "ita"
-				} else if strings.Contains(labelLower, "arabic") {
-					lang = "ara"
-				}
-			}
-			subInfos = append(subInfos, util.SubtitleInfo{
-				URL:      subURL,
-				Language: lang,
-				Label:    label,
-			})
-		}
-		util.SetGlobalSubtitles(subInfos)
-		util.Debug("9Anime subtitles loaded", "count", len(subInfos))
-	}
-
-	util.Debug("9Anime stream URL obtained", "url", streamURL[:min(len(streamURL), 80)])
-	return streamURL, nil
-}
-
-// GetFlixHQEpisodes handles episodes/content for FlixHQ movies and TV shows
-func GetFlixHQEpisodes(media *models.Anime) ([]models.Episode, error) {
-	flixhqClient := scraper.NewFlixHQClient()
-
-	// Extract media ID from URL
-	mediaID := extractMediaIDFromURL(media.URL)
-	if mediaID == "" {
-		return nil, fmt.Errorf("could not extract media ID from URL: %s", media.URL)
-	}
-
-	util.Debug("Getting FlixHQ content", "mediaType", media.MediaType, "mediaID", mediaID)
-
-	// For movies, return a single "episode" representing the movie
-	if media.MediaType == models.MediaTypeMovie {
-		util.Debug("FlixHQ: Processing movie")
-		return []models.Episode{
-			{
-				Number: "1",
-				Num:    1,
-				URL:    mediaID, // Store media ID for later use
-				Title: models.TitleDetails{
-					English: media.Name,
-					Romaji:  media.Name,
-				},
-			},
-		}, nil
-	}
-
-	// For TV shows, get seasons and let user select
-	util.Debug("FlixHQ: Processing TV show, getting seasons")
-
-	// Use spinner for loading seasons (network call)
-	var seasons []scraper.FlixHQSeason
-	var seasonsErr error
-	runWithSpinner("Loading seasons...", func() {
-		seasons, seasonsErr = flixhqClient.GetSeasons(mediaID)
-	})
-	if seasonsErr != nil {
-		return nil, fmt.Errorf("failed to get seasons: %w", seasonsErr)
-	}
-
-	if len(seasons) == 0 {
-		return nil, fmt.Errorf("no seasons found for TV show")
-	}
-
-	// Let user select a season
-	seasonNames := make([]string, len(seasons))
-	for i, s := range seasons {
-		seasonNames[i] = s.Title
-	}
-
-	seasonIdx, err := fuzzyfinder.Find(
-		seasonNames,
-		func(i int) string { return seasonNames[i] },
-		fuzzyfinder.WithPromptString("Select season: "),
-	)
-	if err != nil {
-		return nil, fmt.Errorf("season selection cancelled: %w", err)
-	}
-
-	selectedSeason := seasons[seasonIdx]
-	util.Debug("Selected season", "season", selectedSeason.Title, "id", selectedSeason.ID)
-
-	// Clear the fuzzy finder output before showing the spinner
-	fmt.Print("\033[2K\033[1A\033[2K\r")
-
-	// Use spinner for loading episodes (network call)
-	var flixEpisodes []scraper.FlixHQEpisode
-	var episodesErr error
-	runWithSpinner("Loading episodes...", func() {
-		flixEpisodes, episodesErr = flixhqClient.GetEpisodes(selectedSeason.ID)
-	})
-	if episodesErr != nil {
-		return nil, fmt.Errorf("failed to get episodes: %w", episodesErr)
-	}
-
-	// Convert to models.Episode
-	var episodes []models.Episode
-	for _, ep := range flixEpisodes {
-		episodes = append(episodes, models.Episode{
-			Number: fmt.Sprintf("%d", ep.Number),
-			Num:    ep.Number,
-			URL:    ep.DataID, // Store DataID for stream retrieval
-			Title: models.TitleDetails{
-				English: ep.Title,
-				Romaji:  ep.Title,
-			},
-			DataID:   ep.DataID,
-			SeasonID: selectedSeason.ID,
-		})
-	}
-
-	util.Debug("FlixHQ episodes loaded", "count", len(episodes))
-	return episodes, nil
-}
-
-// GetFlixHQStreamURL gets the stream URL for FlixHQ content
-func GetFlixHQStreamURL(media *models.Anime, episode *models.Episode, quality string) (string, []models.Subtitle, error) {
-	flixhqClient := scraper.NewFlixHQClient()
-	// Set media path for decryption API
-	if media.URL != "" {
-		flixhqClient.SetMediaPath(scraper.ExtractMediaPath(media.URL))
-	}
-	provider := "Vidcloud"
-	subsLanguage := util.GlobalSubsLanguage
-	if subsLanguage == "" {
-		subsLanguage = "english"
-	}
-
-	var streamInfo *scraper.FlixHQStreamInfo
-	var episodeID string
-	var embedLink string
-	var streamErr error
-
-	if media.MediaType == models.MediaTypeMovie {
-		// For movies, episode.URL contains the media ID
-		mediaID := episode.URL
-		util.Debug("Getting movie stream", "mediaID", mediaID)
-
-		// Run network calls (server ID, embed link, stream extraction) with optional spinner
-		runWithSpinner("Loading movie stream...", func() {
-			episodeID, streamErr = flixhqClient.GetMovieServerID(mediaID, provider)
-			if streamErr != nil {
-				return
-			}
-
-			embedLink, streamErr = flixhqClient.GetEmbedLink(episodeID)
-			if streamErr != nil {
-				return
-			}
-
-			// Extract stream info to get available qualities
-			streamInfo, streamErr = flixhqClient.ExtractStreamInfo(embedLink, "auto", subsLanguage)
-		})
-
-		if streamErr != nil {
-			return "", nil, fmt.Errorf("failed to get movie stream: %w", streamErr)
-		}
-
-		if streamInfo == nil {
-			return "", nil, fmt.Errorf("failed to get movie stream: no stream info returned")
-		}
-
-		// If we have multiple quality options, let user choose (UI - no spinner needed)
-		if len(streamInfo.Qualities) > 1 {
-			selectedQuality, selectErr := selectFlixHQQualityOptions(streamInfo.Qualities)
-			if selectErr == nil && selectedQuality.URL != "" {
-				streamInfo.VideoURL = selectedQuality.URL
-				streamInfo.Quality = string(selectedQuality.Quality)
-				streamInfo.IsM3U8 = selectedQuality.IsM3U8
-			}
-		}
-	} else {
-		// For TV shows, episode.URL contains the DataID
-		dataID := episode.URL
-		util.Debug("Getting TV episode stream", "dataID", dataID)
-
-		// Run network calls (server ID, embed link, stream extraction) with optional spinner
-		runWithSpinner("Loading episode stream...", func() {
-			episodeID, streamErr = flixhqClient.GetEpisodeServerID(dataID, provider)
-			if streamErr != nil {
-				return
-			}
-
-			embedLink, streamErr = flixhqClient.GetEmbedLink(episodeID)
-			if streamErr != nil {
-				return
-			}
-
-			// Extract stream info to get available qualities
-			streamInfo, streamErr = flixhqClient.ExtractStreamInfo(embedLink, "auto", subsLanguage)
-		})
-
-		if streamErr != nil {
-			return "", nil, fmt.Errorf("failed to get episode stream: %w", streamErr)
-		}
-
-		if streamInfo == nil {
-			return "", nil, fmt.Errorf("failed to get episode stream: no stream info returned")
-		}
-
-		// If we have multiple quality options, let user choose (UI - no spinner needed)
-		if len(streamInfo.Qualities) > 1 {
-			selectedQuality, selectErr := selectFlixHQQualityOptions(streamInfo.Qualities)
-			if selectErr == nil && selectedQuality.URL != "" {
-				streamInfo.VideoURL = selectedQuality.URL
-				streamInfo.Quality = string(selectedQuality.Quality)
-				streamInfo.IsM3U8 = selectedQuality.IsM3U8
-			}
-		}
-	}
-
-	// Convert subtitles
-	var subtitles []models.Subtitle
-	for _, sub := range streamInfo.Subtitles {
-		subtitles = append(subtitles, models.Subtitle{
-			URL:      sub.URL,
-			Language: sub.Language,
-			Label:    sub.Label,
-		})
-	}
-
-	// Store the referer globally for use in downloads
-	if streamInfo.Referer != "" {
-		util.SetGlobalReferer(streamInfo.Referer)
-	}
-
-	return streamInfo.VideoURL, subtitles, nil
-}
-
-// selectFlixHQQualityOptions shows a menu for the user to select video quality from FlixHQQualityOption
-func selectFlixHQQualityOptions(qualities []scraper.FlixHQQualityOption) (scraper.FlixHQQualityOption, error) {
-	if len(qualities) == 0 {
-		return scraper.FlixHQQualityOption{Quality: scraper.QualityAuto}, fmt.Errorf("no qualities available")
-	}
-
-	// If only one quality, use it directly
-	if len(qualities) == 1 {
-		return qualities[0], nil
-	}
-
-	// Build labels for each quality
-	var items []string
-	client := scraper.NewFlixHQClient()
-	for _, q := range qualities {
-		items = append(items, client.QualityToLabel(q.Quality))
-	}
-
-	prompt := promptui.Select{
-		Label: "Select video quality",
-		Items: items,
-		Size:  10,
-	}
-
-	idx, _, err := prompt.Run()
-	if err != nil {
-		// On error/cancel, return first (auto) quality
-		return qualities[0], err
-	}
-
-	return qualities[idx], nil
-}
-
-// extractMediaIDFromURL extracts the media ID from a FlixHQ URL
-func extractMediaIDFromURL(urlStr string) string {
-	// URL format: https://flixhq.to/movie/watch-movie-name-12345 or /movie/watch-movie-name-12345
-	parts := strings.Split(urlStr, "-")
-	if len(parts) > 0 {
-		return parts[len(parts)-1]
-	}
-	return ""
 }
 
 func GetAnimeEpisodesWithSource(anime *models.Anime) ([]models.Episode, error) {

--- a/internal/api/flixhq_flow_test.go
+++ b/internal/api/flixhq_flow_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/alvarorichard/Goanime/internal/api/providers"
 	"github.com/alvarorichard/Goanime/internal/models"
 	"github.com/alvarorichard/Goanime/internal/scraper"
 	"github.com/alvarorichard/Goanime/internal/util"
@@ -74,7 +75,7 @@ func TestFlixHQFullFlow(t *testing.T) {
 	flixhqClient := scraper.NewFlixHQClient()
 
 	// Extract media ID from URL (get last number from URL like "watch-dexter-39448")
-	mediaID := extractMediaIDFromURL(anime.URL)
+	mediaID := providers.ExtractMediaIDFromURL(anime.URL)
 	t.Logf("Extracted mediaID: %s from URL: %s", mediaID, anime.URL)
 
 	seasons, err := flixhqClient.GetSeasons(mediaID)

--- a/internal/api/providers/allanime.go
+++ b/internal/api/providers/allanime.go
@@ -1,0 +1,97 @@
+package providers
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/alvarorichard/Goanime/internal/models"
+	"github.com/alvarorichard/Goanime/internal/scraper"
+	"github.com/alvarorichard/Goanime/internal/util"
+)
+
+// AniSkipFunc is the function signature for AniSkip data fetching.
+// Injected to avoid circular dependency with the api package.
+type AniSkipFunc func(animeMalId int, episodeNum int, episode *models.Episode) error
+
+// AllAnimeProvider handles episode fetching and stream resolution for AllAnime sources.
+type AllAnimeProvider struct {
+	manager     *scraper.ScraperManager
+	aniSkipFunc AniSkipFunc
+}
+
+func NewAllAnimeProvider() *AllAnimeProvider {
+	return &AllAnimeProvider{manager: scraper.NewScraperManager()}
+}
+
+// SetAniSkipFunc injects the AniSkip integration function.
+// Called by the api package during initialization to avoid circular imports.
+func (p *AllAnimeProvider) SetAniSkipFunc(fn AniSkipFunc) {
+	p.aniSkipFunc = fn
+}
+
+func (p *AllAnimeProvider) Name() string { return "AllAnime" }
+
+func (p *AllAnimeProvider) HasSeasons() bool { return false }
+
+func (p *AllAnimeProvider) FetchEpisodes(anime *models.Anime) ([]models.Episode, error) {
+	scraperInstance, err := p.manager.GetScraper(scraper.AllAnimeType)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get AllAnime scraper: %w", err)
+	}
+
+	if p.aniSkipFunc != nil && anime.MalID > 0 {
+		if adapter, ok := scraperInstance.(interface {
+			Client() *scraper.AllAnimeClient
+		}); ok {
+			client := adapter.Client()
+			episodes, aniErr := client.GetAnimeEpisodesWithAniSkip(anime.URL, anime.MalID, p.aniSkipFunc)
+			if aniErr == nil {
+				util.Debug("AniSkip integration enabled", "malID", anime.MalID)
+				return episodes, nil
+			}
+			util.Debug("AniSkip fallback to regular episodes", "error", aniErr)
+		}
+	}
+
+	episodes, err := scraperInstance.GetAnimeEpisodes(anime.URL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get AllAnime episodes: %w", err)
+	}
+	return episodes, nil
+}
+
+func (p *AllAnimeProvider) GetStreamURL(episode *models.Episode, anime *models.Anime, quality string) (string, error) {
+	scraperInstance, err := p.manager.GetScraper(scraper.AllAnimeType)
+	if err != nil {
+		return "", fmt.Errorf("failed to get AllAnime scraper: %w", err)
+	}
+
+	if quality == "" {
+		quality = "best"
+	}
+
+	streamURL, _, streamErr := scraperInstance.GetStreamURL(anime.URL, episode.Number, quality)
+	if streamErr != nil {
+		return "", fmt.Errorf("failed to get AllAnime stream URL: %w", streamErr)
+	}
+	if streamURL == "" {
+		return "", fmt.Errorf("empty stream URL returned from AllAnime")
+	}
+	return streamURL, nil
+}
+
+// ExtractAllAnimeID extracts the anime ID from a URL or returns the raw ID.
+func ExtractAllAnimeID(urlStr string) string {
+	if !strings.Contains(urlStr, "http") && len(urlStr) < 30 {
+		return urlStr
+	}
+	if strings.Contains(urlStr, "allanime") {
+		for part := range strings.SplitSeq(urlStr, "/") {
+			if len(part) > 5 && len(part) < 30 &&
+				strings.ContainsAny(part, "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789") {
+				return part
+			}
+		}
+	}
+	return urlStr
+}

--- a/internal/api/providers/animedrive.go
+++ b/internal/api/providers/animedrive.go
@@ -1,0 +1,54 @@
+package providers
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/alvarorichard/Goanime/internal/models"
+	"github.com/alvarorichard/Goanime/internal/scraper"
+)
+
+// AnimeDriveProvider handles episode fetching and stream resolution for AnimeDrive sources.
+type AnimeDriveProvider struct {
+	manager *scraper.ScraperManager
+}
+
+func NewAnimeDriveProvider() *AnimeDriveProvider {
+	return &AnimeDriveProvider{manager: scraper.NewScraperManager()}
+}
+
+func (p *AnimeDriveProvider) Name() string { return "AnimeDrive" }
+
+func (p *AnimeDriveProvider) HasSeasons() bool { return false }
+
+func (p *AnimeDriveProvider) FetchEpisodes(anime *models.Anime) ([]models.Episode, error) {
+	scraperInstance, err := p.manager.GetScraper(scraper.AnimeDriveType)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get AnimeDrive scraper: %w", err)
+	}
+	episodes, err := scraperInstance.GetAnimeEpisodes(anime.URL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get AnimeDrive episodes: %w", err)
+	}
+	return episodes, nil
+}
+
+func (p *AnimeDriveProvider) GetStreamURL(episode *models.Episode, anime *models.Anime, quality string) (string, error) {
+	scraperInstance, err := p.manager.GetScraper(scraper.AnimeDriveType)
+	if err != nil {
+		return "", fmt.Errorf("failed to get AnimeDrive scraper: %w", err)
+	}
+
+	// "auto" skips interactive server selection (runs inside spinner context)
+	streamURL, _, streamErr := scraperInstance.GetStreamURL(episode.URL, "auto")
+	if streamErr != nil {
+		if errors.Is(streamErr, scraper.ErrBackRequested) {
+			return "", streamErr
+		}
+		return "", fmt.Errorf("failed to get AnimeDrive stream URL: %w", streamErr)
+	}
+	if streamURL == "" {
+		return "", fmt.Errorf("empty stream URL returned from AnimeDrive")
+	}
+	return streamURL, nil
+}

--- a/internal/api/providers/animefire.go
+++ b/internal/api/providers/animefire.go
@@ -1,0 +1,53 @@
+package providers
+
+import (
+	"fmt"
+
+	"github.com/alvarorichard/Goanime/internal/models"
+	"github.com/alvarorichard/Goanime/internal/scraper"
+)
+
+// AnimeFireProvider handles episode fetching and stream resolution for AnimeFire sources.
+type AnimeFireProvider struct {
+	manager *scraper.ScraperManager
+}
+
+func NewAnimeFireProvider() *AnimeFireProvider {
+	return &AnimeFireProvider{manager: scraper.NewScraperManager()}
+}
+
+func (p *AnimeFireProvider) Name() string { return "Animefire.io" }
+
+func (p *AnimeFireProvider) HasSeasons() bool { return false }
+
+func (p *AnimeFireProvider) FetchEpisodes(anime *models.Anime) ([]models.Episode, error) {
+	scraperInstance, err := p.manager.GetScraper(scraper.AnimefireType)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get AnimeFire scraper: %w", err)
+	}
+	episodes, err := scraperInstance.GetAnimeEpisodes(anime.URL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get AnimeFire episodes: %w", err)
+	}
+	return episodes, nil
+}
+
+func (p *AnimeFireProvider) GetStreamURL(episode *models.Episode, anime *models.Anime, quality string) (string, error) {
+	scraperInstance, err := p.manager.GetScraper(scraper.AnimefireType)
+	if err != nil {
+		return "", fmt.Errorf("failed to get AnimeFire scraper: %w", err)
+	}
+
+	if quality == "" {
+		quality = "best"
+	}
+
+	streamURL, _, streamErr := scraperInstance.GetStreamURL(episode.URL, quality)
+	if streamErr != nil {
+		return "", fmt.Errorf("failed to get AnimeFire stream URL: %w", streamErr)
+	}
+	if streamURL == "" {
+		return "", fmt.Errorf("empty stream URL returned from AnimeFire")
+	}
+	return streamURL, nil
+}

--- a/internal/api/providers/flixhq.go
+++ b/internal/api/providers/flixhq.go
@@ -1,0 +1,261 @@
+package providers
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/alvarorichard/Goanime/internal/models"
+	"github.com/alvarorichard/Goanime/internal/scraper"
+	"github.com/alvarorichard/Goanime/internal/util"
+	"github.com/ktr0731/go-fuzzyfinder"
+	"github.com/manifoldco/promptui"
+)
+
+// FlixHQProvider handles episode fetching and stream resolution for FlixHQ movie/TV sources.
+type FlixHQProvider struct{}
+
+func NewFlixHQProvider() *FlixHQProvider {
+	return &FlixHQProvider{}
+}
+
+func (p *FlixHQProvider) Name() string { return "FlixHQ" }
+
+func (p *FlixHQProvider) HasSeasons() bool { return true }
+
+func (p *FlixHQProvider) FetchEpisodes(anime *models.Anime) ([]models.Episode, error) {
+	flixhqClient := scraper.NewFlixHQClient()
+
+	mediaID := ExtractMediaIDFromURL(anime.URL)
+	if mediaID == "" {
+		return nil, fmt.Errorf("could not extract media ID from URL: %s", anime.URL)
+	}
+
+	util.Debug("Getting FlixHQ content", "mediaType", anime.MediaType, "mediaID", mediaID)
+
+	if anime.MediaType == models.MediaTypeMovie {
+		util.Debug("FlixHQ: Processing movie")
+		return []models.Episode{
+			{
+				Number: "1",
+				Num:    1,
+				URL:    mediaID,
+				Title: models.TitleDetails{
+					English: anime.Name,
+					Romaji:  anime.Name,
+				},
+			},
+		}, nil
+	}
+
+	util.Debug("FlixHQ: Processing TV show, getting seasons")
+
+	var seasons []scraper.FlixHQSeason
+	var seasonsErr error
+	util.RunWithSpinner("Loading seasons...", func() {
+		seasons, seasonsErr = flixhqClient.GetSeasons(mediaID)
+	})
+	if seasonsErr != nil {
+		return nil, fmt.Errorf("failed to get seasons: %w", seasonsErr)
+	}
+	if len(seasons) == 0 {
+		return nil, fmt.Errorf("no seasons found for TV show")
+	}
+
+	seasonNames := make([]string, len(seasons))
+	for i, s := range seasons {
+		seasonNames[i] = s.Title
+	}
+
+	seasonIdx, err := fuzzyfinder.Find(
+		seasonNames,
+		func(i int) string { return seasonNames[i] },
+		fuzzyfinder.WithPromptString("Select season: "),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("season selection cancelled: %w", err)
+	}
+
+	selectedSeason := seasons[seasonIdx]
+	util.Debug("Selected season", "season", selectedSeason.Title, "id", selectedSeason.ID)
+
+	fmt.Print("\033[2K\033[1A\033[2K\r")
+
+	var flixEpisodes []scraper.FlixHQEpisode
+	var episodesErr error
+	util.RunWithSpinner("Loading episodes...", func() {
+		flixEpisodes, episodesErr = flixhqClient.GetEpisodes(selectedSeason.ID)
+	})
+	if episodesErr != nil {
+		return nil, fmt.Errorf("failed to get episodes: %w", episodesErr)
+	}
+
+	var episodes []models.Episode
+	for _, ep := range flixEpisodes {
+		episodes = append(episodes, models.Episode{
+			Number: fmt.Sprintf("%d", ep.Number),
+			Num:    ep.Number,
+			URL:    ep.DataID,
+			Title: models.TitleDetails{
+				English: ep.Title,
+				Romaji:  ep.Title,
+			},
+			DataID:   ep.DataID,
+			SeasonID: selectedSeason.ID,
+		})
+	}
+
+	util.Debug("FlixHQ episodes loaded", "count", len(episodes))
+	return episodes, nil
+}
+
+func (p *FlixHQProvider) GetStreamURL(episode *models.Episode, anime *models.Anime, quality string) (string, error) {
+	util.ClearGlobalSubtitles()
+	util.SetGlobalAnimeSource("FlixHQ")
+
+	flixhqClient := scraper.NewFlixHQClient()
+	if anime.URL != "" {
+		flixhqClient.SetMediaPath(scraper.ExtractMediaPath(anime.URL))
+	}
+	provider := "Vidcloud"
+	subsLanguage := util.GlobalSubsLanguage
+	if subsLanguage == "" {
+		subsLanguage = "english"
+	}
+
+	streamInfo, err := p.resolveStream(flixhqClient, anime, episode, provider, subsLanguage)
+	if err != nil {
+		return "", err
+	}
+
+	p.storeSubtitlesGlobally(streamInfo)
+
+	if streamInfo.Referer != "" {
+		util.SetGlobalReferer(streamInfo.Referer)
+	}
+
+	return streamInfo.VideoURL, nil
+}
+
+// --- Stream resolution (encapsulates the server ID -> embed -> extract -> quality pipeline) ---
+
+func (p *FlixHQProvider) resolveStream(
+	client *scraper.FlixHQClient,
+	anime *models.Anime,
+	episode *models.Episode,
+	provider, subsLanguage string,
+) (*scraper.FlixHQStreamInfo, error) {
+
+	var streamInfo *scraper.FlixHQStreamInfo
+	var episodeID string
+	var embedLink string
+	var streamErr error
+
+	if anime.MediaType == models.MediaTypeMovie {
+		mediaID := episode.URL
+		util.Debug("Getting movie stream", "mediaID", mediaID)
+
+		util.RunWithSpinner("Loading movie stream...", func() {
+			episodeID, streamErr = client.GetMovieServerID(mediaID, provider)
+			if streamErr != nil {
+				return
+			}
+			embedLink, streamErr = client.GetEmbedLink(episodeID)
+			if streamErr != nil {
+				return
+			}
+			streamInfo, streamErr = client.ExtractStreamInfo(embedLink, "auto", subsLanguage)
+		})
+
+		if streamErr != nil {
+			return nil, fmt.Errorf("failed to get movie stream: %w", streamErr)
+		}
+		if streamInfo == nil {
+			return nil, fmt.Errorf("failed to get movie stream: no stream info returned")
+		}
+	} else {
+		dataID := episode.URL
+		util.Debug("Getting TV episode stream", "dataID", dataID)
+
+		util.RunWithSpinner("Loading episode stream...", func() {
+			episodeID, streamErr = client.GetEpisodeServerID(dataID, provider)
+			if streamErr != nil {
+				return
+			}
+			embedLink, streamErr = client.GetEmbedLink(episodeID)
+			if streamErr != nil {
+				return
+			}
+			streamInfo, streamErr = client.ExtractStreamInfo(embedLink, "auto", subsLanguage)
+		})
+
+		if streamErr != nil {
+			return nil, fmt.Errorf("failed to get episode stream: %w", streamErr)
+		}
+		if streamInfo == nil {
+			return nil, fmt.Errorf("failed to get episode stream: no stream info returned")
+		}
+	}
+
+	if len(streamInfo.Qualities) > 1 {
+		selectedQuality, selectErr := p.selectQualityOptions(streamInfo.Qualities)
+		if selectErr == nil && selectedQuality.URL != "" {
+			streamInfo.VideoURL = selectedQuality.URL
+			streamInfo.Quality = string(selectedQuality.Quality)
+			streamInfo.IsM3U8 = selectedQuality.IsM3U8
+		}
+	}
+
+	return streamInfo, nil
+}
+
+func (p *FlixHQProvider) selectQualityOptions(qualities []scraper.FlixHQQualityOption) (scraper.FlixHQQualityOption, error) {
+	if len(qualities) == 0 {
+		return scraper.FlixHQQualityOption{Quality: scraper.QualityAuto}, fmt.Errorf("no qualities available")
+	}
+	if len(qualities) == 1 {
+		return qualities[0], nil
+	}
+
+	client := scraper.NewFlixHQClient()
+	var items []string
+	for _, q := range qualities {
+		items = append(items, client.QualityToLabel(q.Quality))
+	}
+
+	prompt := promptui.Select{
+		Label: "Select video quality",
+		Items: items,
+		Size:  10,
+	}
+
+	idx, _, err := prompt.Run()
+	if err != nil {
+		return qualities[0], err
+	}
+	return qualities[idx], nil
+}
+
+func (p *FlixHQProvider) storeSubtitlesGlobally(streamInfo *scraper.FlixHQStreamInfo) {
+	if len(streamInfo.Subtitles) == 0 || util.GlobalNoSubs {
+		return
+	}
+	var subInfos []util.SubtitleInfo
+	for _, sub := range streamInfo.Subtitles {
+		subInfos = append(subInfos, util.SubtitleInfo{
+			URL:      sub.URL,
+			Language: sub.Language,
+			Label:    sub.Label,
+		})
+	}
+	util.SetGlobalSubtitles(subInfos)
+}
+
+// ExtractMediaIDFromURL extracts the media ID from a FlixHQ URL.
+// URL format: https://flixhq.to/movie/watch-movie-name-12345 or /movie/watch-movie-name-12345
+func ExtractMediaIDFromURL(urlStr string) string {
+	parts := strings.Split(urlStr, "-")
+	if len(parts) > 0 {
+		return parts[len(parts)-1]
+	}
+	return ""
+}

--- a/internal/api/providers/goyabu.go
+++ b/internal/api/providers/goyabu.go
@@ -1,0 +1,49 @@
+package providers
+
+import (
+	"fmt"
+
+	"github.com/alvarorichard/Goanime/internal/models"
+	"github.com/alvarorichard/Goanime/internal/scraper"
+)
+
+// GoyabuProvider handles episode fetching and stream resolution for Goyabu sources.
+type GoyabuProvider struct {
+	manager *scraper.ScraperManager
+}
+
+func NewGoyabuProvider() *GoyabuProvider {
+	return &GoyabuProvider{manager: scraper.NewScraperManager()}
+}
+
+func (p *GoyabuProvider) Name() string { return "Goyabu" }
+
+func (p *GoyabuProvider) HasSeasons() bool { return false }
+
+func (p *GoyabuProvider) FetchEpisodes(anime *models.Anime) ([]models.Episode, error) {
+	scraperInstance, err := p.manager.GetScraper(scraper.GoyabuType)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get Goyabu scraper: %w", err)
+	}
+	episodes, err := scraperInstance.GetAnimeEpisodes(anime.URL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get Goyabu episodes: %w", err)
+	}
+	return episodes, nil
+}
+
+func (p *GoyabuProvider) GetStreamURL(episode *models.Episode, anime *models.Anime, quality string) (string, error) {
+	scraperInstance, err := p.manager.GetScraper(scraper.GoyabuType)
+	if err != nil {
+		return "", fmt.Errorf("failed to get Goyabu scraper: %w", err)
+	}
+
+	streamURL, _, streamErr := scraperInstance.GetStreamURL(episode.URL)
+	if streamErr != nil {
+		return "", fmt.Errorf("failed to get Goyabu stream URL: %w", streamErr)
+	}
+	if streamURL == "" {
+		return "", fmt.Errorf("empty stream URL returned from Goyabu")
+	}
+	return streamURL, nil
+}

--- a/internal/api/providers/nineanime.go
+++ b/internal/api/providers/nineanime.go
@@ -1,0 +1,117 @@
+package providers
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/alvarorichard/Goanime/internal/models"
+	"github.com/alvarorichard/Goanime/internal/scraper"
+	"github.com/alvarorichard/Goanime/internal/util"
+)
+
+// NineAnimeProvider handles episode fetching and stream resolution for 9Anime sources.
+type NineAnimeProvider struct{}
+
+func NewNineAnimeProvider() *NineAnimeProvider {
+	return &NineAnimeProvider{}
+}
+
+func (p *NineAnimeProvider) Name() string { return "9Anime" }
+
+func (p *NineAnimeProvider) HasSeasons() bool { return false }
+
+func (p *NineAnimeProvider) FetchEpisodes(anime *models.Anime) ([]models.Episode, error) {
+	nineAnimeClient := scraper.NewNineAnimeClient()
+
+	animeID := anime.URL
+	util.Debug("Getting 9Anime episodes", "animeID", animeID)
+
+	episodes, err := nineAnimeClient.GetAnimeEpisodes(animeID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get episodes from 9Anime: %w", err)
+	}
+
+	util.Debug("9Anime episodes loaded", "count", len(episodes))
+	return episodes, nil
+}
+
+func (p *NineAnimeProvider) GetStreamURL(episode *models.Episode, anime *models.Anime, quality string) (string, error) {
+	util.ClearGlobalSubtitles()
+	util.SetGlobalAnimeSource("9Anime")
+
+	nineAnimeClient := scraper.NewNineAnimeClient()
+
+	episodeID := episode.DataID
+	if episodeID == "" {
+		episodeID = episode.URL
+	}
+
+	util.Debug("Getting 9Anime stream", "episodeID", episodeID, "quality", quality)
+
+	streamURL, metadata, err := nineAnimeClient.GetStreamURL(episodeID, "sub")
+	if err != nil {
+		return "", fmt.Errorf("failed to get stream URL from 9Anime: %w", err)
+	}
+
+	if referer, ok := metadata["referer"]; ok && referer != "" {
+		util.SetGlobalReferer(referer)
+	}
+
+	p.storeSubtitlesFromMetadata(metadata)
+
+	util.Debug("9Anime stream URL obtained", "url", streamURL[:min(len(streamURL), 80)])
+	return streamURL, nil
+}
+
+// storeSubtitlesFromMetadata parses subtitle information from 9Anime stream metadata
+// and stores them globally for mpv playback.
+func (p *NineAnimeProvider) storeSubtitlesFromMetadata(metadata map[string]string) {
+	subtitleURLs, ok := metadata["subtitles"]
+	if !ok || subtitleURLs == "" || util.GlobalNoSubs {
+		return
+	}
+
+	subURLs := strings.Split(subtitleURLs, ",")
+	var subLabels []string
+	if labels, ok := metadata["subtitle_labels"]; ok {
+		subLabels = strings.Split(labels, ",")
+	}
+
+	var subInfos []util.SubtitleInfo
+	for i, subURL := range subURLs {
+		label := "Unknown"
+		lang := "unknown"
+		if i < len(subLabels) {
+			label = subLabels[i]
+			lang = labelToLanguageCode(label)
+		}
+		subInfos = append(subInfos, util.SubtitleInfo{
+			URL:      subURL,
+			Language: lang,
+			Label:    label,
+		})
+	}
+	util.SetGlobalSubtitles(subInfos)
+	util.Debug("9Anime subtitles loaded", "count", len(subInfos))
+}
+
+var languageMap = map[string]string{
+	"english":    "eng",
+	"portuguese": "por",
+	"spanish":    "spa",
+	"japanese":   "jpn",
+	"french":     "fre",
+	"german":     "ger",
+	"italian":    "ita",
+	"arabic":     "ara",
+}
+
+func labelToLanguageCode(label string) string {
+	lower := strings.ToLower(label)
+	for keyword, code := range languageMap {
+		if strings.Contains(lower, keyword) {
+			return code
+		}
+	}
+	return "unknown"
+}

--- a/internal/api/providers/provider.go
+++ b/internal/api/providers/provider.go
@@ -1,0 +1,13 @@
+package providers
+
+import "github.com/alvarorichard/Goanime/internal/models"
+
+// EpisodeProvider defines the unified interface for all anime/media source providers.
+// Each provider encapsulates the logic for fetching episodes and resolving stream URLs
+// for a specific source (AllAnime, AnimeFire, FlixHQ, etc.).
+type EpisodeProvider interface {
+	Name() string
+	FetchEpisodes(anime *models.Anime) ([]models.Episode, error)
+	GetStreamURL(episode *models.Episode, anime *models.Anime, quality string) (string, error)
+	HasSeasons() bool
+}

--- a/internal/api/providers/registry.go
+++ b/internal/api/providers/registry.go
@@ -1,0 +1,238 @@
+package providers
+
+import (
+	"strings"
+	"sync"
+
+	"github.com/alvarorichard/Goanime/internal/models"
+)
+
+var (
+	providerCache   = make(map[string]EpisodeProvider)
+	providerCacheMu sync.RWMutex
+)
+
+type providerFactory func() EpisodeProvider
+
+var sourceRegistry = map[string]providerFactory{
+	"allanime":   func() EpisodeProvider { return NewAllAnimeProvider() },
+	"animefire":  func() EpisodeProvider { return NewAnimeFireProvider() },
+	"animedrive": func() EpisodeProvider { return NewAnimeDriveProvider() },
+	"flixhq":     func() EpisodeProvider { return NewFlixHQProvider() },
+	"9anime":     func() EpisodeProvider { return NewNineAnimeProvider() },
+	"goyabu":     func() EpisodeProvider { return NewGoyabuProvider() },
+}
+
+// ForSource resolves the appropriate EpisodeProvider for the given anime.
+// It uses a priority chain: Source field > Name tags > URL patterns > fallback (AllAnime).
+// Never returns nil.
+func ForSource(anime *models.Anime) EpisodeProvider {
+	name := ResolveSourceName(anime)
+	return getOrCreateProvider(name)
+}
+
+// ForSourceName returns the EpisodeProvider for a given normalized source name string.
+// Useful when the caller already knows the source key (e.g. from CLI --source flag).
+func ForSourceName(source string) EpisodeProvider {
+	name := normalizeSource(source)
+	if name == "" {
+		name = "allanime"
+	}
+	return getOrCreateProvider(name)
+}
+
+// ResolveSourceName determines the normalized source key for an anime using the priority chain.
+func ResolveSourceName(anime *models.Anime) string {
+	if anime == nil {
+		return "allanime"
+	}
+
+	if n := normalizeSource(anime.Source); n != "" {
+		return n
+	}
+
+	if anime.MediaType == models.MediaTypeMovie || anime.MediaType == models.MediaTypeTV {
+		return "flixhq"
+	}
+
+	if n := detectFromTags(anime.Name); n != "" {
+		return n
+	}
+
+	if n := DetectFromTagsAndURL(anime.Name, anime.URL); n != "" {
+		return n
+	}
+
+	if n := detectFromURL(anime.URL); n != "" {
+		return n
+	}
+
+	return "allanime"
+}
+
+func getOrCreateProvider(name string) EpisodeProvider {
+	providerCacheMu.RLock()
+	if p, ok := providerCache[name]; ok {
+		providerCacheMu.RUnlock()
+		return p
+	}
+	providerCacheMu.RUnlock()
+
+	providerCacheMu.Lock()
+	defer providerCacheMu.Unlock()
+
+	if p, ok := providerCache[name]; ok {
+		return p
+	}
+
+	factory, exists := sourceRegistry[name]
+	if !exists {
+		factory = sourceRegistry["allanime"]
+	}
+	p := factory()
+	providerCache[name] = p
+	return p
+}
+
+// --- Convenience helpers (replace scattered is*Source functions) ---
+
+func IsAllAnime(anime *models.Anime) bool {
+	return ResolveSourceName(anime) == "allanime"
+}
+
+func IsAnimeFire(anime *models.Anime) bool {
+	return ResolveSourceName(anime) == "animefire"
+}
+
+func IsAnimeDrive(anime *models.Anime) bool {
+	return ResolveSourceName(anime) == "animedrive"
+}
+
+func IsFlixHQ(anime *models.Anime) bool {
+	return ResolveSourceName(anime) == "flixhq"
+}
+
+func Is9Anime(anime *models.Anime) bool {
+	return ResolveSourceName(anime) == "9anime"
+}
+
+func IsGoyabu(anime *models.Anime) bool {
+	return ResolveSourceName(anime) == "goyabu"
+}
+
+// --- Source detection internals ---
+
+var sourceAliases = map[string]string{
+	"allanime":     "allanime",
+	"animefire":    "animefire",
+	"animefire.io": "animefire",
+	"animedrive":   "animedrive",
+	"flixhq":       "flixhq",
+	"sflix":        "flixhq",
+	"movie":        "flixhq",
+	"tv":           "flixhq",
+	"9anime":       "9anime",
+	"nineanime":    "9anime",
+	"goyabu":       "goyabu",
+	"ptbr":         "animefire",
+	"pt-br":        "animefire",
+}
+
+func normalizeSource(source string) string {
+	if source == "" {
+		return ""
+	}
+	key := strings.ToLower(strings.TrimSpace(source))
+	if n, ok := sourceAliases[key]; ok {
+		return n
+	}
+	if strings.Contains(key, "animefire") {
+		return "animefire"
+	}
+	if strings.Contains(key, "allanime") {
+		return "allanime"
+	}
+	return ""
+}
+
+func detectFromTags(name string) string {
+	lower := strings.ToLower(name)
+
+	if strings.Contains(lower, "[english]") {
+		return "allanime"
+	}
+	if strings.Contains(lower, "[multilanguage]") {
+		return "9anime"
+	}
+	if strings.Contains(lower, "[movie]") || strings.Contains(lower, "[tv]") || strings.Contains(lower, "[movies/tv]") {
+		return "flixhq"
+	}
+	if strings.Contains(lower, "[pt-br]") || strings.Contains(lower, "[português]") || strings.Contains(lower, "[portuguese]") {
+		return ""
+	}
+	return ""
+}
+
+func detectFromURL(urlStr string) string {
+	if urlStr == "" {
+		return ""
+	}
+	lower := strings.ToLower(urlStr)
+
+	if strings.Contains(lower, "animefire") {
+		return "animefire"
+	}
+	if strings.Contains(lower, "animesdrive") {
+		return "animedrive"
+	}
+	if strings.Contains(lower, "goyabu") {
+		return "goyabu"
+	}
+	if strings.Contains(lower, "flixhq") {
+		return "flixhq"
+	}
+	if strings.Contains(lower, "allanime") {
+		return "allanime"
+	}
+
+	if isLikelyAllAnimeID(urlStr) {
+		return "allanime"
+	}
+
+	return ""
+}
+
+// DetectFromTagsAndURL combines tag and URL detection for PT-BR disambiguation.
+// PT-BR tags don't uniquely identify a source, so URL patterns are needed.
+func DetectFromTagsAndURL(name, urlStr string) string {
+	lower := strings.ToLower(name)
+
+	if strings.Contains(lower, "[pt-br]") || strings.Contains(lower, "[português]") || strings.Contains(lower, "[portuguese]") {
+		lowerURL := strings.ToLower(urlStr)
+		if strings.Contains(lowerURL, "animesdrive") {
+			return "animedrive"
+		}
+		if strings.Contains(lowerURL, "goyabu") {
+			return "goyabu"
+		}
+		return "animefire"
+	}
+	return ""
+}
+
+func isLikelyAllAnimeID(s string) bool {
+	if strings.Contains(s, "http") {
+		return false
+	}
+	if len(s) < 6 || len(s) >= 30 {
+		return false
+	}
+	hasLetter := false
+	for _, c := range s {
+		if (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') {
+			hasLetter = true
+			break
+		}
+	}
+	return hasLetter
+}

--- a/internal/api/providers/registry_test.go
+++ b/internal/api/providers/registry_test.go
@@ -1,0 +1,261 @@
+package providers_test
+
+import (
+	"testing"
+
+	"github.com/alvarorichard/Goanime/internal/api/providers"
+	"github.com/alvarorichard/Goanime/internal/models"
+)
+
+func TestResolveSourceName_BySourceField(t *testing.T) {
+	tests := []struct {
+		source   string
+		expected string
+	}{
+		{"AllAnime", "allanime"},
+		{"Animefire.io", "animefire"},
+		{"AnimeDrive", "animedrive"},
+		{"FlixHQ", "flixhq"},
+		{"9Anime", "9anime"},
+		{"Goyabu", "goyabu"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.source, func(t *testing.T) {
+			anime := &models.Anime{Source: tt.source}
+			got := providers.ResolveSourceName(anime)
+			if got != tt.expected {
+				t.Errorf("ResolveSourceName(Source=%q) = %q, want %q", tt.source, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestResolveSourceName_ByTags(t *testing.T) {
+	tests := []struct {
+		name     string
+		expected string
+	}{
+		{"[English] Naruto", "allanime"},
+		{"[Multilanguage] One Piece", "9anime"},
+		{"[Movie] Avengers", "flixhq"},
+		{"[TV] Breaking Bad", "flixhq"},
+		{"[Movies/TV] Spider-Man", "flixhq"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			anime := &models.Anime{Name: tt.name}
+			got := providers.ResolveSourceName(anime)
+			if got != tt.expected {
+				t.Errorf("ResolveSourceName(Name=%q) = %q, want %q", tt.name, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestResolveSourceName_ByURL(t *testing.T) {
+	tests := []struct {
+		url      string
+		expected string
+	}{
+		{"https://animefire.io/video/naruto", "animefire"},
+		{"https://animesdrive.com/naruto-ep-1", "animedrive"},
+		{"https://goyabu.to/naruto", "goyabu"},
+		{"https://flixhq.to/movie/avengers-12345", "flixhq"},
+		{"https://allanime.to/anime/naruto", "allanime"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.url, func(t *testing.T) {
+			anime := &models.Anime{URL: tt.url}
+			got := providers.ResolveSourceName(anime)
+			if got != tt.expected {
+				t.Errorf("ResolveSourceName(URL=%q) = %q, want %q", tt.url, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestResolveSourceName_AllAnimeIDFallback(t *testing.T) {
+	anime := &models.Anime{URL: "abc123XYZ"}
+	got := providers.ResolveSourceName(anime)
+	if got != "allanime" {
+		t.Errorf("ResolveSourceName(URL=%q) = %q, want %q", anime.URL, got, "allanime")
+	}
+}
+
+func TestResolveSourceName_Priority_SourceOverTags(t *testing.T) {
+	anime := &models.Anime{
+		Source: "AnimeDrive",
+		Name:   "[English] Some Anime",
+		URL:    "https://animefire.io/video/test",
+	}
+	got := providers.ResolveSourceName(anime)
+	if got != "animedrive" {
+		t.Errorf("Source field should take priority, got %q want %q", got, "animedrive")
+	}
+}
+
+func TestResolveSourceName_Priority_TagsOverURL(t *testing.T) {
+	anime := &models.Anime{
+		Name: "[English] Some Anime",
+		URL:  "https://animefire.io/video/test",
+	}
+	got := providers.ResolveSourceName(anime)
+	if got != "allanime" {
+		t.Errorf("[English] tag should resolve to allanime, got %q", got)
+	}
+}
+
+func TestResolveSourceName_PTBR_DisambiguationByURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		url      string
+		expected string
+	}{
+		{"[PT-BR] Naruto", "https://animesdrive.com/naruto", "animedrive"},
+		{"[PT-BR] Naruto", "https://goyabu.to/naruto", "goyabu"},
+		{"[PT-BR] Naruto", "https://animefire.io/naruto", "animefire"},
+		{"[PT-BR] Naruto", "https://unknown.com/naruto", "animefire"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.url, func(t *testing.T) {
+			anime := &models.Anime{Name: tt.name, URL: tt.url}
+			got := providers.ResolveSourceName(anime)
+			if got != tt.expected {
+				t.Errorf("ResolveSourceName(Name=%q, URL=%q) = %q, want %q", tt.name, tt.url, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestResolveSourceName_MediaType(t *testing.T) {
+	anime := &models.Anime{MediaType: models.MediaTypeMovie}
+	got := providers.ResolveSourceName(anime)
+	if got != "flixhq" {
+		t.Errorf("MediaTypeMovie should resolve to flixhq, got %q", got)
+	}
+
+	anime = &models.Anime{MediaType: models.MediaTypeTV}
+	got = providers.ResolveSourceName(anime)
+	if got != "flixhq" {
+		t.Errorf("MediaTypeTV should resolve to flixhq, got %q", got)
+	}
+}
+
+func TestResolveSourceName_NilAnime(t *testing.T) {
+	got := providers.ResolveSourceName(nil)
+	if got != "allanime" {
+		t.Errorf("nil anime should fallback to allanime, got %q", got)
+	}
+}
+
+func TestForSource_NeverReturnsNil(t *testing.T) {
+	cases := []*models.Anime{
+		nil,
+		{},
+		{Source: "UnknownSource"},
+		{URL: "something-totally-random"},
+		{Source: "AllAnime"},
+		{Source: "FlixHQ"},
+		{Source: "9Anime"},
+	}
+
+	for _, anime := range cases {
+		p := providers.ForSource(anime)
+		if p == nil {
+			t.Errorf("ForSource(%+v) returned nil", anime)
+		}
+	}
+}
+
+func TestForSource_ReturnsCorrectType(t *testing.T) {
+	tests := []struct {
+		anime        *models.Anime
+		expectedName string
+	}{
+		{&models.Anime{Source: "AllAnime"}, "AllAnime"},
+		{&models.Anime{Source: "Animefire.io"}, "Animefire.io"},
+		{&models.Anime{Source: "AnimeDrive"}, "AnimeDrive"},
+		{&models.Anime{Source: "FlixHQ"}, "FlixHQ"},
+		{&models.Anime{Source: "9Anime"}, "9Anime"},
+		{&models.Anime{Source: "Goyabu"}, "Goyabu"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.expectedName, func(t *testing.T) {
+			p := providers.ForSource(tt.anime)
+			if p.Name() != tt.expectedName {
+				t.Errorf("ForSource(Source=%q).Name() = %q, want %q", tt.anime.Source, p.Name(), tt.expectedName)
+			}
+		})
+	}
+}
+
+func TestForSourceName(t *testing.T) {
+	tests := []struct {
+		source       string
+		expectedName string
+	}{
+		{"allanime", "AllAnime"},
+		{"animefire", "Animefire.io"},
+		{"animedrive", "AnimeDrive"},
+		{"flixhq", "FlixHQ"},
+		{"9anime", "9Anime"},
+		{"goyabu", "Goyabu"},
+		{"", "AllAnime"},
+		{"unknown", "AllAnime"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.source, func(t *testing.T) {
+			p := providers.ForSourceName(tt.source)
+			if p.Name() != tt.expectedName {
+				t.Errorf("ForSourceName(%q).Name() = %q, want %q", tt.source, p.Name(), tt.expectedName)
+			}
+		})
+	}
+}
+
+func TestConvenienceHelpers(t *testing.T) {
+	if !providers.IsAllAnime(&models.Anime{Source: "AllAnime"}) {
+		t.Error("IsAllAnime should return true for Source=AllAnime")
+	}
+	if !providers.IsAnimeFire(&models.Anime{Source: "Animefire.io"}) {
+		t.Error("IsAnimeFire should return true for Source=Animefire.io")
+	}
+	if !providers.IsAnimeDrive(&models.Anime{Source: "AnimeDrive"}) {
+		t.Error("IsAnimeDrive should return true for Source=AnimeDrive")
+	}
+	if !providers.IsFlixHQ(&models.Anime{Source: "FlixHQ"}) {
+		t.Error("IsFlixHQ should return true for Source=FlixHQ")
+	}
+	if !providers.Is9Anime(&models.Anime{Source: "9Anime"}) {
+		t.Error("Is9Anime should return true for Source=9Anime")
+	}
+	if !providers.IsGoyabu(&models.Anime{Source: "Goyabu"}) {
+		t.Error("IsGoyabu should return true for Source=Goyabu")
+	}
+
+	if providers.IsFlixHQ(&models.Anime{Source: "AllAnime"}) {
+		t.Error("IsFlixHQ should return false for Source=AllAnime")
+	}
+	if providers.Is9Anime(&models.Anime{Source: "AllAnime"}) {
+		t.Error("Is9Anime should return false for Source=AllAnime")
+	}
+}
+
+func TestProviderInterfaceCompliance(t *testing.T) {
+	providerNames := []string{"allanime", "animefire", "animedrive", "flixhq", "9anime", "goyabu"}
+	for _, name := range providerNames {
+		p := providers.ForSourceName(name)
+		if p == nil {
+			t.Fatalf("ForSourceName(%q) returned nil", name)
+		}
+		if p.Name() == "" {
+			t.Errorf("Provider for %q has empty Name()", name)
+		}
+	}
+}

--- a/internal/download/workflow.go
+++ b/internal/download/workflow.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/alvarorichard/Goanime/internal/api"
+	"github.com/alvarorichard/Goanime/internal/api/providers"
 	"github.com/alvarorichard/Goanime/internal/appflow"
 	"github.com/alvarorichard/Goanime/internal/downloader"
 	"github.com/alvarorichard/Goanime/internal/player"
@@ -61,7 +62,7 @@ func HandleDownloadRequest(request *util.DownloadRequest) error {
 
 	// If this is 9Anime content, use the dedicated 9anime downloader
 	// 9Anime episodes use data-id based resolution that is incompatible with legacy downloaders
-	if anime.Source == "9Anime" {
+	if providers.Is9Anime(anime) {
 		util.Infof("Detected 9Anime content: %s — using 9Anime downloader", anime.Name)
 		nad := downloader.NewNineAnimeDownloader(downloader.NineAnimeDownloadConfig{
 			AnimeName:    anime.Name,
@@ -85,7 +86,7 @@ func HandleDownloadRequest(request *util.DownloadRequest) error {
 			request.StartEpisode, request.EndEpisode, anime.Name)
 
 		// Exclusive AllAnime Smart Range
-		if request.AllAnimeSmart && (anime.Source == "AllAnime" || source == "allanime" || source == "AllAnime") {
+		if request.AllAnimeSmart && (providers.IsAllAnime(anime) || strings.EqualFold(source, "allanime")) {
 			util.Info("AllAnime Smart Range enabled: mirror priority + AniSkip integration + progress UI")
 			// Use player batch downloader with provided range to get consistent progress UI
 			eps, err := api.GetAnimeEpisodesEnhanced(anime)

--- a/internal/player/download.go
+++ b/internal/player/download.go
@@ -20,6 +20,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"charm.land/huh/v2"
 	"github.com/alvarorichard/Goanime/internal/api"
+	"github.com/alvarorichard/Goanime/internal/api/providers"
 	"github.com/alvarorichard/Goanime/internal/downloader/hls"
 	"github.com/alvarorichard/Goanime/internal/models"
 	"github.com/alvarorichard/Goanime/internal/util"
@@ -689,9 +690,8 @@ func ExtractVideoSources(episodeURL string) ([]struct {
 }
 
 // getBestQualityURL returns the best available quality for an episode.
-// For AllAnime episodes (non-HTTP identifiers), resolve via enhanced API using episode.Number and animeID.
+// For non-HTTP identifiers, resolves via the provider registry.
 func getBestQualityURL(episode models.Episode, animeURL string) (string, error) {
-	// Non-AllAnime HTTP page URL path
 	if strings.HasPrefix(strings.ToLower(episode.URL), "http://") || strings.HasPrefix(strings.ToLower(episode.URL), "https://") {
 		sources, err := ExtractVideoSources(episode.URL)
 		if err != nil {
@@ -709,24 +709,20 @@ func getBestQualityURL(episode models.Episode, animeURL string) (string, error) 
 		return best.URL, nil
 	}
 
-	// AllAnime path: animeURL is AllAnime ID/URL, episode.Number is episode string
-	isAllAnime := func(u string) bool {
-		return strings.Contains(u, "allanime") || (len(u) < 30 && !strings.Contains(u, "http") && len(u) > 0)
-	}
-	if isAllAnime(animeURL) {
-		anime := &models.Anime{URL: animeURL, Source: "AllAnime", Name: "AllAnime"}
-		// Build minimal episode with proper number and AllAnime context URL
-		ep := &models.Episode{Number: episode.Number, URL: animeURL}
+	anime := &models.Anime{URL: animeURL}
+	provider := providers.ForSource(anime)
+	ep := &models.Episode{Number: episode.Number, URL: animeURL}
+
+	if providers.IsAllAnime(anime) {
 		if url, err := api.GetEpisodeStreamURLEnhanced(ep, anime, util.GlobalQuality); err == nil && url != "" {
 			return url, nil
 		}
-		if url, err := api.GetEpisodeStreamURL(ep, anime, util.GlobalQuality); err == nil && url != "" {
-			return url, nil
-		}
-		return "", fmt.Errorf("failed to resolve AllAnime stream URL")
+	}
+	if url, err := api.GetEpisodeStreamURL(ep, anime, util.GlobalQuality); err == nil && url != "" {
+		return url, nil
 	}
 
-	return "", fmt.Errorf("unsupported episode identifier: %s", episode.URL)
+	return "", fmt.Errorf("failed to resolve stream URL via %s", provider.Name())
 }
 
 // ExtractVideoSourcesWithPrompt allows the user to choose video quality.

--- a/internal/player/scraper.go
+++ b/internal/player/scraper.go
@@ -17,6 +17,7 @@ import (
 	"charm.land/huh/v2"
 	"github.com/PuerkitoBio/goquery"
 	"github.com/alvarorichard/Goanime/internal/api"
+	"github.com/alvarorichard/Goanime/internal/api/providers"
 	"github.com/alvarorichard/Goanime/internal/models"
 	"github.com/alvarorichard/Goanime/internal/scraper"
 	"github.com/alvarorichard/Goanime/internal/util"
@@ -308,34 +309,27 @@ func GetVideoURLForEpisode(episodeURL string) (string, error) {
 	return extractActualVideoURL(videoURL)
 }
 
-// GetVideoURLForEpisodeEnhanced gets the video URL using the enhanced API with AllAnime navigation support
+// GetVideoURLForEpisodeEnhanced gets the video URL using the enhanced API with AllAnime navigation support.
+// Uses the provider registry for source detection instead of local is*Source helpers.
 func GetVideoURLForEpisodeEnhanced(episode *models.Episode, anime *models.Anime) (string, error) {
 	util.Debug("GetVideoURLForEpisodeEnhanced called", "episodeURL", episode.URL, "episodeNum", episode.Number)
 	if anime != nil {
 		util.Debug("Anime context", "name", anime.Name, "source", anime.Source, "mediaType", anime.MediaType, "url", anime.URL)
 	}
 
-	// If we don't have anime context, decide safely how to resolve
 	if anime == nil {
-		// If it's a normal HTTP URL, use legacy extraction
 		if strings.Contains(episode.URL, "http") {
-			if util.IsDebug {
-				util.Debugf("No anime context; using legacy extraction for HTTP URL, episode %s", episode.Number)
-			}
+			util.Debug("No anime context; using legacy extraction for HTTP URL")
 			return GetVideoURLForEpisode(episode.URL)
 		}
 
-		// If episode.URL looks like an AllAnime ID, synthesize minimal anime context
 		if isLikelyAllAnimeID(episode.URL) {
-			if util.IsDebug {
-				util.Debugf("No anime context; detected AllAnime ID '%s'. Using enhanced API with synthetic anime context.", episode.URL)
-			}
+			util.Debug("No anime context; detected AllAnime ID, using synthetic context")
 			tmpAnime := &models.Anime{
 				URL:    episode.URL,
 				Source: "AllAnime",
 				Name:   "[AllAnime]",
 			}
-			// Ensure episode number is set
 			if episode.Number == "" && episode.Num > 0 {
 				episode.Number = fmt.Sprintf("%d", episode.Num)
 			}
@@ -345,19 +339,15 @@ func GetVideoURLForEpisodeEnhanced(episode *models.Episode, anime *models.Anime)
 			return api.GetEpisodeStreamURLEnhanced(episode, tmpAnime, util.GlobalQuality)
 		}
 
-		// If it's likely just an episode number without anime context, we cannot resolve via enhanced API
 		return "", fmt.Errorf("cannot resolve stream without anime context for episode %s; missing anime identifier", episode.Number)
 	}
 
-	// Try AnimeDrive enhanced navigation if applicable
-	if isAnimeDriveSourcePlayer(anime) {
+	if providers.IsAnimeDrive(anime) {
 		streamURL, err := api.GetEpisodeStreamURL(episode, anime, util.GlobalQuality)
 		if err == nil {
-			// Validate the URL is a playable video, not an iframe/embed page
 			if isPlayableVideoURL(streamURL) {
 				return streamURL, nil
 			}
-			// Try to extract actual video from intermediate URL
 			if needsVideoExtraction(streamURL) {
 				resolved, resolveErr := extractActualVideoURL(streamURL)
 				if resolveErr == nil && resolved != "" {
@@ -367,116 +357,45 @@ func GetVideoURLForEpisodeEnhanced(episode *models.Episode, anime *models.Anime)
 			util.Debug("AnimeDrive returned non-playable URL", "url", streamURL)
 			return "", fmt.Errorf("AnimeDrive returned non-playable URL: %s", streamURL)
 		}
-		// Check if user requested to go back from server selection
 		if errors.Is(err, scraper.ErrBackRequested) {
 			return "", ErrBackToEpisodeSelection
 		}
-		// For AnimeDrive, return the error instead of trying legacy method
 		return "", fmt.Errorf("failed to get AnimeDrive stream URL: %w", err)
 	}
 
-	// Try FlixHQ for movies/TV shows
-	if isFlixHQSourcePlayer(anime) {
-		util.Debug("FlixHQ source detected", "source", anime.Source, "mediaType", anime.MediaType, "episodeURL", episode.URL)
+	if providers.IsFlixHQ(anime) {
+		util.Debug("FlixHQ source detected", "source", anime.Source, "mediaType", anime.MediaType)
 		streamURL, err := api.GetEpisodeStreamURL(episode, anime, util.GlobalQuality)
 		if err == nil {
-			util.Debug("FlixHQ stream URL obtained", "url", streamURL)
 			return streamURL, nil
 		}
-		util.Debug("FlixHQ stream URL failed", "error", err)
-		// For FlixHQ, return the error - legacy method won't work with DataIDs
 		return "", fmt.Errorf("failed to get FlixHQ stream URL: %w", err)
 	}
 
-	// Try AllAnime enhanced navigation first if applicable
-	if isAllAnimeSourcePlayer(anime) {
+	if providers.IsAllAnime(anime) {
 		streamURL, err := api.GetEpisodeStreamURLEnhanced(episode, anime, util.GlobalQuality)
 		if err == nil {
 			return streamURL, nil
 		}
 	}
 
-	// Use the regular enhanced API to get stream URL
 	streamURL, err := api.GetEpisodeStreamURL(episode, anime, util.GlobalQuality)
 	if err != nil {
-		// Only use legacy fallback for non-AllAnime sources
-		if !isAllAnimeSourcePlayer(anime) {
+		if !providers.IsAllAnime(anime) {
 			return GetVideoURLForEpisode(episode.URL)
 		}
-		// For AllAnime, return the error instead of trying legacy method
 		return "", fmt.Errorf("failed to get AllAnime stream URL: %w", err)
 	}
 
-	// The enhanced API may return intermediate URLs (Blogger embeds, AnimeFire
-	// video JSON API) that are not directly playable. Resolve them to actual
-	// CDN video URLs before returning.
 	if needsVideoExtraction(streamURL) {
 		resolved, err := extractActualVideoURL(streamURL)
 		if err == nil && resolved != "" {
 			return resolved, nil
 		}
-		// If resolution failed, fall back to the original URL so yt-dlp can try
 		util.Debug("Could not resolve intermediate URL, using as-is", "url", streamURL, "err", err)
 	}
 
 	return streamURL, nil
-}
-
-// Helper function to check if anime is from AllAnime source (player module)
-func isAllAnimeSourcePlayer(anime *models.Anime) bool {
-	if anime == nil {
-		return false
-	}
-	if anime.Source == "AllAnime" {
-		return true
-	}
-
-	if strings.Contains(anime.URL, "allanime") {
-		return true
-	}
-
-	if len(anime.URL) < 30 &&
-		strings.ContainsAny(anime.URL, "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789") &&
-		!strings.Contains(anime.URL, "http") &&
-		!strings.Contains(anime.URL, "animesdrive") {
-		return true
-	}
-
-	return false
-}
-
-// Helper function to check if anime is from AnimeDrive source (player module)
-func isAnimeDriveSourcePlayer(anime *models.Anime) bool {
-	if anime == nil {
-		return false
-	}
-	if anime.Source == "AnimeDrive" {
-		return true
-	}
-	if strings.Contains(anime.Name, "[AnimeDrive]") {
-		return true
-	}
-	if strings.Contains(anime.URL, "animesdrive") {
-		return true
-	}
-	return false
-}
-
-// Helper function to check if anime is from FlixHQ source (player module)
-func isFlixHQSourcePlayer(anime *models.Anime) bool {
-	if anime == nil {
-		return false
-	}
-	if anime.Source == "FlixHQ" {
-		return true
-	}
-	if anime.MediaType == models.MediaTypeMovie || anime.MediaType == models.MediaTypeTV {
-		return true
-	}
-	if strings.Contains(anime.URL, "flixhq") {
-		return true
-	}
-	return false
 }
 
 // Helper: detect if a string is purely numeric (e.g., "12" or "12.5")

--- a/internal/util/help.go
+++ b/internal/util/help.go
@@ -104,7 +104,7 @@ func ShowBeautifulHelp() {
 	addOption(&helpContent, "--update", "Check for updates and update automatically to the latest version.")
 	addOption(&helpContent, "-d", "Download mode - download specific episodes for offline viewing.")
 	addOption(&helpContent, "-r", "Range download mode - download multiple episodes (use with -d).")
-	addOption(&helpContent, "--source", "Specify anime source (allanime, animefire). Default: search all sources.")
+	addOption(&helpContent, "--source", "Specify anime source (see Available Sources below). Default: search all sources.")
 	addOption(&helpContent, "--quality", "Specify video quality (best, worst, 720p, 1080p, etc.). Default: best.")
 	addOption(&helpContent, "--allanime-smart", "AllAnime Smart Range: auto-skip intros/outros via AniSkip and use priority mirrors.")
 	addOption(&helpContent, "--type", "Specify media type (anime, movie, tv). Default: anime.")
@@ -112,6 +112,21 @@ func ShowBeautifulHelp() {
 	addOption(&helpContent, "--no-subs", "Disable subtitles for movies/TV shows (FlixHQ only).")
 	addOption(&helpContent, "--audio", "Specify preferred audio language for movies/TV (FlixHQ only: pt-BR,english,spanish).")
 	addOption(&helpContent, "-o", "Output directory for downloads (default: ~/.local/goanime/downloads/anime/). Files use Plex naming: Anime - S01E01.mp4.")
+	helpContent.WriteString("\n")
+
+	// Available Sources section
+	helpContent.WriteString(separatorStyle.Render(strings.Repeat("─", 80)))
+	helpContent.WriteString("\n")
+	helpContent.WriteString(sectionTitleStyle.Render("Available Sources (--source):"))
+	helpContent.WriteString("\n")
+	addOption(&helpContent, "allanime", "English subbed/dubbed anime (AllAnime)")
+	addOption(&helpContent, "animefire", "Portuguese anime - dubbed and subbed (AnimeFire)")
+	addOption(&helpContent, "animedrive", "Portuguese anime with multiple servers (AnimeDrive)")
+	addOption(&helpContent, "goyabu", "Portuguese anime (Goyabu)")
+	addOption(&helpContent, "9anime", "Multilanguage anime with subtitles (9Anime)")
+	addOption(&helpContent, "flixhq", "Movies and TV shows in English (FlixHQ)")
+	addOption(&helpContent, "sflix", "Movies and TV shows - alternative (SFlix)")
+	addOption(&helpContent, "ptbr", "Search all Portuguese sources (AnimeFire + Goyabu)")
 	helpContent.WriteString("\n")
 
 	// Upscale Options section
@@ -136,7 +151,7 @@ func ShowBeautifulHelp() {
 	helpContent.WriteString(sectionTitleStyle.Render("Features:"))
 	helpContent.WriteString("\n")
 
-	addFeature(&helpContent, "Multi-Source Support", "Stream from AllAnime, AnimeFire, and FlixHQ (movies/TV) with automatic fallback.")
+	addFeature(&helpContent, "Multi-Source Support", "Stream from AllAnime, AnimeFire, AnimeDrive, Goyabu, 9Anime, and FlixHQ with automatic fallback.")
 	addFeature(&helpContent, "Movies & TV Shows", "Watch movies and TV series alongside anime using FlixHQ integration.")
 	addFeature(&helpContent, "Smart Search", "Intelligent search with fuzzy matching and suggestions.")
 	addFeature(&helpContent, "Quality Selection", "Choose video quality from multiple available sources.")

--- a/internal/util/spinner.go
+++ b/internal/util/spinner.go
@@ -1,0 +1,39 @@
+package util
+
+import (
+	"math"
+	"os"
+	"sync"
+
+	"charm.land/huh/v2/spinner"
+	"golang.org/x/term"
+)
+
+var (
+	stdoutIsTerminal     bool
+	stdoutIsTerminalOnce sync.Once
+)
+
+func isStdoutTerminal() bool {
+	stdoutIsTerminalOnce.Do(func() {
+		fd := os.Stdout.Fd()
+		stdoutIsTerminal = fd <= math.MaxInt && term.IsTerminal(int(fd))
+	})
+	return stdoutIsTerminal
+}
+
+// RunWithSpinner runs the action with a spinner if stdout is a terminal,
+// otherwise runs the action directly. This ensures CI and non-interactive
+// environments work correctly since huh/v2 spinner may skip the Action
+// callback when no terminal is attached.
+func RunWithSpinner(title string, action func()) {
+	if isStdoutTerminal() {
+		_ = spinner.New().
+			Title(title).
+			Type(spinner.Dots).
+			Action(action).
+			Run()
+	} else {
+		action()
+	}
+}


### PR DESCRIPTION
## Summary

Centralizes all source-detection and stream-resolution logic into a **registry-based Strategy pattern** (`internal/api/providers/`), eliminating duplicated `if/else` chains scattered across the player, download, and API layers. This ensures a clean, extensible architecture for all current and future providers.

## Motivation

The codebase had **four independent source-detection chains** that each tried to figure out which anime source (AllAnime, AnimeFire, AnimeDrive, FlixHQ, 9Anime, Goyabu) was being used. Adding a new source required touching **all four locations** (and hoping you didn't miss one).

## Architecture

### Before

```mermaid
graph TD
A[player.go] --> B{isAllAnime?}
A --> C{isAnimeDrive?}
A --> D{isFlixHQ?}
B --> E[AllAnime scraper]
C --> F[AnimeDrive scraper]
D --> G[FlixHQ scraper]
H[download.go] --> I{isAllAnime? inline}
H --> J[ExtractVideoSources]
J --> K{AnimeFire JSON?}
J --> L{Resolution regex?}
M[enhanced.go] --> N{Source field?}
M --> O{Name tags?}
M --> P{URL patterns?}
N --> Q[AllAnime / AnimeFire / AnimeDrive / FlixHQ / 9Anime]
O --> Q
P --> Q
style B fill:#f66,stroke:#333
style C fill:#f66,stroke:#333
style D fill:#f66,stroke:#333
style I fill:#f66,stroke:#333
style K fill:#f66,stroke:#333
style N fill:#f96,stroke:#333
style O fill:#f96,stroke:#333
style P fill:#f96,stroke:#333
```

### After

```mermaid
graph TD
A[player.go] --> R[GetVideoURLForEpisodeEnhanced]
H[download.go] --> S[getBestQualityURL]
T[downloader.go] --> U[getBestQualityURL]
R --> V[api.GetEpisodeStreamURL]
S --> V
U --> V
V --> W["providers.ForSource(anime)"]
W --> X[registry.go: ResolveSourceName]
X --> |"Priority 1"| X1["anime.Source → normalizeSource()"]
X --> |"Priority 2"| X2["Name tags [PT-BR], [English], [Goyabu]"]
X --> |"Priority 3"| X3["URL Patterns → detectFromURL()"]
W --> Y1[AllAnimeProvider]
W --> Y2[AnimefireProvider]
W --> Y3[AnimeDriveProvider]
W --> Y4[FlixHQProvider]
W --> Y5[NineAnimeProvider]
W --> Y6[GoyabuProvider]
style W fill:#6f6,stroke:#333
style X fill:#6f6,stroke:#333
style V fill:#6f6,stroke:#333
```

## What Changed

- Created `internal/api/providers/` package with `EpisodeProvider` interface and 6 implementations
- Created `internal/util/spinner.go` (extracted `RunWithSpinner` for cross-package reuse)
- Deleted legacy `isAllAnimeSourcePlayer`, `isAnimeDriveSourcePlayer`, `isFlixHQSourcePlayer` helpers
- Moved `GetFlixHQEpisodes`, `GetFlixHQStreamURL`, `GetNineAnimeEpisodes`, `GetNineAnimeStreamURL` into their respective providers
- Simplified `SearchAnimeEnhanced` with `sourceToScraperType` map lookup
- Reduced `GetAnimeEpisodesEnhanced` and `GetEpisodeStreamURL` to thin delegates
- Added "Available Sources" section to CLI help
- Added comprehensive black-box tests for registry and factory (15 test functions, all passing)

## Adding a New Source

Before this PR, adding a source required modifying 4+ files with source-specific logic chains. Now:

1. Create `providers/newsource.go` implementing `EpisodeProvider` interface
2. Register it in `sourceRegistry` map in `registry.go`

Zero changes required in player, download, or API orchestration files.

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./internal/api/providers/...` — all 15 test functions pass
- [ ] Manual smoke test: search and stream from AllAnime source
- [ ] Manual smoke test: search and stream from AnimeFire source
- [ ] Manual smoke test: verify `--source` flag works with all registered sources
- [ ] Verify CLI `--help` shows new "Available Sources" section


Made with [Cursor](https://cursor.com)