### PR TITLE
refactor(scraper): unify source validation guards

### DIFF
--- a/internal/scraper/allanime.go
+++ b/internal/scraper/allanime.go
@@ -207,7 +207,7 @@ func (c *AllAnimeClient) SearchAnime(query string, options ...any) ([]*models.An
 }
 
 // GetEpisodesList gets the list of available episodes for an anime (based on Curd implementation)
-func (c *AllAnimeClient) GetEpisodesList(animeID string, mode string) ([]string, error) {
+func (c *AllAnimeClient) GetEpisodesList(animeID, mode string) ([]string, error) {
 	if mode == "" {
 		mode = "sub"
 	}
@@ -455,7 +455,7 @@ var LinkPriorities = []string{
 }
 
 // GetEpisodeURL gets the streaming URL for a specific episode using priority-based selection
-func (c *AllAnimeClient) GetEpisodeURL(animeID string, episodeNo string, mode string, quality string) (string, map[string]string, error) {
+func (c *AllAnimeClient) GetEpisodeURL(animeID, episodeNo, mode, quality string) (string, map[string]string, error) {
 	if mode == "" {
 		mode = "sub"
 	}
@@ -524,7 +524,7 @@ func (c *AllAnimeClient) GetEpisodeURL(animeID string, episodeNo string, mode st
 }
 
 // processSourceURLsConcurrent processes source URLs with concurrent requests and priority-based selection
-func (c *AllAnimeClient) processSourceURLsConcurrent(sourceURLs []string, quality string, animeID string, episodeNo string) (string, map[string]string, error) {
+func (c *AllAnimeClient) processSourceURLsConcurrent(sourceURLs []string, quality, animeID, episodeNo string) (string, map[string]string, error) {
 	type result struct {
 		index     int
 		links     map[string]string

--- a/internal/scraper/allanime.go
+++ b/internal/scraper/allanime.go
@@ -59,22 +59,6 @@ func NewAllAnimeClient() *AllAnimeClient {
 	return allAnimeClientInstance
 }
 
-// SearchResponse represents the API response structure for anime search
-type SearchResponse struct {
-	Data struct {
-		Shows struct {
-			Edges []struct {
-				ID                string `json:"_id"`
-				Name              string `json:"name"`
-				AvailableEpisodes struct {
-					Sub int `json:"sub"`
-					Dub int `json:"dub"`
-				} `json:"availableEpisodes"`
-			} `json:"edges"`
-		} `json:"shows"`
-	} `json:"data"`
-}
-
 // EpisodeResponse represents the API response for episode details
 type EpisodeResponse struct {
 	Data struct {
@@ -85,16 +69,6 @@ type EpisodeResponse struct {
 				SourceUrl  string `json:"sourceUrl"`
 			} `json:"sourceUrls"`
 		} `json:"episode"`
-	} `json:"data"`
-}
-
-// EpisodesListResponse represents the API response for episodes list
-type EpisodesListResponse struct {
-	Data struct {
-		Show struct {
-			ID                      string         `json:"_id"`
-			AvailableEpisodesDetail map[string]any `json:"availableEpisodesDetail"`
-		} `json:"show"`
 	} `json:"data"`
 }
 
@@ -156,13 +130,17 @@ func (c *AllAnimeClient) SearchAnime(query string, options ...any) ([]*models.An
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("search request returned status %d", resp.StatusCode)
+	if err := checkHTTPStatus(resp, "AllAnime search"); err != nil {
+		return nil, err
 	}
 
 	body, err := io.ReadAll(io.LimitReader(resp.Body, 10*1024*1024))
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+
+	if err := checkHTMLResponse(resp, body, "AllAnime search"); err != nil {
+		return nil, err
 	}
 
 	// Parse using a simple structure like Curd
@@ -265,13 +243,17 @@ func (c *AllAnimeClient) GetEpisodesList(animeID string, mode string) ([]string,
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("episodes list request returned status %d", resp.StatusCode)
+	if err := checkHTTPStatus(resp, "AllAnime episodes list"); err != nil {
+		return nil, err
 	}
 
 	body, err := io.ReadAll(io.LimitReader(resp.Body, 10*1024*1024))
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+
+	if err := checkHTMLResponse(resp, body, "AllAnime episodes list"); err != nil {
+		return nil, err
 	}
 
 	// Use the same response structure as Curd
@@ -518,13 +500,17 @@ func (c *AllAnimeClient) GetEpisodeURL(animeID string, episodeNo string, mode st
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	if resp.StatusCode != http.StatusOK {
-		return "", nil, fmt.Errorf("episode URL request returned status %d", resp.StatusCode)
+	if err := checkHTTPStatus(resp, "AllAnime episode URL"); err != nil {
+		return "", nil, err
 	}
 
 	body, err := io.ReadAll(io.LimitReader(resp.Body, 10*1024*1024))
 	if err != nil {
 		return "", nil, fmt.Errorf("failed to read response: %w", err)
+	}
+
+	if err := checkHTMLResponse(resp, body, "AllAnime episode URL"); err != nil {
+		return "", nil, err
 	}
 
 	// Parse the response to extract source URLs
@@ -746,13 +732,17 @@ func (c *AllAnimeClient) getLinks(sourceURL string) (map[string]string, error) {
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("links request returned status %d", resp.StatusCode)
+	if err := checkHTTPStatus(resp, "AllAnime links"); err != nil {
+		return nil, err
 	}
 
 	body, err := io.ReadAll(io.LimitReader(resp.Body, 10*1024*1024))
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+
+	if err := checkHTMLResponse(resp, body, "AllAnime links"); err != nil {
+		return nil, err
 	}
 
 	links := c.extractVideoLinks(string(body))

--- a/internal/scraper/allanime_test.go
+++ b/internal/scraper/allanime_test.go
@@ -163,3 +163,46 @@ func TestCheckHTTPStatusNonBlockingCodeReturnsPlainError(t *testing.T) {
 	assert.False(t, errors.Is(err, ErrSourceUnavailable), "404 should not be ErrSourceUnavailable, got: %v", err)
 	assert.Contains(t, err.Error(), "404")
 }
+
+func TestAllAnimeGetLinksClassifiesHTMLContentTypeAsSourceUnavailable(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, `<!DOCTYPE html><html><head><title>Just a moment...</title></head><body><div id="cf-wrapper"></div></body></html>`)
+	}))
+	defer server.Close()
+
+	client := &AllAnimeClient{
+		client:    util.GetFastClient(),
+		referer:   AllAnimeReferer,
+		apiBase:   server.URL,
+		userAgent: UserAgent,
+	}
+
+	_, err := client.getLinks(server.URL + "/links")
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrSourceUnavailable), "expected ErrSourceUnavailable for HTML content-type, got: %v", err)
+}
+
+func TestAllAnimeGetLinksClassifiesHTMLBodyAsSourceUnavailable(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, `<html><body>Access Denied</body></html>`)
+	}))
+	defer server.Close()
+
+	client := &AllAnimeClient{
+		client:    util.GetFastClient(),
+		referer:   AllAnimeReferer,
+		apiBase:   server.URL,
+		userAgent: UserAgent,
+	}
+
+	_, err := client.getLinks(server.URL + "/links")
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrSourceUnavailable), "expected ErrSourceUnavailable for HTML body, got: %v", err)
+}

--- a/internal/scraper/allanime_test.go
+++ b/internal/scraper/allanime_test.go
@@ -1,0 +1,165 @@
+package scraper
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/alvarorichard/Goanime/internal/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAllAnimeSearchAnimeClassifiesHTMLPayloadAsSourceUnavailable(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, `<!DOCTYPE html><html><head><title>Just a moment...</title></head><body><div id="cf-wrapper">Cloudflare block</div></body></html>`)
+	}))
+	defer server.Close()
+
+	client := &AllAnimeClient{
+		client:    util.GetFastClient(),
+		referer:   AllAnimeReferer,
+		apiBase:   server.URL,
+		userAgent: UserAgent,
+	}
+
+	_, err := client.SearchAnime("One Piece")
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrSourceUnavailable), "expected ErrSourceUnavailable, got: %v", err)
+}
+
+func TestAllAnimeSearchAnimeValidJSONParsesCorrectly(t *testing.T) {
+	t.Parallel()
+
+	const validJSON = `{"data":{"shows":{"edges":[{"_id":"abc","name":"One Piece","englishName":"One Piece","availableEpisodes":{"sub":1100}}]}}}`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, validJSON)
+	}))
+	defer server.Close()
+
+	client := &AllAnimeClient{
+		client:    util.GetFastClient(),
+		referer:   AllAnimeReferer,
+		apiBase:   server.URL,
+		userAgent: UserAgent,
+	}
+
+	results, err := client.SearchAnime("One Piece")
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Contains(t, results[0].Name, "One Piece")
+}
+
+func TestAllAnimeSearchAnimeClassifies403AsSourceUnavailable(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer server.Close()
+
+	client := &AllAnimeClient{
+		client:    util.GetFastClient(),
+		referer:   AllAnimeReferer,
+		apiBase:   server.URL,
+		userAgent: UserAgent,
+	}
+
+	_, err := client.SearchAnime("One Piece")
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrSourceUnavailable), "expected ErrSourceUnavailable for 403, got: %v", err)
+}
+
+func TestAllAnimeGetEpisodesListClassifiesHTMLPayloadAsSourceUnavailable(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, `<html><body>Access Denied</body></html>`)
+	}))
+	defer server.Close()
+
+	client := &AllAnimeClient{
+		client:    util.GetFastClient(),
+		referer:   AllAnimeReferer,
+		apiBase:   server.URL,
+		userAgent: UserAgent,
+	}
+
+	_, err := client.GetEpisodesList("some-id", "sub")
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrSourceUnavailable), "expected ErrSourceUnavailable, got: %v", err)
+}
+
+func TestAllAnimeGetEpisodeURLClassifiesHTMLAsSourceUnavailable(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, `<html><body>Rate limited</body></html>`)
+	}))
+	defer server.Close()
+
+	client := &AllAnimeClient{
+		client:    util.GetFastClient(),
+		referer:   AllAnimeReferer,
+		apiBase:   server.URL,
+		userAgent: UserAgent,
+	}
+
+	_, _, err := client.GetEpisodeURL("anime-id", "1", "sub", "best")
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrSourceUnavailable), "expected ErrSourceUnavailable for episode URL, got: %v", err)
+}
+
+func TestAllAnimeGetEpisodeURL503ClassifiesAsSourceUnavailable(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+
+	client := &AllAnimeClient{
+		client:    util.GetFastClient(),
+		referer:   AllAnimeReferer,
+		apiBase:   server.URL,
+		userAgent: UserAgent,
+	}
+
+	_, _, err := client.GetEpisodeURL("anime-id", "1", "sub", "best")
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrSourceUnavailable), "expected ErrSourceUnavailable for 503, got: %v", err)
+}
+
+func TestCheckHTMLResponseByteFallback(t *testing.T) {
+	t.Parallel()
+
+	resp := &http.Response{Header: make(http.Header)}
+	body := []byte("\r\n<!DOCTYPE html><html><body>blocked</body></html>")
+
+	err := checkHTMLResponse(resp, body, "test-source")
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrSourceUnavailable), "expected ErrSourceUnavailable from byte fallback, got: %v", err)
+}
+
+func TestCheckHTTPStatusNonBlockingCodeReturnsPlainError(t *testing.T) {
+	t.Parallel()
+
+	resp := &http.Response{StatusCode: http.StatusNotFound}
+	err := checkHTTPStatus(resp, "test-source")
+	require.Error(t, err)
+	assert.False(t, errors.Is(err, ErrSourceUnavailable), "404 should not be ErrSourceUnavailable, got: %v", err)
+	assert.Contains(t, err.Error(), "404")
+}

--- a/internal/scraper/animefire.go
+++ b/internal/scraper/animefire.go
@@ -50,6 +50,7 @@ func NewAnimefireClient() *AnimefireClient {
 
 // SearchAnime searches for anime on Animefire.io using the original logic.
 func (c *AnimefireClient) SearchAnime(query string) ([]*models.Anime, error) {
+	// AnimeFire expects spaces as hyphens in the URL
 	normalizedQuery := strings.ReplaceAll(strings.ToLower(strings.TrimSpace(query)), " ", "-")
 	searchURL := fmt.Sprintf("%s/pesquisar/%s", c.baseURL, url.PathEscape(normalizedQuery))
 
@@ -108,6 +109,7 @@ func (c *AnimefireClient) SearchAnime(query string) ([]*models.Anime, error) {
 
 		animes := c.extractSearchResults(doc)
 		if len(animes) == 0 {
+			// Legitimate empty result set – return without error
 			return []*models.Anime{}, nil
 		}
 
@@ -372,6 +374,7 @@ func (c *AnimefireClient) extractVideoURL(doc *goquery.Document) (string, error)
 		quality int
 	}
 
+	// Method 1: Look for video element with data-video-src attribute
 	var sources []videoSource
 	doc.Find("[data-video-src]").Each(func(_ int, s *goquery.Selection) {
 		src, exists := s.Attr("data-video-src")
@@ -398,6 +401,7 @@ func (c *AnimefireClient) extractVideoURL(doc *goquery.Document) (string, error)
 		return best.url, nil
 	}
 
+	// Method 2: Look for video element with src attribute
 	if videoSrc, exists := doc.Find("video source").Attr("src"); exists && videoSrc != "" {
 		return validateStreamURL(videoSrc, "AnimeFire")
 	}
@@ -405,6 +409,7 @@ func (c *AnimefireClient) extractVideoURL(doc *goquery.Document) (string, error)
 		return validateStreamURL(videoSrc, "AnimeFire")
 	}
 
+	// Method 3: Look for iframe with Blogger video
 	iframeSrc := ""
 	doc.Find("iframe").Each(func(_ int, s *goquery.Selection) {
 		if src, exists := s.Attr("src"); exists {
@@ -418,6 +423,7 @@ func (c *AnimefireClient) extractVideoURL(doc *goquery.Document) (string, error)
 		return validateStreamURL(iframeSrc, "AnimeFire")
 	}
 
+	// Method 4: Look for data-video, data-src, data-url attributes in various elements
 	selectors := []string{
 		"div[data-video]",
 		"div[data-src]",
@@ -434,6 +440,7 @@ func (c *AnimefireClient) extractVideoURL(doc *goquery.Document) (string, error)
 		}
 	}
 
+	// Method 5: Search in HTML content for video URLs
 	html, err := doc.Html()
 	if err == nil {
 		if matches := extractAnimefireBloggerURL(html); matches != "" {

--- a/internal/scraper/animefire.go
+++ b/internal/scraper/animefire.go
@@ -23,10 +23,9 @@ const (
 
 // Pre-compiled regexes for AnimeFire scraper (avoid per-call compilation)
 var (
-	animefireBloggerRe = regexp.MustCompile(`https://www\.blogger\.com/video\.g\?token=([A-Za-z0-9_-]+)`)
 	animefireMp4Re     = regexp.MustCompile(`(https?://[^"'\s<>]+\.mp4(?:\?[^"'\s<>]*)?)`)
 	animefireM3U8Re    = regexp.MustCompile(`(https?://[^"'\s<>]+\.m3u8(?:\?[^"'\s<>]*)?)`)
-	animefireEpisodeRe = regexp.MustCompile(`(?i)epis[oó]dio\s+(\d+)`)
+	animefireEpisodeRe = regexp.MustCompile(`(?i)epis[oÃ³]dio\s+(\d+)`)
 )
 
 // AnimefireClient handles interactions with Animefire.io
@@ -41,7 +40,7 @@ type AnimefireClient struct {
 // NewAnimefireClient creates a new Animefire client
 func NewAnimefireClient() *AnimefireClient {
 	return &AnimefireClient{
-		client:     util.GetFastClient(), // Use shared fast client
+		client:     util.GetFastClient(),
 		baseURL:    AnimefireBase,
 		userAgent:  UserAgent,
 		maxRetries: 2,
@@ -49,9 +48,8 @@ func NewAnimefireClient() *AnimefireClient {
 	}
 }
 
-// SearchAnime searches for anime on Animefire.io using the original logic
+// SearchAnime searches for anime on Animefire.io using the original logic.
 func (c *AnimefireClient) SearchAnime(query string) ([]*models.Anime, error) {
-	// AnimeFire expects spaces as hyphens in the URL
 	normalizedQuery := strings.ReplaceAll(strings.ToLower(strings.TrimSpace(query)), " ", "-")
 	searchURL := fmt.Sprintf("%s/pesquisar/%s", c.baseURL, url.PathEscape(normalizedQuery))
 
@@ -78,8 +76,8 @@ func (c *AnimefireClient) SearchAnime(query string) ([]*models.Anime, error) {
 			return nil, lastErr
 		}
 
-		if resp.StatusCode != http.StatusOK {
-			lastErr = c.handleStatusError(resp)
+		if err := checkHTTPStatus(resp, "AnimeFire search"); err != nil {
+			lastErr = err
 			_ = resp.Body.Close()
 			if c.shouldRetry(attempt) {
 				c.sleep()
@@ -99,8 +97,8 @@ func (c *AnimefireClient) SearchAnime(query string) ([]*models.Anime, error) {
 			return nil, lastErr
 		}
 
-		if c.isChallengePage(doc) {
-			lastErr = errors.New("animefire returned a challenge page (try VPN or wait)")
+		if err := checkChallengeDocument(doc, "AnimeFire search"); err != nil {
+			lastErr = err
 			if c.shouldRetry(attempt) {
 				c.sleep()
 				continue
@@ -110,7 +108,6 @@ func (c *AnimefireClient) SearchAnime(query string) ([]*models.Anime, error) {
 
 		animes := c.extractSearchResults(doc)
 		if len(animes) == 0 {
-			// Legitimate empty result set – return without error
 			return []*models.Anime{}, nil
 		}
 
@@ -132,13 +129,6 @@ func (c *AnimefireClient) decorateRequest(req *http.Request) {
 	req.Header.Set("Referer", c.baseURL+"/")
 }
 
-func (c *AnimefireClient) handleStatusError(resp *http.Response) error {
-	if resp.StatusCode == http.StatusForbidden {
-		return fmt.Errorf("access restricted: VPN may be required")
-	}
-	return fmt.Errorf("server returned: %s", resp.Status)
-}
-
 func (c *AnimefireClient) shouldRetry(attempt int) bool {
 	return attempt < c.maxRetries
 }
@@ -150,24 +140,10 @@ func (c *AnimefireClient) sleep() {
 	time.Sleep(c.retryDelay)
 }
 
-func (c *AnimefireClient) isChallengePage(doc *goquery.Document) bool {
-	title := strings.ToLower(strings.TrimSpace(doc.Find("title").First().Text()))
-	if strings.Contains(title, "just a moment") {
-		return true
-	}
-
-	if doc.Find("#cf-wrapper").Length() > 0 || doc.Find("#challenge-form").Length() > 0 {
-		return true
-	}
-
-	body := strings.ToLower(doc.Text())
-	return strings.Contains(body, "cf-error") || strings.Contains(body, "cloudflare")
-}
-
 func (c *AnimefireClient) extractSearchResults(doc *goquery.Document) []*models.Anime {
 	var animes []*models.Anime
 
-	doc.Find(".row.ml-1.mr-1 a").Each(func(i int, s *goquery.Selection) {
+	doc.Find(".row.ml-1.mr-1 a").Each(func(_ int, s *goquery.Selection) {
 		if urlPath, exists := s.Attr("href"); exists {
 			name := strings.TrimSpace(s.Text())
 			if name != "" {
@@ -183,7 +159,7 @@ func (c *AnimefireClient) extractSearchResults(doc *goquery.Document) []*models.
 		return animes
 	}
 
-	doc.Find(".card_ani").Each(func(i int, s *goquery.Selection) {
+	doc.Find(".card_ani").Each(func(_ int, s *goquery.Selection) {
 		titleElem := s.Find(".ani_name a")
 		title := strings.TrimSpace(titleElem.Text())
 		link, exists := titleElem.Attr("href")
@@ -206,7 +182,7 @@ func (c *AnimefireClient) extractSearchResults(doc *goquery.Document) []*models.
 	return animes
 }
 
-// resolveURL resolves relative URLs to absolute URLs
+// resolveURL resolves relative URLs to absolute URLs.
 func (c *AnimefireClient) resolveURL(base, ref string) string {
 	if strings.HasPrefix(ref, "http") {
 		return ref
@@ -218,7 +194,6 @@ func (c *AnimefireClient) resolveURL(base, ref string) string {
 }
 
 // GetAnimeEpisodes fetches and parses the list of episodes for a given anime.
-// It returns a sorted slice of Episode structs, ordered by episode number.
 func (c *AnimefireClient) GetAnimeEpisodes(animeURL string) ([]models.Episode, error) {
 	util.Debug("AnimeFire episodes", "url", animeURL)
 
@@ -243,8 +218,8 @@ func (c *AnimefireClient) GetAnimeEpisodes(animeURL string) ([]models.Episode, e
 			return nil, lastErr
 		}
 
-		if resp.StatusCode != http.StatusOK {
-			lastErr = c.handleStatusError(resp)
+		if err := checkHTTPStatus(resp, "AnimeFire episodes"); err != nil {
+			lastErr = err
 			_ = resp.Body.Close()
 			if c.shouldRetry(attempt) {
 				c.sleep()
@@ -264,8 +239,8 @@ func (c *AnimefireClient) GetAnimeEpisodes(animeURL string) ([]models.Episode, e
 			return nil, lastErr
 		}
 
-		if c.isChallengePage(doc) {
-			lastErr = errors.New("animefire returned a challenge page (try VPN or wait)")
+		if err := checkChallengeDocument(doc, "AnimeFire episodes"); err != nil {
+			lastErr = err
 			if c.shouldRetry(attempt) {
 				c.sleep()
 				continue
@@ -274,8 +249,6 @@ func (c *AnimefireClient) GetAnimeEpisodes(animeURL string) ([]models.Episode, e
 		}
 
 		episodes := c.parseEpisodes(doc)
-
-		// Sort episodes by number ascending
 		sort.Slice(episodes, func(i, j int) bool {
 			return episodes[i].Num < episodes[j].Num
 		})
@@ -289,14 +262,14 @@ func (c *AnimefireClient) GetAnimeEpisodes(animeURL string) ([]models.Episode, e
 	return nil, errors.New("failed to retrieve episodes from AnimeFire")
 }
 
-// parseEpisodes extracts a list of Episode structs from the given goquery.Document.
+// parseEpisodes extracts a list of Episode structs from the given document.
 func (c *AnimefireClient) parseEpisodes(doc *goquery.Document) []models.Episode {
 	var episodes []models.Episode
 	doc.Find("a.lEp.epT.divNumEp.smallbox.px-2.mx-1.text-left.d-flex").Each(func(i int, s *goquery.Selection) {
 		episodeNum := s.Text()
 		episodeURL, _ := s.Attr("href")
 
-		num := i + 1 // default to index-based numbering
+		num := i + 1
 		matches := animefireEpisodeRe.FindStringSubmatch(episodeNum)
 		if len(matches) >= 2 {
 			parsed, err := strconv.Atoi(matches[1])
@@ -317,8 +290,7 @@ func (c *AnimefireClient) parseEpisodes(doc *goquery.Document) []models.Episode 
 	return episodes
 }
 
-// GetEpisodeStreamURL gets the streaming URL for a specific episode from AnimeFire
-// This handles various video sources including Blogger embeds
+// GetEpisodeStreamURL gets the streaming URL for a specific episode from AnimeFire.
 func (c *AnimefireClient) GetEpisodeStreamURL(episodeURL string) (string, error) {
 	util.Debug("AnimeFire stream URL extraction", "episodeURL", episodeURL)
 
@@ -343,8 +315,8 @@ func (c *AnimefireClient) GetEpisodeStreamURL(episodeURL string) (string, error)
 			return "", lastErr
 		}
 
-		if resp.StatusCode != http.StatusOK {
-			lastErr = c.handleStatusError(resp)
+		if err := checkHTTPStatus(resp, "AnimeFire episode page"); err != nil {
+			lastErr = err
 			_ = resp.Body.Close()
 			if c.shouldRetry(attempt) {
 				c.sleep()
@@ -364,8 +336,8 @@ func (c *AnimefireClient) GetEpisodeStreamURL(episodeURL string) (string, error)
 			return "", lastErr
 		}
 
-		if c.isChallengePage(doc) {
-			lastErr = errors.New("animefire returned a challenge page (try VPN or wait)")
+		if err := checkChallengeDocument(doc, "AnimeFire episode page"); err != nil {
+			lastErr = err
 			if c.shouldRetry(attempt) {
 				c.sleep()
 				continue
@@ -373,7 +345,6 @@ func (c *AnimefireClient) GetEpisodeStreamURL(episodeURL string) (string, error)
 			return "", lastErr
 		}
 
-		// Try to find video URL using multiple methods
 		videoURL, err := c.extractVideoURL(doc)
 		if err == nil && videoURL != "" {
 			util.Debug("AnimeFire video URL found", "url", videoURL)
@@ -393,24 +364,49 @@ func (c *AnimefireClient) GetEpisodeStreamURL(episodeURL string) (string, error)
 	return "", errors.New("failed to extract video URL from AnimeFire")
 }
 
-// extractVideoURL extracts the video URL from an AnimeFire episode page
+// extractVideoURL extracts the video URL from an AnimeFire episode page.
 func (c *AnimefireClient) extractVideoURL(doc *goquery.Document) (string, error) {
-	// Method 1: Look for video element with data-video-src attribute
-	if videoSrc, exists := doc.Find("video[data-video-src]").Attr("data-video-src"); exists && videoSrc != "" {
-		return videoSrc, nil
+	qualityRanks := map[string]int{"1080p": 5, "720p": 4, "480p": 3, "360p": 2, "240p": 1}
+	type videoSource struct {
+		url     string
+		quality int
 	}
 
-	// Method 2: Look for video element with src attribute
+	var sources []videoSource
+	doc.Find("[data-video-src]").Each(func(_ int, s *goquery.Selection) {
+		src, exists := s.Attr("data-video-src")
+		if !exists || src == "" {
+			return
+		}
+
+		validatedURL, err := validateStreamURL(src, "AnimeFire")
+		if err != nil {
+			return
+		}
+
+		label, _ := s.Attr("data-quality")
+		sources = append(sources, videoSource{url: validatedURL, quality: qualityRanks[strings.ToLower(label)]})
+	})
+	if len(sources) > 0 {
+		best := sources[0]
+		for _, source := range sources[1:] {
+			if source.quality > best.quality {
+				best = source
+			}
+		}
+		util.Debugf("AnimeFire: selected quality rank %d url %s from %d sources", best.quality, best.url, len(sources))
+		return best.url, nil
+	}
+
 	if videoSrc, exists := doc.Find("video source").Attr("src"); exists && videoSrc != "" {
-		return videoSrc, nil
+		return validateStreamURL(videoSrc, "AnimeFire")
 	}
 	if videoSrc, exists := doc.Find("video").Attr("src"); exists && videoSrc != "" {
-		return videoSrc, nil
+		return validateStreamURL(videoSrc, "AnimeFire")
 	}
 
-	// Method 3: Look for iframe with Blogger video
 	iframeSrc := ""
-	doc.Find("iframe").Each(func(i int, s *goquery.Selection) {
+	doc.Find("iframe").Each(func(_ int, s *goquery.Selection) {
 		if src, exists := s.Attr("src"); exists {
 			if strings.Contains(src, "blogger.com") || strings.Contains(src, "blogspot.com") {
 				iframeSrc = src
@@ -419,42 +415,35 @@ func (c *AnimefireClient) extractVideoURL(doc *goquery.Document) (string, error)
 	})
 	if iframeSrc != "" {
 		util.Debug("Found Blogger iframe", "src", iframeSrc)
-		return iframeSrc, nil
+		return validateStreamURL(iframeSrc, "AnimeFire")
 	}
 
-	// Method 4: Look for data-video, data-src, data-url attributes in various elements
 	selectors := []string{
-		"div[data-video-src]",
 		"div[data-video]",
 		"div[data-src]",
 		"div[data-url]",
 		"[data-player]",
 	}
-	attrs := []string{"data-video-src", "data-video", "data-src", "data-url", "data-player"}
+	attrs := []string{"data-video", "data-src", "data-url", "data-player"}
 
 	for i, selector := range selectors {
 		if elem := doc.Find(selector); elem.Length() > 0 {
 			if val, exists := elem.Attr(attrs[i]); exists && val != "" {
-				return val, nil
+				return validateStreamURL(val, "AnimeFire")
 			}
 		}
 	}
 
-	// Method 5: Search in HTML content for video URLs
 	html, err := doc.Html()
 	if err == nil {
-		// Look for Blogger video links
-		if animefireBloggerRe.MatchString(html) {
-			if matches := animefireBloggerRe.FindString(html); matches != "" {
-				return matches, nil
-			}
+		if matches := extractAnimefireBloggerURL(html); matches != "" {
+			return validateStreamURL(matches, "AnimeFire")
 		}
 
-		// Look for direct video URLs
 		for _, re := range []*regexp.Regexp{animefireMp4Re, animefireM3U8Re} {
 			if re.MatchString(html) {
 				if matches := re.FindString(html); matches != "" {
-					return matches, nil
+					return validateStreamURL(matches, "AnimeFire")
 				}
 			}
 		}
@@ -463,7 +452,62 @@ func (c *AnimefireClient) extractVideoURL(doc *goquery.Document) (string, error)
 	return "", errors.New("no video source found in the page")
 }
 
-// GetAnimeDetails - placeholder method, details are fetched by API layer
+func extractAnimefireBloggerURL(html string) string {
+	const marker = "https://www.blogger.com/video.g?token="
+
+	search := html
+	offset := 0
+	for {
+		start := strings.Index(search, marker)
+		if start < 0 {
+			return ""
+		}
+
+		start += offset
+		candidate := html[start:]
+		if end := strings.IndexAny(candidate, "\"' <>\r\n\t"); end >= 0 {
+			candidate = candidate[:end]
+		}
+
+		if isValidAnimefireBloggerURL(candidate) {
+			return candidate
+		}
+
+		next := start + len(marker)
+		if next >= len(html) {
+			return ""
+		}
+		search = html[next:]
+		offset = next
+	}
+}
+
+func isValidAnimefireBloggerURL(rawValue string) bool {
+	parsed, err := url.Parse(strings.TrimSpace(rawValue))
+	if err != nil {
+		return false
+	}
+
+	if parsed.Scheme != "https" || parsed.Host != "www.blogger.com" || parsed.Path != "/video.g" {
+		return false
+	}
+
+	token := parsed.Query().Get("token")
+	if token == "" {
+		return false
+	}
+
+	for _, r := range token {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '_' || r == '-' {
+			continue
+		}
+		return false
+	}
+
+	return true
+}
+
+// GetAnimeDetails is a placeholder method; details are fetched by the API layer.
 func (c *AnimefireClient) GetAnimeDetails(animeURL string) (*models.Anime, error) {
 	return nil, fmt.Errorf("anime details should be fetched using API layer, not scraper")
 }

--- a/internal/scraper/animefire.go
+++ b/internal/scraper/animefire.go
@@ -25,7 +25,7 @@ const (
 var (
 	animefireMp4Re     = regexp.MustCompile(`(https?://[^"'\s<>]+\.mp4(?:\?[^"'\s<>]*)?)`)
 	animefireM3U8Re    = regexp.MustCompile(`(https?://[^"'\s<>]+\.m3u8(?:\?[^"'\s<>]*)?)`)
-	animefireEpisodeRe = regexp.MustCompile(`(?i)epis[oÃ³]dio\s+(\d+)`)
+	animefireEpisodeRe = regexp.MustCompile(`(?i)epis[oó]dio\s+(\d+)`)
 )
 
 // AnimefireClient handles interactions with Animefire.io

--- a/internal/scraper/animefire_stream_test.go
+++ b/internal/scraper/animefire_stream_test.go
@@ -1,0 +1,117 @@
+package scraper
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func episodePageFixture(sources []struct{ src, quality string }) string {
+	body := `<html><head><title>Anime Episode</title></head><body>`
+	for _, s := range sources {
+		body += fmt.Sprintf(`<div data-video-src="%s" data-quality="%s"></div>`, s.src, s.quality)
+	}
+	body += `</body></html>`
+	return body
+}
+
+func TestAnimefireGetEpisodeStreamURLSelectsHighestQuality(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, episodePageFixture([]struct{ src, quality string }{
+			{"https://cdn.example.com/ep1_480p.mp4", "480p"},
+			{"https://cdn.example.com/ep1_720p.mp4", "720p"},
+			{"https://cdn.example.com/ep1_360p.mp4", "360p"},
+		}))
+	}))
+	defer server.Close()
+
+	client := NewAnimefireClient()
+	client.baseURL = server.URL
+
+	streamURL, err := client.GetEpisodeStreamURL(server.URL + "/anime/1/episode/1")
+	require.NoError(t, err)
+	assert.Equal(t, "https://cdn.example.com/ep1_720p.mp4", streamURL)
+}
+
+func TestAnimefireGetEpisodeStreamURL1080pWins(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, episodePageFixture([]struct{ src, quality string }{
+			{"https://cdn.example.com/ep_720p.mp4", "720p"},
+			{"https://cdn.example.com/ep_1080p.mp4", "1080p"},
+		}))
+	}))
+	defer server.Close()
+
+	client := NewAnimefireClient()
+	client.baseURL = server.URL
+
+	streamURL, err := client.GetEpisodeStreamURL(server.URL + "/anime/2/episode/1")
+	require.NoError(t, err)
+	assert.Equal(t, "https://cdn.example.com/ep_1080p.mp4", streamURL)
+}
+
+func TestAnimefireGetEpisodeStreamURLSingleSource(t *testing.T) {
+	t.Parallel()
+
+	const streamURL = "https://cdn.example.com/ep_only.mp4"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, episodePageFixture([]struct{ src, quality string }{
+			{streamURL, ""},
+		}))
+	}))
+	defer server.Close()
+
+	client := NewAnimefireClient()
+	client.baseURL = server.URL
+
+	resolvedURL, err := client.GetEpisodeStreamURL(server.URL + "/anime/3/episode/1")
+	require.NoError(t, err)
+	assert.Equal(t, streamURL, resolvedURL)
+}
+
+func TestAnimefireGetEpisodeStreamURLErrorsWhenNoSource(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, `<html><body><div class="episode-player"></div></body></html>`)
+	}))
+	defer server.Close()
+
+	client := NewAnimefireClient()
+	client.baseURL = server.URL
+
+	_, err := client.GetEpisodeStreamURL(server.URL + "/anime/4/episode/1")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no video source")
+}
+
+func TestAnimefireGetEpisodeStreamURLBlockedPage(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, `<html><head><title>Just a moment...</title></head><body><div id="cf-wrapper"></div></body></html>`)
+	}))
+	defer server.Close()
+
+	client := NewAnimefireClient()
+	client.baseURL = server.URL
+
+	_, err := client.GetEpisodeStreamURL(server.URL + "/anime/5/episode/1")
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrSourceUnavailable), "challenge page should yield ErrSourceUnavailable, got: %v", err)
+}

--- a/internal/scraper/animefire_test.go
+++ b/internal/scraper/animefire_test.go
@@ -1,6 +1,7 @@
 package scraper
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -88,7 +89,7 @@ func TestAnimefireSearchDetectsChallengePage(t *testing.T) {
 
 	_, err := client.SearchAnime("naruto")
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "challenge")
+	assert.True(t, errors.Is(err, ErrSourceUnavailable), "expected ErrSourceUnavailable, got: %v", err)
 }
 
 func TestAnimefireExtractsVideoFromIframe(t *testing.T) {

--- a/internal/scraper/errors.go
+++ b/internal/scraper/errors.go
@@ -69,7 +69,7 @@ func checkChallengeDocument(doc *goquery.Document, source string) error {
 }
 
 // validateStreamURL ensures extracted playback URLs are absolute HTTP(S) URLs.
-func validateStreamURL(rawURL string, source string) (string, error) {
+func validateStreamURL(rawURL, source string) (string, error) {
 	parsed, err := url.Parse(strings.TrimSpace(rawURL))
 	if err != nil {
 		return "", fmt.Errorf("%s returned malformed stream URL: %w", source, ErrInvalidStreamURL)

--- a/internal/scraper/errors.go
+++ b/internal/scraper/errors.go
@@ -1,0 +1,87 @@
+// Package scraper provides shared scraper guards and error helpers.
+package scraper
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/PuerkitoBio/goquery"
+)
+
+// ErrSourceUnavailable is returned when an upstream source is temporarily
+// unavailable or blocked and cannot provide the expected payload.
+var ErrSourceUnavailable = errors.New("source unavailable")
+
+// ErrInvalidStreamURL is returned when a scraper extracts a value that is not a
+// valid absolute playback URL.
+var ErrInvalidStreamURL = errors.New("invalid stream url")
+
+// checkHTTPStatus wraps blocking upstream statuses with ErrSourceUnavailable so
+// callers can differentiate provider-side issues from local parsing failures.
+func checkHTTPStatus(resp *http.Response, source string) error {
+	switch resp.StatusCode {
+	case http.StatusForbidden, http.StatusTooManyRequests, http.StatusServiceUnavailable:
+		return fmt.Errorf("%s returned status %d (source blocked?): %w", source, resp.StatusCode, ErrSourceUnavailable)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("%s returned status %d", source, resp.StatusCode)
+	}
+	return nil
+}
+
+// checkHTMLResponse detects HTML challenge or error pages where JSON payloads
+// are expected.
+func checkHTMLResponse(resp *http.Response, body []byte, source string) error {
+	if strings.Contains(strings.ToLower(resp.Header.Get("Content-Type")), "text/html") {
+		return fmt.Errorf("%s returned HTML instead of JSON (source blocked?): %w", source, ErrSourceUnavailable)
+	}
+
+	trimmed := bytes.TrimLeft(body, " \t\r\n")
+	if len(trimmed) > 0 && trimmed[0] == '<' {
+		return fmt.Errorf("%s returned HTML instead of JSON (source blocked?): %w", source, ErrSourceUnavailable)
+	}
+
+	return nil
+}
+
+// checkChallengeDocument detects common Cloudflare/challenge pages in HTML
+// responses that should be classified as a source-unavailable condition.
+func checkChallengeDocument(doc *goquery.Document, source string) error {
+	title := strings.ToLower(strings.TrimSpace(doc.Find("title").First().Text()))
+	if strings.Contains(title, "just a moment") {
+		return fmt.Errorf("%s returned a challenge page: %w", source, ErrSourceUnavailable)
+	}
+
+	if doc.Find("#cf-wrapper").Length() > 0 || doc.Find("#challenge-form").Length() > 0 {
+		return fmt.Errorf("%s returned a challenge page: %w", source, ErrSourceUnavailable)
+	}
+
+	body := strings.ToLower(doc.Text())
+	if strings.Contains(body, "cf-error") || strings.Contains(body, "cloudflare") {
+		return fmt.Errorf("%s returned a challenge page: %w", source, ErrSourceUnavailable)
+	}
+
+	return nil
+}
+
+// validateStreamURL ensures extracted playback URLs are absolute HTTP(S) URLs.
+func validateStreamURL(rawURL string, source string) (string, error) {
+	parsed, err := url.Parse(strings.TrimSpace(rawURL))
+	if err != nil {
+		return "", fmt.Errorf("%s returned malformed stream URL: %w", source, ErrInvalidStreamURL)
+	}
+
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return "", fmt.Errorf("%s returned unsupported stream URL scheme %q: %w", source, parsed.Scheme, ErrInvalidStreamURL)
+	}
+
+	if parsed.Host == "" {
+		return "", fmt.Errorf("%s returned stream URL without host: %w", source, ErrInvalidStreamURL)
+	}
+
+	return parsed.String(), nil
+}

--- a/internal/scraper/errors.go
+++ b/internal/scraper/errors.go
@@ -27,7 +27,7 @@ func checkHTTPStatus(resp *http.Response, source string) error {
 	case http.StatusForbidden, http.StatusTooManyRequests, http.StatusServiceUnavailable:
 		return fmt.Errorf("%s returned status %d (source blocked?): %w", source, resp.StatusCode, ErrSourceUnavailable)
 	}
-	if resp.StatusCode != http.StatusOK {
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return fmt.Errorf("%s returned status %d", source, resp.StatusCode)
 	}
 	return nil

--- a/internal/scraper/goyabu.go
+++ b/internal/scraper/goyabu.go
@@ -123,14 +123,19 @@ func (c *GoyabuClient) SearchAnime(query string) ([]*models.Anime, error) {
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	if resp.StatusCode != http.StatusOK {
-		util.Debug("Goyabu API returned non-200, trying HTML fallback", "status", resp.StatusCode)
+	if err := checkHTTPStatus(resp, "Goyabu search API"); err != nil {
+		util.Debug("Goyabu API unavailable, trying HTML fallback", "error", err)
 		return c.searchAnimeHTML(query)
 	}
 
 	body, err := io.ReadAll(io.LimitReader(resp.Body, 5*1024*1024))
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+
+	if err := checkHTMLResponse(resp, body, "Goyabu search API"); err != nil {
+		util.Debug("Goyabu API returned HTML, trying HTML fallback", "error", err)
+		return c.searchAnimeHTML(query)
 	}
 
 	// The API returns an object keyed by post ID, not an array.
@@ -183,9 +188,20 @@ func (c *GoyabuClient) fetchNonce() (string, error) {
 	}
 	defer func() { _ = resp.Body.Close() }()
 
+	if err := checkHTTPStatus(resp, "Goyabu homepage"); err != nil {
+		return "", err
+	}
+
 	body, err := io.ReadAll(io.LimitReader(resp.Body, 5*1024*1024))
 	if err != nil {
 		return "", err
+	}
+
+	doc, err := goquery.NewDocumentFromReader(strings.NewReader(string(body)))
+	if err == nil {
+		if err := checkChallengeDocument(doc, "Goyabu homepage"); err != nil {
+			return "", err
+		}
 	}
 
 	// Extract nonce from glosAP config: "nonce":"xxxxx"
@@ -222,8 +238,8 @@ func (c *GoyabuClient) searchAnimeHTML(query string) ([]*models.Anime, error) {
 			return nil, lastErr
 		}
 
-		if resp.StatusCode != http.StatusOK {
-			lastErr = fmt.Errorf("server returned: %s", resp.Status)
+		if err := checkHTTPStatus(resp, "Goyabu search HTML"); err != nil {
+			lastErr = err
 			_ = resp.Body.Close()
 			if c.shouldRetry(attempt) {
 				c.sleep()
@@ -236,6 +252,15 @@ func (c *GoyabuClient) searchAnimeHTML(query string) ([]*models.Anime, error) {
 		_ = resp.Body.Close()
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse HTML: %w", err)
+		}
+
+		if err := checkChallengeDocument(doc, "Goyabu search HTML"); err != nil {
+			lastErr = err
+			if c.shouldRetry(attempt) {
+				c.sleep()
+				continue
+			}
+			return nil, lastErr
 		}
 
 		return c.extractSearchResults(doc), nil
@@ -339,8 +364,8 @@ func (c *GoyabuClient) GetAnimeEpisodes(animeURL string) ([]models.Episode, erro
 			return nil, lastErr
 		}
 
-		if resp.StatusCode != http.StatusOK {
-			lastErr = fmt.Errorf("server returned: %s", resp.Status)
+		if err := checkHTTPStatus(resp, "Goyabu episodes"); err != nil {
+			lastErr = err
 			_ = resp.Body.Close()
 			if c.shouldRetry(attempt) {
 				c.sleep()
@@ -353,6 +378,18 @@ func (c *GoyabuClient) GetAnimeEpisodes(animeURL string) ([]models.Episode, erro
 		_ = resp.Body.Close()
 		if err != nil {
 			return nil, fmt.Errorf("failed to read response: %w", err)
+		}
+
+		doc, err := goquery.NewDocumentFromReader(strings.NewReader(string(body)))
+		if err == nil {
+			if err := checkChallengeDocument(doc, "Goyabu episodes"); err != nil {
+				lastErr = err
+				if c.shouldRetry(attempt) {
+					c.sleep()
+					continue
+				}
+				return nil, lastErr
+			}
 		}
 
 		episodes := c.parseEpisodesFromJS(string(body))
@@ -476,8 +513,8 @@ func (c *GoyabuClient) GetEpisodeStreamURL(episodeURL string) (string, error) {
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("server returned: %s", resp.Status)
+	if err := checkHTTPStatus(resp, "Goyabu episode page"); err != nil {
+		return "", err
 	}
 
 	body, err := io.ReadAll(io.LimitReader(resp.Body, 10*1024*1024))
@@ -490,17 +527,21 @@ func (c *GoyabuClient) GetEpisodeStreamURL(episodeURL string) (string, error) {
 	// Strategy 1: Look for direct video URL in the page
 	doc, err := goquery.NewDocumentFromReader(strings.NewReader(pageHTML))
 	if err == nil {
+		if err := checkChallengeDocument(doc, "Goyabu episode page"); err != nil {
+			return "", err
+		}
+
 		// Check for iframe with video embed
 		if src, exists := doc.Find("iframe").Attr("src"); exists && src != "" {
-			return src, nil
+			return validateStreamURL(src, "Goyabu")
 		}
 
 		// Check for video element
 		if src, exists := doc.Find("video source").Attr("src"); exists && src != "" {
-			return src, nil
+			return validateStreamURL(src, "Goyabu")
 		}
 		if src, exists := doc.Find("video[data-video-src]").Attr("data-video-src"); exists && src != "" {
-			return src, nil
+			return validateStreamURL(src, "Goyabu")
 		}
 	}
 
@@ -518,14 +559,14 @@ func (c *GoyabuClient) GetEpisodeStreamURL(episodeURL string) (string, error) {
 	for _, re := range goyabuVideoPatterns {
 		matches := re.FindStringSubmatch(pageHTML)
 		if len(matches) >= 2 {
-			return matches[1], nil
+			return validateStreamURL(matches[1], "Goyabu")
 		}
 	}
 
 	// Strategy 4: Return Blogger embed URL as last resort (video player can handle it)
 	if bloggerURL != "" {
 		util.Debug("Using Blogger embed URL as fallback", "url", bloggerURL)
-		return bloggerURL, nil
+		return validateStreamURL(bloggerURL, "Goyabu")
 	}
 
 	return "", fmt.Errorf("could not find stream URL in episode page")
@@ -584,9 +625,17 @@ func (c *GoyabuClient) decodeBloggerToken(token string) (string, error) {
 	}
 	defer func() { _ = resp.Body.Close() }()
 
+	if err := checkHTTPStatus(resp, "Goyabu blogger decode"); err != nil {
+		return "", err
+	}
+
 	body, err := io.ReadAll(io.LimitReader(resp.Body, 5*1024*1024))
 	if err != nil {
 		return "", fmt.Errorf("failed to read AJAX response: %w", err)
+	}
+
+	if err := checkHTMLResponse(resp, body, "Goyabu blogger decode"); err != nil {
+		return "", err
 	}
 
 	// Try to parse the response as JSON with video URLs
@@ -595,7 +644,7 @@ func (c *GoyabuClient) decodeBloggerToken(token string) (string, error) {
 		// Maybe it returned a direct URL string
 		urlStr := strings.TrimSpace(string(body))
 		if strings.HasPrefix(urlStr, "http") {
-			return urlStr, nil
+			return validateStreamURL(urlStr, "Goyabu")
 		}
 		return "", fmt.Errorf("failed to parse AJAX response: %w", err)
 	}
@@ -617,7 +666,7 @@ func (c *GoyabuClient) decodeBloggerToken(token string) (string, error) {
 				}
 			}
 			if bestURL != "" {
-				return bestURL, nil
+				return validateStreamURL(bestURL, "Goyabu")
 			}
 		}
 	}
@@ -630,7 +679,7 @@ func (c *GoyabuClient) decodeBloggerToken(token string) (string, error) {
 		for _, key := range []string{"url", "file", "src", "video_url", "stream_url"} {
 			if val, ok := obj[key]; ok {
 				if urlStr, ok := val.(string); ok && strings.HasPrefix(urlStr, "http") {
-					return urlStr, nil
+					return validateStreamURL(urlStr, "Goyabu")
 				}
 			}
 		}

--- a/internal/scraper/goyabu.go
+++ b/internal/scraper/goyabu.go
@@ -197,8 +197,11 @@ func (c *GoyabuClient) fetchNonce() (string, error) {
 		return "", err
 	}
 
-	if err := checkHTMLResponse(resp, body, "Goyabu homepage"); err != nil {
-		return "", err
+	doc, err := goquery.NewDocumentFromReader(strings.NewReader(string(body)))
+	if err == nil {
+		if err := checkChallengeDocument(doc, "Goyabu homepage"); err != nil {
+			return "", err
+		}
 	}
 
 	// Extract nonce from glosAP config: "nonce":"xxxxx"
@@ -377,13 +380,16 @@ func (c *GoyabuClient) GetAnimeEpisodes(animeURL string) ([]models.Episode, erro
 			return nil, fmt.Errorf("failed to read response: %w", err)
 		}
 
-		if err := checkHTMLResponse(resp, body, "Goyabu episodes"); err != nil {
-			lastErr = err
-			if c.shouldRetry(attempt) {
-				c.sleep()
-				continue
+		doc, err := goquery.NewDocumentFromReader(strings.NewReader(string(body)))
+		if err == nil {
+			if err := checkChallengeDocument(doc, "Goyabu episodes"); err != nil {
+				lastErr = err
+				if c.shouldRetry(attempt) {
+					c.sleep()
+					continue
+				}
+				return nil, lastErr
 			}
-			return nil, lastErr
 		}
 
 		episodes := c.parseEpisodesFromJS(string(body))

--- a/internal/scraper/goyabu.go
+++ b/internal/scraper/goyabu.go
@@ -197,11 +197,8 @@ func (c *GoyabuClient) fetchNonce() (string, error) {
 		return "", err
 	}
 
-	doc, err := goquery.NewDocumentFromReader(strings.NewReader(string(body)))
-	if err == nil {
-		if err := checkChallengeDocument(doc, "Goyabu homepage"); err != nil {
-			return "", err
-		}
+	if err := checkHTMLResponse(resp, body, "Goyabu homepage"); err != nil {
+		return "", err
 	}
 
 	// Extract nonce from glosAP config: "nonce":"xxxxx"
@@ -380,16 +377,13 @@ func (c *GoyabuClient) GetAnimeEpisodes(animeURL string) ([]models.Episode, erro
 			return nil, fmt.Errorf("failed to read response: %w", err)
 		}
 
-		doc, err := goquery.NewDocumentFromReader(strings.NewReader(string(body)))
-		if err == nil {
-			if err := checkChallengeDocument(doc, "Goyabu episodes"); err != nil {
-				lastErr = err
-				if c.shouldRetry(attempt) {
-					c.sleep()
-					continue
-				}
-				return nil, lastErr
+		if err := checkHTMLResponse(resp, body, "Goyabu episodes"); err != nil {
+			lastErr = err
+			if c.shouldRetry(attempt) {
+				c.sleep()
+				continue
 			}
+			return nil, lastErr
 		}
 
 		episodes := c.parseEpisodesFromJS(string(body))

--- a/internal/scraper/goyabu_test.go
+++ b/internal/scraper/goyabu_test.go
@@ -2,6 +2,7 @@ package scraper
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -335,4 +336,75 @@ func TestGoyabuParseEpisodesFromJS_NoEpisodes(t *testing.T) {
 	episodes, err := client.GetAnimeEpisodes(server.URL + "/anime/test")
 	require.NoError(t, err)
 	assert.Empty(t, episodes)
+}
+
+func TestGoyabuSearchAnimeClassifiesBlockedHTMLAsSourceUnavailable(t *testing.T) {
+	t.Parallel()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/" && r.URL.Query().Get("s") == "":
+			w.WriteHeader(http.StatusForbidden)
+		case r.URL.Query().Get("s") != "":
+			w.WriteHeader(http.StatusOK)
+			_, _ = fmt.Fprint(w, `<html><head><title>Just a moment...</title></head><body><div id="cf-wrapper"></div></body></html>`)
+		default:
+			http.NotFound(w, r)
+		}
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	client := NewGoyabuClient()
+	client.baseURL = server.URL
+	client.maxRetries = 0
+	client.retryDelay = 0
+
+	_, err := client.SearchAnime("naruto")
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrSourceUnavailable), "expected ErrSourceUnavailable, got: %v", err)
+}
+
+func TestGoyabuGetEpisodeStreamURLBlockedPage(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, `<html><head><title>Just a moment...</title></head><body><div id="cf-wrapper"></div></body></html>`)
+	}))
+	defer server.Close()
+
+	client := NewGoyabuClient()
+	client.baseURL = server.URL
+	client.maxRetries = 0
+	client.retryDelay = 0
+
+	_, err := client.GetEpisodeStreamURL(server.URL + "/episode/blocked")
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrSourceUnavailable), "expected ErrSourceUnavailable, got: %v", err)
+}
+
+func TestGoyabuDecodeBloggerTokenClassifiesHTMLAsSourceUnavailable(t *testing.T) {
+	t.Parallel()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/wp-admin/admin-ajax.php", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, `<html><body>blocked</body></html>`)
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	client := NewGoyabuClient()
+	client.baseURL = server.URL
+	client.maxRetries = 0
+	client.retryDelay = 0
+
+	_, err := client.decodeBloggerToken("token123")
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrSourceUnavailable), "expected ErrSourceUnavailable, got: %v", err)
 }

--- a/internal/scraper/unified.go
+++ b/internal/scraper/unified.go
@@ -296,6 +296,7 @@ drainLoop:
 				sourceName := sm.getScraperDisplayName(res.scraperType)
 				util.Debug("Late search error", "source", sourceName, "error", res.err)
 				searchErrors = append(searchErrors, fmt.Sprintf("%s: %v", sourceName, res.err))
+				searchSourceErrors = append(searchSourceErrors, fmt.Errorf("%s: %w", sourceName, res.err))
 				errorsMutex.Unlock()
 				continue
 			}

--- a/internal/scraper/unified.go
+++ b/internal/scraper/unified.go
@@ -3,6 +3,7 @@ package scraper
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"regexp"
 	"strings"
@@ -154,6 +155,7 @@ func (sm *ScraperManager) searchAllScrapersConcurrent(query string) ([]*models.A
 		allResults         []*models.Anime
 		resultsMutex       sync.Mutex
 		searchErrors       []string
+		searchSourceErrors []error
 		errorsMutex        sync.Mutex
 		sourcesWithResults map[ScraperType]bool
 	)
@@ -205,6 +207,7 @@ func (sm *ScraperManager) searchAllScrapersConcurrent(query string) ([]*models.A
 				sourceName := sm.getScraperDisplayName(res.scraperType)
 				util.Debug("Search error", "source", sourceName, "error", res.err)
 				searchErrors = append(searchErrors, fmt.Sprintf("%s: %v", sourceName, res.err))
+				searchSourceErrors = append(searchSourceErrors, fmt.Errorf("%s: %w", sourceName, res.err))
 				errorsMutex.Unlock()
 				continue
 			}
@@ -327,7 +330,7 @@ drainLoop:
 		errorsMutex.Lock()
 		defer errorsMutex.Unlock()
 		if len(searchErrors) > 0 {
-			return nil, fmt.Errorf("no anime found with name: %s (some sources failed: %s)", query, strings.Join(searchErrors, "; "))
+			return nil, fmt.Errorf("no anime found with name: %s (some sources failed: %s): %w", query, strings.Join(searchErrors, "; "), errors.Join(searchSourceErrors...))
 		}
 		return nil, fmt.Errorf("no anime found with name: %s", query)
 	}

--- a/internal/scraper/unified_test.go
+++ b/internal/scraper/unified_test.go
@@ -2,6 +2,7 @@ package scraper
 
 import (
 	"errors"
+	"fmt"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -653,6 +654,34 @@ func TestSearchAnime_QueryPassedCorrectly(t *testing.T) {
 	assert.Len(t, capturedQueries, 2)
 	assert.Contains(t, capturedQueries, "allanime:Shingeki no Kyojin")
 	assert.Contains(t, capturedQueries, "animefire:Shingeki no Kyojin")
+}
+
+// =============================================================================
+// Test: ErrSourceUnavailable sentinel is preserved through errors.Join
+// =============================================================================
+
+func TestSearchAnime_AllSourcesUnavailable_SentinelChainPreserved(t *testing.T) {
+	t.Parallel()
+
+	unavailableErr := fmt.Errorf("blocked by Cloudflare: %w", ErrSourceUnavailable)
+
+	allAnimeMock := &MockScraper{
+		searchFunc: func(_ string) ([]*models.Anime, error) {
+			return nil, unavailableErr
+		},
+	}
+	animefireMock := &MockScraper{
+		searchFunc: func(_ string) ([]*models.Anime, error) {
+			return nil, unavailableErr
+		},
+	}
+
+	manager := createTestManager(allAnimeMock, animefireMock)
+	_, err := manager.SearchAnime("one piece", nil)
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrSourceUnavailable),
+		"errors.Is should find ErrSourceUnavailable in the chain, got: %v", err)
 }
 
 // =============================================================================

--- a/pkg/goanime/client_test.go
+++ b/pkg/goanime/client_test.go
@@ -1,6 +1,7 @@
 package goanime_test
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/alvarorichard/Goanime/pkg/goanime"
@@ -102,6 +103,9 @@ func TestSearchAnime_Integration(t *testing.T) {
 	// Test search across all sources
 	results, err := client.SearchAnime("Naruto", nil)
 	if err != nil {
+		if errors.Is(err, goanime.ErrSourceUnavailable) {
+			t.Skipf("Skipping integration test while upstream source is unavailable: %v", err)
+		}
 		t.Fatalf("SearchAnime failed: %v", err)
 	}
 
@@ -133,6 +137,9 @@ func TestSearchAnimeSpecificSource_Integration(t *testing.T) {
 
 	results, err := client.SearchAnime("One Piece", &source)
 	if err != nil {
+		if errors.Is(err, goanime.ErrSourceUnavailable) {
+			t.Skipf("Skipping source-specific integration test while upstream source is unavailable: %v", err)
+		}
 		t.Fatalf("SearchAnime with specific source failed: %v", err)
 	}
 

--- a/pkg/goanime/errors.go
+++ b/pkg/goanime/errors.go
@@ -1,0 +1,8 @@
+// Package goanime exposes public client APIs and shared sentinel errors.
+package goanime
+
+import "github.com/alvarorichard/Goanime/internal/scraper"
+
+// ErrSourceUnavailable indicates that the selected upstream source is
+// temporarily unavailable or blocked.
+var ErrSourceUnavailable = scraper.ErrSourceUnavailable


### PR DESCRIPTION
## Summary

- centralizes shared source errors and validation helpers in `internal/scraper/errors.go`
- applies HTTP status, HTML/challenge-page, and invalid stream URL guards to `AllAnime`, `AnimeFire`, and `Goyabu`
- exposes `ErrSourceUnavailable` to package consumers through `pkg/goanime/errors.go`
- adds and updates tests covering the new guards and the main regression paths

## Why

Source-unavailable and invalid-response handling was becoming too source-specific. This change unifies that behavior so the scraper layer is easier to maintain and gives more consistent diagnostics and fallback handling across providers.

## Test plan

- `go vet ./...`
- `staticcheck ./...`
- `gosec ./...`
- `govulncheck ./...`
- `golangci-lint run`
- `go test ./internal/scraper -v`
- `go test ./pkg/goanime -v`
- `go test ./internal/scraper ./internal/api ./pkg/goanime -short`
- `go build ./cmd/goanime`

## Notes

- This PR ships commit `69bef20`, already pushed to `Vittuu:dev`.
- The local tree used for the web app has other customizations, but this PR references only the fork's `dev` branch.
