### PR TITLE
fix: improve seasonal title normalization and search fallbacks

### DIFF
--- a/internal/api/anime.go
+++ b/internal/api/anime.go
@@ -521,6 +521,27 @@ func generateSearchVariations(cleanedName string) []string {
 		addVariation(cleanedName[4:])
 	}
 
+	// Variation: Strip trailing season qualifiers in two passes so both the
+	// intermediate form and the base title are produced as search fallbacks.
+	//
+	// Pass 1 – strip a trailing "Part N" / "Parte N" suffix:
+	//   "Attack on Titan Final Season Part 2" → "Attack on Titan Final Season"
+	rePartSuffix := regexp.MustCompile(`(?i)\s+(?:part|parte)\s*\d+\s*$`)
+	withoutPart := strings.TrimSpace(rePartSuffix.ReplaceAllString(cleanedName, ""))
+	if withoutPart != cleanedName {
+		addVariation(withoutPart)
+	}
+	// Pass 2 – strip a trailing season qualifier from both the original title and
+	// the part-stripped form:
+	//   "Attack on Titan Final Season" → "Attack on Titan"
+	//   "My Hero Academia Season 6"   → "My Hero Academia"
+	reSeasonQualifier := regexp.MustCompile(`(?i)\s+(?:final\s+season|season\s+\d+|\d+(?:st|nd|rd|th)\s+season|cour\s*\d+)\s*$`)
+	for _, candidate := range []string{cleanedName, withoutPart} {
+		if base := strings.TrimSpace(reSeasonQualifier.ReplaceAllString(candidate, "")); base != "" && base != candidate {
+			addVariation(base)
+		}
+	}
+
 	// Variation: For very long titles, try first few words
 	words := strings.Fields(cleanedName)
 	if len(words) > 4 {
@@ -572,13 +593,19 @@ func CleanTitle(title string) string {
 	reCompleto := regexp.MustCompile(`(?i)\s+(?:completo|episodio\s*\d+|ep\s*\d+)\s*$`)
 	cleaned = strings.TrimSpace(reCompleto.ReplaceAllString(cleaned, ""))
 
-	// Remove season indicators like "X Temporada", "Season X", "Temporada X", "Xª Temporada"
-	reSeasonPt := regexp.MustCompile(`(?i)\s*[-–—]?\s*(?:\d+[ªº]?\s*temporada|temporada\s*\d+|season\s*\d+|\d+(?:st|nd|rd|th)\s*season)\s*$`)
+	// Remove season indicators like "X Temporada", "Season X", "Temporada X", "Xª Temporada",
+	// "Cour N", and ordinal forms like "4th Season".
+	// NOTE: "Final Season" is intentionally excluded here because it is part of the canonical
+	// title for some anime (e.g. "Shingeki no Kyojin: The Final Season"). Search fallbacks for
+	// "Final Season" are handled in generateSearchVariations instead.
+	reSeasonPt := regexp.MustCompile(`(?i)\s*[-–—]?\s*(?:\d+[ªº]?\s*temporada|temporada\s*\d+|season\s*\d+|\d+(?:st|nd|rd|th)\s*season|cour\s*\d+)\s*$`)
 	cleaned = strings.TrimSpace(reSeasonPt.ReplaceAllString(cleaned, ""))
 
-	// Remove "Parte X" (Part X) common in Brazilian titles
+	// Remove "Parte X" or "Part X" suffixes (including combined "Season N Part N" leftovers).
 	rePart := regexp.MustCompile(`(?i)\s*[-–—]?\s*(?:parte\s*\d+|part\s*\d+)\s*$`)
 	cleaned = strings.TrimSpace(rePart.ReplaceAllString(cleaned, ""))
+	// Re-apply season strip in case "Season N Part N" left a dangling season token.
+	cleaned = strings.TrimSpace(reSeasonPt.ReplaceAllString(cleaned, ""))
 
 	// Remove season/episode indicators like "2.0 A2" at the end (but NOT plain season numbers)
 	re4 := regexp.MustCompile(`\s+\d+(\.\d+)?\s+A\d+\s*$`)

--- a/internal/api/anime_title_test.go
+++ b/internal/api/anime_title_test.go
@@ -448,3 +448,73 @@ func TestCleanTitle_PreservesValidTitles(t *testing.T) {
 		})
 	}
 }
+
+// TestCleanTitle_SeasonReleaseVariants covers the multi-part / cour / ordinal
+// season patterns that appear on AllAnime and AnimeFire titles.
+// NOTE: "Final Season" is deliberately NOT stripped by CleanTitle because it
+// forms part of the canonical title (e.g. "The Final Season"). Fallback search
+// variations for "Final Season" are tested in TestGenerateSearchVariations_SeasonFallbacks.
+func TestCleanTitle_SeasonReleaseVariants(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		input    string
+		expected string
+	}{
+		// "Cour N" suffix should be stripped
+		{"Mushoku Tensei Cour 2", "Mushoku Tensei"},
+		// Ordinal season ("4th Season")
+		{"Black Clover 4th Season", "Black Clover"},
+		// "Season N Part N" combined form – Part N stripped first, then Season N
+		{"Demon Slayer Season 3 Part 2", "Demon Slayer"},
+		// "2nd Season" ordinal
+		{"Re:Zero 2nd Season", "Re:Zero"},
+		// Plain "Season N" still works
+		{"My Hero Academia Season 6", "My Hero Academia"},
+		// "Final Season" is preserved as part of canonical title
+		{"Attack on Titan: The Final Season", "Attack on Titan: The Final Season"},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.input, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.expected, CleanTitle(tc.input),
+				"CleanTitle(%q)", tc.input)
+		})
+	}
+}
+
+// TestGenerateSearchVariations_SeasonFallbacks ensures that season-qualified
+// titles produce the base title as a search fallback variation so AniList can
+// match even when the database entry has no season suffix.
+func TestGenerateSearchVariations_SeasonFallbacks(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		cleaned  string
+		mustHave string
+	}{
+		// "Final Season" qualifier stripped → base title
+		{"Attack on Titan Final Season", "Attack on Titan"},
+		// "Part 2" stripped first → intermediate with "Final Season"
+		{"Attack on Titan Final Season Part 2", "Attack on Titan Final Season"},
+		// "Cour N" stripped → base title
+		{"Mushoku Tensei Cour 2", "Mushoku Tensei"},
+		// "Season N" stripped → base title
+		{"My Hero Academia Season 6", "My Hero Academia"},
+		// "Part N" stripped first → intermediate with "Season N"
+		{"Demon Slayer Season 3 Part 2", "Demon Slayer Season 3"},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.cleaned, func(t *testing.T) {
+			t.Parallel()
+			variations := generateSearchVariations(tc.cleaned)
+			assert.Contains(t, variations, tc.mustHave,
+				"generateSearchVariations(%q) should include %q\ngot: %v",
+				tc.cleaned, tc.mustHave, variations)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- `CleanTitle` now strips `Cour N` suffixes (e.g. `Mushoku Tensei Cour 2` → `Mushoku Tensei`)
- `CleanTitle` intentionally keeps `Final Season` intact — it is a canonical title fragment for some anime (e.g. `Shingeki no Kyojin: The Final Season`); stripping it caused regressions in existing tests
- `generateSearchVariations` uses a two-pass approach: strip `Part N` first (producing the intermediate title), then strip the season qualifier (producing the base title) — so `"Demon Slayer Season 3 Part 2"` yields both `"Demon Slayer Season 3"` and `"Demon Slayer"` as AniList fallbacks
- `Final Season` is also stripped in `generateSearchVariations` so AniList can match even when the entry has no season suffix

## Test plan

- [x] `go test ./internal/api -run TestCleanTitle_SeasonReleaseVariants -v` → PASS (Cour 2, 4th Season, Season N Part N, 2nd Season, Final Season preserved)
- [x] `go test ./internal/api -run TestGenerateSearchVariations_SeasonFallbacks -v` → PASS (Final Season, Season N Part N, Cour N all produce base-title fallback)
- [x] `go test ./internal/api -short` → all ok (no regressions in existing BrazilianSources / RealAnimefireExamples tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)