### PR TITLE
test: cover AnimeFire stream extraction with episode-page fixtures

### DIFF
--- a/internal/scraper/animefire.go
+++ b/internal/scraper/animefire.go
@@ -210,11 +210,78 @@ func (c *AnimefireClient) GetAnimeEpisodes(animeURL string) ([]models.Episode, e
 	return nil, fmt.Errorf("episodes should be fetched using API layer, not scraper")
 }
 
-// GetEpisodeStreamURL gets the streaming URL for a specific episode
-// This is specific to scraper functionality, not duplicated from API
+// qualityOrder maps common AnimeFire quality labels to a numeric rank.
+// Higher is better.
+var qualityOrder = map[string]int{
+	"1080p": 5, "720p": 4, "480p": 3, "360p": 2, "240p": 1,
+}
+
+// qualityRank returns the numeric rank for a quality string, defaulting to 0.
+func qualityRank(q string) int {
+	if r, ok := qualityOrder[strings.ToLower(q)]; ok {
+		return r
+	}
+	return 0
+}
+
+// GetEpisodeStreamURL fetches the episode page, reads all [data-video-src]
+// elements and returns the URL with the highest quality label.
+// Returns ErrSourceUnavailable if the page is a challenge / block page.
 func (c *AnimefireClient) GetEpisodeStreamURL(episodeURL string) (string, error) {
-	// Implementation for getting stream URLs - specific to scraper
-	return "", fmt.Errorf("stream URL extraction not implemented")
+	req, err := http.NewRequest("GET", episodeURL, nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to create request: %w", err)
+	}
+	c.decorateRequest(req)
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to fetch episode page: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", c.handleStatusError(resp)
+	}
+
+	doc, err := goquery.NewDocumentFromReader(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse episode page: %w", err)
+	}
+
+	if c.isChallengePage(doc) {
+		return "", fmt.Errorf("animefire episode page blocked: %w", ErrSourceUnavailable)
+	}
+
+	type videoSource struct {
+		url     string
+		quality string
+	}
+
+	var sources []videoSource
+	doc.Find("[data-video-src]").Each(func(_ int, s *goquery.Selection) {
+		src, exists := s.Attr("data-video-src")
+		if !exists || src == "" {
+			return
+		}
+		quality, _ := s.Attr("data-quality")
+		sources = append(sources, videoSource{url: src, quality: quality})
+	})
+
+	if len(sources) == 0 {
+		return "", errors.New("no video sources found on episode page (data-video-src missing)")
+	}
+
+	// Pick the highest-quality source.
+	best := sources[0]
+	for _, s := range sources[1:] {
+		if qualityRank(s.quality) > qualityRank(best.quality) {
+			best = s
+		}
+	}
+
+	util.Debugf("AnimeFire stream: selected %s (%s) from %d sources", best.url, best.quality, len(sources))
+	return best.url, nil
 }
 
 // GetAnimeDetails - placeholder method, details are fetched by API layer

--- a/internal/scraper/animefire_stream_test.go
+++ b/internal/scraper/animefire_stream_test.go
@@ -1,0 +1,122 @@
+package scraper
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// episodePageFixture builds a minimal AnimeFire episode HTML fixture with the
+// supplied video sources so tests don't need real network access.
+func episodePageFixture(sources []struct{ src, quality string }) string {
+	body := `<html><head><title>Anime Episode</title></head><body>`
+	for _, s := range sources {
+		body += fmt.Sprintf(`<div data-video-src="%s" data-quality="%s"></div>`, s.src, s.quality)
+	}
+	body += `</body></html>`
+	return body
+}
+
+func TestAnimefireGetEpisodeStreamURLSelectsHighestQuality(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, episodePageFixture([]struct{ src, quality string }{
+			{"https://cdn.example.com/ep1_480p.mp4", "480p"},
+			{"https://cdn.example.com/ep1_720p.mp4", "720p"},
+			{"https://cdn.example.com/ep1_360p.mp4", "360p"},
+		}))
+	}))
+	defer server.Close()
+
+	client := NewAnimefireClient()
+	client.baseURL = server.URL
+
+	url, err := client.GetEpisodeStreamURL(server.URL + "/anime/1/episode/1")
+	require.NoError(t, err)
+	assert.Equal(t, "https://cdn.example.com/ep1_720p.mp4", url,
+		"should prefer 720p over 480p and 360p")
+}
+
+func TestAnimefireGetEpisodeStreamURL1080pWins(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, episodePageFixture([]struct{ src, quality string }{
+			{"https://cdn.example.com/ep_720p.mp4", "720p"},
+			{"https://cdn.example.com/ep_1080p.mp4", "1080p"},
+		}))
+	}))
+	defer server.Close()
+
+	client := NewAnimefireClient()
+	client.baseURL = server.URL
+
+	url, err := client.GetEpisodeStreamURL(server.URL + "/anime/2/episode/1")
+	require.NoError(t, err)
+	assert.Equal(t, "https://cdn.example.com/ep_1080p.mp4", url)
+}
+
+func TestAnimefireGetEpisodeStreamURLSingleSource(t *testing.T) {
+	t.Parallel()
+
+	const streamURL = "https://cdn.example.com/ep_only.mp4"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, episodePageFixture([]struct{ src, quality string }{
+			{streamURL, ""},
+		}))
+	}))
+	defer server.Close()
+
+	client := NewAnimefireClient()
+	client.baseURL = server.URL
+
+	url, err := client.GetEpisodeStreamURL(server.URL + "/anime/3/episode/1")
+	require.NoError(t, err)
+	assert.Equal(t, streamURL, url, "single source should be returned regardless of quality label")
+}
+
+func TestAnimefireGetEpisodeStreamURLErrorsWhenNoSource(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, `<html><body><div class="episode-player"></div></body></html>`)
+	}))
+	defer server.Close()
+
+	client := NewAnimefireClient()
+	client.baseURL = server.URL
+
+	_, err := client.GetEpisodeStreamURL(server.URL + "/anime/4/episode/1")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "data-video-src",
+		"error should mention the missing attribute so the cause is clear")
+}
+
+func TestAnimefireGetEpisodeStreamURLBlockedPage(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, `<html><head><title>Just a moment...</title></head><body><div id="cf-wrapper"></div></body></html>`)
+	}))
+	defer server.Close()
+
+	client := NewAnimefireClient()
+	client.baseURL = server.URL
+
+	_, err := client.GetEpisodeStreamURL(server.URL + "/anime/5/episode/1")
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrSourceUnavailable),
+		"challenge page should yield ErrSourceUnavailable, got: %v", err)
+}

--- a/internal/scraper/errors.go
+++ b/internal/scraper/errors.go
@@ -1,0 +1,21 @@
+package scraper
+
+import (
+	"errors"
+	"fmt"
+)
+
+// ErrSourceUnavailable is returned when an upstream source is temporarily
+// unavailable – for example, when an API endpoint returns an HTML page
+// (block/challenge page) instead of the expected JSON payload.
+var ErrSourceUnavailable = errors.New("source unavailable")
+
+// checkHTMLResponse returns a wrapped ErrSourceUnavailable when body starts
+// with '<', indicating the API endpoint returned HTML (e.g. a block page)
+// instead of the expected JSON. source is used in the error message.
+func checkHTMLResponse(body []byte, source string) error {
+	if len(body) > 0 && body[0] == '<' {
+		return fmt.Errorf("%s returned HTML instead of JSON (source blocked?): %w", source, ErrSourceUnavailable)
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary

- Implements `GetEpisodeStreamURL` in `AnimefireClient`: fetches the episode page, reads all `[data-video-src]` elements, and returns the URL with the highest quality rank (`1080p > 720p > 480p > 360p > 240p`)
- Returns `ErrSourceUnavailable` (from #136) when the page is a challenge/block page
- New `animefire_stream_test.go` with five `httptest` fixture tests

## Test plan

- [x] `go test ./internal/scraper -run TestAnimefireGetEpisodeStreamURLSelectsHighestQuality -v` → PASS (720p beats 480p/360p)
- [x] `go test ./internal/scraper -run TestAnimefireGetEpisodeStreamURL1080pWins -v` → PASS
- [x] `go test ./internal/scraper -run TestAnimefireGetEpisodeStreamURLSingleSource -v` → PASS
- [x] `go test ./internal/scraper -run TestAnimefireGetEpisodeStreamURLErrorsWhenNoSource -v` → PASS (error mentions `data-video-src`)
- [x] `go test ./internal/scraper -run TestAnimefireGetEpisodeStreamURLBlockedPage -v` → PASS (`ErrSourceUnavailable`)
- [x] `go test ./internal/scraper ./internal/api ./pkg/goanime -short` → all ok

🤖 Generated with [Claude Code](https://claude.com/claude-code)