### PR TITLE
fix: Goyabu batchexecute index + AllAnime AES-GCM key rotation

### DIFF
--- a/internal/player/goyabu_blogger_fix_test.go
+++ b/internal/player/goyabu_blogger_fix_test.go
@@ -25,7 +25,7 @@
 //
 // Funções testadas:
 //   - parseBatchexecuteResponse (real — player/scraper.go, fix 2026-04-23)
-//   - parseBatchexecuteResponse_legacy (lógica anterior ao fix, inlinada aqui)
+//   - parseBatchexecuteResponseLegacy (lógica anterior ao fix, inlinada aqui)
 // ===========================================================================
 
 package player
@@ -52,12 +52,12 @@ const (
 )
 
 // ---------------------------------------------------------------------------
-// parseBatchexecuteResponse_legacy — lógica ANTERIOR ao fix de 2026-04-23
+// parseBatchexecuteResponseLegacy — lógica ANTERIOR ao fix de 2026-04-23
 //
 // Mantida aqui para demonstrar o bug: só verifica data[2] e não tem fallback
 // regex. Qualquer resposta com streams fora do índice 2 retorna erro.
 // ---------------------------------------------------------------------------
-func parseBatchexecuteResponse_legacy(body []byte) (string, error) {
+func parseBatchexecuteResponseLegacy(body []byte) (string, error) {
 	var videoURL string
 	for _, line := range strings.Split(string(body), "\n") {
 		if !strings.Contains(line, "wrb.fr") {
@@ -152,7 +152,7 @@ func TestParseBatchexecuteResponse_StreamsAtIndex2_FormatoClassico(t *testing.T)
 	body := buildBatchexecuteBody(2, []string{googleVideoURL720p, googleVideoURL360p})
 
 	// Parser antigo (pré-fix) funciona porque streams estão em data[2].
-	legacyURL, err := parseBatchexecuteResponse_legacy(body)
+	legacyURL, err := parseBatchexecuteResponseLegacy(body)
 	require.NoError(t, err, "lógica antiga deve funcionar com streams em data[2]")
 	assert.Equal(t, googleVideoURL720p, legacyURL)
 
@@ -175,7 +175,7 @@ func TestParseBatchexecuteResponse_Bug_StreamsEmIndex0(t *testing.T) {
 	body := buildBatchexecuteBody(0, []string{googleVideoURL720p})
 
 	// BUG simulado: parser antigo (pré 2026-04-23) falha com streams em data[0].
-	_, err := parseBatchexecuteResponse_legacy(body)
+	_, err := parseBatchexecuteResponseLegacy(body)
 	assert.Error(t, err, "BUG 2026-04-23: parser antigo NÃO encontra streams em data[0]")
 
 	// SOLUÇÃO: parser corrigido encontra streams em qualquer índice.
@@ -192,7 +192,7 @@ func TestParseBatchexecuteResponse_Bug_StreamsEmIndex1(t *testing.T) {
 	body := buildBatchexecuteBody(1, []string{googleVideoURL360p})
 
 	// BUG simulado: parser antigo falha (data tem 2 elementos, len(data) < 3).
-	_, err := parseBatchexecuteResponse_legacy(body)
+	_, err := parseBatchexecuteResponseLegacy(body)
 	assert.Error(t, err, "BUG 2026-04-23: parser antigo falha quando len(data) < 3")
 
 	// SOLUÇÃO: parser corrigido encontra streams em data[1].
@@ -208,7 +208,7 @@ func TestParseBatchexecuteResponse_Bug_DataComUmElemento(t *testing.T) {
 
 	body := buildBatchexecuteBody(0, []string{googleVideoURL360p})
 
-	_, err := parseBatchexecuteResponse_legacy(body)
+	_, err := parseBatchexecuteResponseLegacy(body)
 	assert.Error(t, err, "BUG 2026-04-23: len(data)==1 < 3, parser antigo descarta")
 
 	url, err := parseBatchexecuteResponse(body)
@@ -257,7 +257,7 @@ func TestParseBatchexecuteResponse_FallbackRegex(t *testing.T) {
 		`debug: ` + googleVideoURL720p + ` extra`)
 
 	// Parser antigo (sem fallback regex) falha.
-	_, err := parseBatchexecuteResponse_legacy(body)
+	_, err := parseBatchexecuteResponseLegacy(body)
 	assert.Error(t, err, "parser antigo não tem fallback regex")
 
 	// Parser corrigido encontra via regex.

--- a/internal/player/goyabu_blogger_fix_test.go
+++ b/internal/player/goyabu_blogger_fix_test.go
@@ -1,0 +1,365 @@
+// ===========================================================================
+// goyabu_blogger_fix_test.go — Regressão para o bug Goyabu/Blogger batchexecute
+//
+// Problema detectado: 2026-04-23
+//   Diiver reportou via Discord que episódios do Goyabu (fonte PT-BR) não
+//   reproduziam. O log de debug mostrava o erro
+//   "no video URL found in batchexecute response" em todas as 3 tentativas
+//   do extrator de URL do Blogger.
+//
+// Causa raiz (player/scraper.go — antes do fix de 2026-04-23):
+//   O parser do batchexecute assumia que o array de streams estava fixo no
+//   índice data[2] do payload inner JSON. Quando o Google alterou o índice
+//   (ou retornou data com menos de 3 elementos), o código executava `continue`
+//   silenciosamente sem extrair nenhuma URL. Não havia fallback de regex.
+//
+//   Trecho bugado (removido em 2026-04-23):
+//     if len(data) < 3 { continue }        // falha se data tiver 0–2 elementos
+//     streams, ok := data[2].([]any)       // índice hardcoded — quebra com mudança do Google
+//
+// Correção aplicada: 2026-04-23
+//   1. O parser itera todos os índices de data[], identificando streams como
+//      o primeiro elemento que seja um array de arrays.
+//   2. Fallback regex extrai URLs *.googlevideo.com diretamente do corpo bruto
+//      caso o parsing estruturado não produza resultado.
+//
+// Funções testadas:
+//   - parseBatchexecuteResponse (real — player/scraper.go, fix 2026-04-23)
+//   - parseBatchexecuteResponse_legacy (lógica anterior ao fix, inlinada aqui)
+// ===========================================================================
+
+package player
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// Constantes de URL usadas nos fixtures de teste
+// ---------------------------------------------------------------------------
+
+const (
+	googleVideoURL720p = "https://rr3---sn-q4f7l.googlevideo.com/videoplayback?expire=9999999999&itag=22&mime=video%2Fmp4&source=blogger"
+	googleVideoURL360p = "https://rr3---sn-q4f7l.googlevideo.com/videoplayback?expire=9999999999&itag=18&mime=video%2Fmp4&source=blogger"
+	googleVideoNoMIME  = "https://rr3---sn-q4f7l.googlevideo.com/videoplayback?expire=9999999999&itag=22&source=blogger"
+)
+
+// ---------------------------------------------------------------------------
+// parseBatchexecuteResponse_legacy — lógica ANTERIOR ao fix de 2026-04-23
+//
+// Mantida aqui para demonstrar o bug: só verifica data[2] e não tem fallback
+// regex. Qualquer resposta com streams fora do índice 2 retorna erro.
+// ---------------------------------------------------------------------------
+func parseBatchexecuteResponse_legacy(body []byte) (string, error) {
+	var videoURL string
+	for _, line := range strings.Split(string(body), "\n") {
+		if !strings.Contains(line, "wrb.fr") {
+			continue
+		}
+		var outer []any
+		if err := json.Unmarshal([]byte(line), &outer); err != nil {
+			continue
+		}
+		for _, entry := range outer {
+			arr, ok := entry.([]any)
+			if !ok || len(arr) < 3 {
+				continue
+			}
+			if fmt.Sprint(arr[0]) != "wrb.fr" || fmt.Sprint(arr[1]) != "WcwnYd" {
+				continue
+			}
+			var data []any
+			if err := json.Unmarshal(fmt.Append(nil, arr[2]), &data); err != nil {
+				continue
+			}
+			// BUG (antes de 2026-04-23): índice hardcoded; falha se data tiver
+			// menos de 3 elementos ou se o Google mover streams para outro índice.
+			if len(data) < 3 {
+				continue
+			}
+			streams, ok := data[2].([]any)
+			if !ok {
+				continue
+			}
+			for _, s := range streams {
+				stream, ok := s.([]any)
+				if !ok || len(stream) < 1 {
+					continue
+				}
+				u, ok := stream[0].(string)
+				if !ok {
+					continue
+				}
+				if strings.Contains(u, "mime=video%2Fmp4") || strings.Contains(u, "mime=video/mp4") {
+					videoURL = u
+					break
+				}
+			}
+			break
+		}
+		if videoURL != "" {
+			break
+		}
+	}
+	if videoURL == "" {
+		return "", errors.New("no video URL found in batchexecute response")
+	}
+	return videoURL, nil
+}
+
+// ---------------------------------------------------------------------------
+// buildBatchexecuteBody constrói um corpo de resposta batchexecute realista.
+//
+// O formato real do Google é:
+//   )]}'\n
+//   [["wrb.fr","WcwnYd","<inner_json_string>",null,...,"generic"]]\n
+//
+// onde <inner_json_string> é o payload inner JSON serializado como string.
+// streams é posicionado em data[dataIdx] do inner payload.
+// ---------------------------------------------------------------------------
+func buildBatchexecuteBody(dataIdx int, streamURLs []string) []byte {
+	streams := make([]any, len(streamURLs))
+	for i, u := range streamURLs {
+		streams[i] = []any{u, float64(360)}
+	}
+
+	data := make([]any, dataIdx+1)
+	data[dataIdx] = streams
+
+	innerJSON, _ := json.Marshal(data)
+
+	outerLine, _ := json.Marshal([][]any{
+		{"wrb.fr", "WcwnYd", string(innerJSON), nil, nil, nil, "generic"},
+	})
+
+	return []byte(")]}'\n" + string(outerLine) + "\n")
+}
+
+// ---------------------------------------------------------------------------
+// Testes: formato clássico (streams em data[2]) — ambos os parsers funcionam
+// ---------------------------------------------------------------------------
+
+func TestParseBatchexecuteResponse_StreamsAtIndex2_FormatoClassico(t *testing.T) {
+	t.Parallel()
+
+	body := buildBatchexecuteBody(2, []string{googleVideoURL720p, googleVideoURL360p})
+
+	// Parser antigo (pré-fix) funciona porque streams estão em data[2].
+	legacyURL, err := parseBatchexecuteResponse_legacy(body)
+	require.NoError(t, err, "lógica antiga deve funcionar com streams em data[2]")
+	assert.Equal(t, googleVideoURL720p, legacyURL)
+
+	// Parser corrigido também funciona.
+	fixedURL, err := parseBatchexecuteResponse(body)
+	require.NoError(t, err)
+	assert.Equal(t, googleVideoURL720p, fixedURL)
+}
+
+// ---------------------------------------------------------------------------
+// Testes: simulação do bug 2026-04-23 — streams em índice != 2
+// ---------------------------------------------------------------------------
+
+// TestParseBatchexecuteResponse_Bug_StreamsEmIndex0 demonstra o bug:
+// quando o Google retorna streams em data[0], o parser antigo falha enquanto
+// o parser corrigido (fix 2026-04-23) encontra a URL.
+func TestParseBatchexecuteResponse_Bug_StreamsEmIndex0(t *testing.T) {
+	t.Parallel()
+
+	body := buildBatchexecuteBody(0, []string{googleVideoURL720p})
+
+	// BUG simulado: parser antigo (pré 2026-04-23) falha com streams em data[0].
+	_, err := parseBatchexecuteResponse_legacy(body)
+	assert.Error(t, err, "BUG 2026-04-23: parser antigo NÃO encontra streams em data[0]")
+
+	// SOLUÇÃO: parser corrigido encontra streams em qualquer índice.
+	url, err := parseBatchexecuteResponse(body)
+	require.NoError(t, err, "fix 2026-04-23: parser deve encontrar streams em data[0]")
+	assert.Equal(t, googleVideoURL720p, url)
+}
+
+// TestParseBatchexecuteResponse_Bug_StreamsEmIndex1 cobre o caso em que o
+// Google retorna apenas dois elementos em data (índice 0 e 1).
+func TestParseBatchexecuteResponse_Bug_StreamsEmIndex1(t *testing.T) {
+	t.Parallel()
+
+	body := buildBatchexecuteBody(1, []string{googleVideoURL360p})
+
+	// BUG simulado: parser antigo falha (data tem 2 elementos, len(data) < 3).
+	_, err := parseBatchexecuteResponse_legacy(body)
+	assert.Error(t, err, "BUG 2026-04-23: parser antigo falha quando len(data) < 3")
+
+	// SOLUÇÃO: parser corrigido encontra streams em data[1].
+	url, err := parseBatchexecuteResponse(body)
+	require.NoError(t, err, "fix 2026-04-23: deve encontrar streams em data[1]")
+	assert.Equal(t, googleVideoURL360p, url)
+}
+
+// TestParseBatchexecuteResponse_Bug_DataComUmElemento cobre o caso extremo
+// onde data possui apenas um elemento (data[0] = streams).
+func TestParseBatchexecuteResponse_Bug_DataComUmElemento(t *testing.T) {
+	t.Parallel()
+
+	body := buildBatchexecuteBody(0, []string{googleVideoURL360p})
+
+	_, err := parseBatchexecuteResponse_legacy(body)
+	assert.Error(t, err, "BUG 2026-04-23: len(data)==1 < 3, parser antigo descarta")
+
+	url, err := parseBatchexecuteResponse(body)
+	require.NoError(t, err)
+	assert.Equal(t, googleVideoURL360p, url)
+}
+
+// ---------------------------------------------------------------------------
+// Testes: seleção de qualidade
+// ---------------------------------------------------------------------------
+
+func TestParseBatchexecuteResponse_Prefere720p(t *testing.T) {
+	t.Parallel()
+
+	// Resposta com 360p listado antes do 720p.
+	body := buildBatchexecuteBody(2, []string{googleVideoURL360p, googleVideoURL720p})
+
+	url, err := parseBatchexecuteResponse(body)
+	require.NoError(t, err)
+	assert.Equal(t, googleVideoURL720p, url, "deve preferir 720p (itag=22) sobre 360p (itag=18)")
+}
+
+func TestParseBatchexecuteResponse_Apenas360p(t *testing.T) {
+	t.Parallel()
+
+	body := buildBatchexecuteBody(2, []string{googleVideoURL360p})
+
+	url, err := parseBatchexecuteResponse(body)
+	require.NoError(t, err)
+	assert.Equal(t, googleVideoURL360p, url)
+}
+
+// ---------------------------------------------------------------------------
+// Testes: fallback regex (fix 2026-04-23)
+// ---------------------------------------------------------------------------
+
+// TestParseBatchexecuteResponse_FallbackRegex verifica que, quando o parsing
+// estruturado não encontra streams, o regex ainda captura URLs googlevideo.com
+// presentes no corpo bruto da resposta.
+func TestParseBatchexecuteResponse_FallbackRegex(t *testing.T) {
+	t.Parallel()
+
+	// Corpo com URL googlevideo.com mas sem estrutura wrb.fr/WcwnYd válida.
+	body := []byte(`)]}'\n` +
+		`[["wrb.fr","WcwnYd","{}",null,null,null,"generic"]]` + "\n" +
+		`debug: ` + googleVideoURL720p + ` extra`)
+
+	// Parser antigo (sem fallback regex) falha.
+	_, err := parseBatchexecuteResponse_legacy(body)
+	assert.Error(t, err, "parser antigo não tem fallback regex")
+
+	// Parser corrigido encontra via regex.
+	url, err := parseBatchexecuteResponse(body)
+	require.NoError(t, err, "fix 2026-04-23: fallback regex deve encontrar URL googlevideo.com")
+	assert.Contains(t, url, ".googlevideo.com")
+}
+
+// TestParseBatchexecuteResponse_FallbackRegex_StreamsSemMIME cobre streams
+// que existem na estrutura mas não têm mime=video%2Fmp4, enquanto o corpo
+// bruto contém uma URL googlevideo.com válida.
+func TestParseBatchexecuteResponse_FallbackRegex_StreamsSemMIME(t *testing.T) {
+	t.Parallel()
+
+	body := buildBatchexecuteBody(2, []string{googleVideoNoMIME})
+	// Adiciona URL válida em texto livre no final do corpo.
+	body = append(body, []byte("\ninfo: "+googleVideoURL360p)...)
+
+	url, err := parseBatchexecuteResponse(body)
+	require.NoError(t, err)
+	assert.Contains(t, url, ".googlevideo.com")
+}
+
+// ---------------------------------------------------------------------------
+// Testes: casos de erro / resposta inválida
+// ---------------------------------------------------------------------------
+
+func TestParseBatchexecuteResponse_CorpoVazio(t *testing.T) {
+	t.Parallel()
+
+	_, err := parseBatchexecuteResponse([]byte{})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no video URL found")
+}
+
+func TestParseBatchexecuteResponse_JSONInvalido(t *testing.T) {
+	t.Parallel()
+
+	body := []byte(")]}'\n[this is not valid json]\n")
+
+	_, err := parseBatchexecuteResponse(body)
+	assert.Error(t, err)
+}
+
+func TestParseBatchexecuteResponse_SemLinhaWrbFr(t *testing.T) {
+	t.Parallel()
+
+	body := []byte(")]}'\n[[\"other.method\",\"SomeRPC\",\"[]\",null]]\n")
+
+	_, err := parseBatchexecuteResponse(body)
+	assert.Error(t, err)
+}
+
+func TestParseBatchexecuteResponse_DataSemArrayDeArrays(t *testing.T) {
+	t.Parallel()
+
+	// data contém apenas strings e números, nenhum array de arrays.
+	innerJSON := `["string_value", 42, null]`
+	outerLine, _ := json.Marshal([][]any{
+		{"wrb.fr", "WcwnYd", innerJSON, nil, nil, nil, "generic"},
+	})
+	body := []byte(")]}'\n" + string(outerLine) + "\n")
+
+	_, err := parseBatchexecuteResponse(body)
+	assert.Error(t, err)
+}
+
+func TestParseBatchexecuteResponse_StreamsVazios(t *testing.T) {
+	t.Parallel()
+
+	// data[2] é um array vazio — não atende à condição len(s) > 0.
+	innerJSON := `[null, null, []]`
+	outerLine, _ := json.Marshal([][]any{
+		{"wrb.fr", "WcwnYd", innerJSON, nil, nil, nil, "generic"},
+	})
+	body := []byte(")]}'\n" + string(outerLine) + "\n")
+
+	_, err := parseBatchexecuteResponse(body)
+	assert.Error(t, err)
+}
+
+// ---------------------------------------------------------------------------
+// Testes: múltiplos índices — parser deve usar o primeiro válido encontrado
+// ---------------------------------------------------------------------------
+
+func TestParseBatchexecuteResponse_UsaPrimeiroIndiceValido(t *testing.T) {
+	t.Parallel()
+
+	// data[1] = streams com 360p; data[3] = streams com 720p.
+	// Parser deve retornar o primeiro válido encontrado (data[1], 360p).
+	streams360 := []any{[]any{googleVideoURL360p, float64(360)}}
+	streams720 := []any{[]any{googleVideoURL720p, float64(720)}}
+
+	data := []any{nil, streams360, nil, streams720}
+	innerJSON, _ := json.Marshal(data)
+	outerLine, _ := json.Marshal([][]any{
+		{"wrb.fr", "WcwnYd", string(innerJSON), nil, nil, nil, "generic"},
+	})
+	body := []byte(")]}'\n" + string(outerLine) + "\n")
+
+	url, err := parseBatchexecuteResponse(body)
+	require.NoError(t, err)
+	// Streams em data[1] (360p) devem ser encontrados primeiro.
+	assert.Equal(t, googleVideoURL360p, url)
+}

--- a/internal/player/scraper.go
+++ b/internal/player/scraper.go
@@ -768,8 +768,30 @@ func extractBloggerGoogleVideoURL(bloggerURL string) (string, error) {
 	}
 
 	// Step 3: Parse the batchexecute response to find the googlevideo URL
+	videoURL, err := parseBatchexecuteResponse(batchBody)
+	if err != nil {
+		return "", err
+	}
+
+	util.Debugf("Blogger extract: video URL obtained (%d chars)", len(videoURL))
+	return videoURL, nil
+}
+
+// parseBatchexecuteResponse extracts the best MP4 video URL from a Google
+// batchexecute API response body (WcwnYd RPC).
+//
+// Fix 2026-04-23: the previous implementation assumed streams were always at
+// data[2] inside the inner JSON payload. When Google changed the response
+// structure (or returned fewer top-level elements), the hardcoded index caused
+// a silent `continue`, and all three retry attempts produced
+// "no video URL found in batchexecute response".
+//
+// The fix iterates every index of data[] looking for the first element that is
+// itself an array of arrays (the streams list). A regex fallback is also
+// applied over the raw body in case structured parsing fails entirely.
+func parseBatchexecuteResponse(body []byte) (string, error) {
 	var videoURL string
-	for line := range strings.SplitSeq(string(batchBody), "\n") {
+	for line := range strings.SplitSeq(string(body), "\n") {
 		if !strings.Contains(line, "wrb.fr") {
 			continue
 		}
@@ -789,14 +811,22 @@ func extractBloggerGoogleVideoURL(bloggerURL string) (string, error) {
 			if err := json.Unmarshal(fmt.Append(nil, arr[2]), &data); err != nil {
 				continue
 			}
-			if len(data) < 3 {
+			// Search all indices for a streams array (resilient to Google index changes).
+			var streams []any
+			for i, elem := range data {
+				if s, ok := elem.([]any); ok && len(s) > 0 {
+					if _, isSlice := s[0].([]any); isSlice {
+						streams = s
+						util.Debugf("Blogger batchexecute: found streams at data[%d]", i)
+						break
+					}
+				}
+			}
+			if streams == nil {
+				util.Debugf("Blogger batchexecute: no streams array found in data (len=%d)", len(data))
 				continue
 			}
-			streams, ok := data[2].([]any)
-			if !ok {
-				continue
-			}
-			// Collect all MP4 stream URLs and prefer higher quality (itag=22 is 720p, itag=18 is 360p)
+			// Collect MP4 URLs; prefer 720p (itag=22) over 360p (itag=18).
 			var mp4URLs []string
 			for _, s := range streams {
 				stream, ok := s.([]any)
@@ -811,7 +841,6 @@ func extractBloggerGoogleVideoURL(bloggerURL string) (string, error) {
 					mp4URLs = append(mp4URLs, u)
 				}
 			}
-			// Prefer 720p (itag=22) over 360p (itag=18)
 			for _, u := range mp4URLs {
 				if strings.Contains(u, "itag=22") {
 					videoURL = u
@@ -835,11 +864,19 @@ func extractBloggerGoogleVideoURL(bloggerURL string) (string, error) {
 		}
 	}
 
+	// Regex fallback: scan the raw body for any *.googlevideo.com URL.
 	if videoURL == "" {
-		return "", errors.New("no video URL found in batchexecute response")
+		googleVideoRe := regexp.MustCompile(`https://[^"\\]+\.googlevideo\.com/[^"\\]+`)
+		if match := googleVideoRe.FindString(string(body)); match != "" {
+			util.Debugf("Blogger batchexecute: found googlevideo URL via regex fallback")
+			videoURL = match
+		}
 	}
 
-	util.Debugf("Blogger extract: video URL obtained (%d chars)", len(videoURL))
+	if videoURL == "" {
+		util.Debugf("Blogger batchexecute response body (first 500 bytes): %s", string(body[:min(500, len(body))]))
+		return "", errors.New("no video URL found in batchexecute response")
+	}
 	return videoURL, nil
 }
 

--- a/internal/scraper/allanime.go
+++ b/internal/scraper/allanime.go
@@ -7,7 +7,6 @@ import (
 	"crypto/cipher"
 	"crypto/sha256"
 	"encoding/base64"
-	"encoding/binary"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -29,8 +28,9 @@ const (
 	AllAnimeAPI     = "https://api.allanime.day/api"
 	UserAgent       = "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:109.0) Gecko/20100101 Firefox/121.0"
 	// allAnimeKeyPhrase is the passphrase used to derive the AES-256 key via SHA-256.
-	// Matches: printf '%s' 'SimtVuagFbGR2K7P' | openssl dgst -sha256 -binary
-	allAnimeKeyPhrase = "SimtVuagFbGR2K7P"
+	// Updated 2026-04-24: AllAnime rotated the key to "Xot36i3lK3:v1".
+	// Matches: printf '%s' 'Xot36i3lK3:v1' | openssl dgst -sha256 -binary
+	allAnimeKeyPhrase = "Xot36i3lK3:v1"
 )
 
 // Pre-compiled regexes for AllAnime scraper (avoid per-call compilation)
@@ -69,39 +69,52 @@ type sourceInfo struct {
 
 // decodeToBeParsed decrypts the "tobeparsed" blob from the AllAnime API.
 //
-// The blob is base64-encoded. The first 12 bytes are the AES-CTR nonce/IV.
-// The remaining bytes are the ciphertext encrypted with AES-256-CTR.
-// The counter starts at nonce || 0x00000002 (matching OpenSSL conventions).
+// Blob format (updated 2026-04-24): [1-byte version 0x01][12-byte nonce][ciphertext][16-byte GCM tag]
+// The cipher is AES-256-GCM; the key is SHA-256("Xot36i3lK3:v1").
+// Minimum valid size: 1 + 12 + 0 + 16 = 29 bytes (empty plaintext), so we require ≥ 30.
 //
-// After decryption, the plaintext is JSON containing sourceUrl/sourceName pairs.
+// ani-cli reference: https://github.com/pystardust/ani-cli/commit/e5523a9b480f67ee878a0cc075043313cc58e07d
 func decodeToBeParsed(blob string) ([]sourceInfo, error) {
+	util.Debugf("AllAnime tobeparsed raw blob (first 60 chars): %q", blob[:min(60, len(blob))])
+
+	// Try standard base64 first, then URL-safe (AllAnime may use either)
 	data, err := base64.StdEncoding.DecodeString(blob)
 	if err != nil {
-		return nil, fmt.Errorf("base64 decode failed: %w", err)
+		data, err = base64.URLEncoding.DecodeString(blob)
+		if err != nil {
+			data, err = base64.RawURLEncoding.DecodeString(blob)
+			if err != nil {
+				return nil, fmt.Errorf("base64 decode failed: %w", err)
+			}
+		}
 	}
 
-	if len(data) < 13 { // 12-byte nonce + at least 1 byte of ciphertext
+	util.Debugf("AllAnime tobeparsed decoded length: %d bytes, first 16 bytes: %x", len(data), data[:min(16, len(data))])
+
+	// 1 (version) + 12 (nonce) + 16 (GCM tag) + at least 1 byte plaintext = 30
+	if len(data) < 30 {
 		return nil, fmt.Errorf("tobeparsed blob too short (%d bytes)", len(data))
 	}
 
-	nonce := data[:12]
-	ciphertext := data[12:]
+	// Blob format: [0x01 version byte][12-byte nonce][ciphertext + 16-byte GCM tag]
+	nonce := data[1:13]
+	ciphertextWithTag := data[13:]
+	util.Debugf("AllAnime tobeparsed nonce: %x", nonce)
 
 	block, err := aes.NewCipher(allAnimeKey)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create AES cipher: %w", err)
 	}
 
-	// Build the 16-byte IV for AES-256-CTR: nonce (12 bytes) + counter starting at 2.
-	// This matches the bash script: ctr="${iv}00000002"
-	iv := make([]byte, aes.BlockSize)
-	copy(iv[:12], nonce)
-	binary.BigEndian.PutUint32(iv[12:], 2)
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create GCM: %w", err)
+	}
 
-	stream := cipher.NewCTR(block, iv) // #nosec G407 -- IV is derived from the nonce in the encrypted blob, not hardcoded
-
-	plaintext := make([]byte, len(ciphertext))
-	stream.XORKeyStream(plaintext, ciphertext)
+	plaintext, err := gcm.Open(nil, nonce, ciphertextWithTag, nil)
+	if err != nil {
+		return nil, fmt.Errorf("AES-GCM decryption failed: %w", err)
+	}
 
 	// Parse the decrypted JSON to extract sourceUrl/sourceName pairs.
 	// The bash script does:
@@ -117,6 +130,8 @@ func decodeToBeParsed(blob string) ([]sourceInfo, error) {
 			} `json:"episode"`
 		} `json:"data"`
 	}
+
+	util.Debugf("AllAnime tobeparsed decrypted (first 200 bytes): %q", string(plaintext[:min(200, len(plaintext))]))
 
 	// The plaintext may contain the full GraphQL response or just the sourceUrls array.
 	// Try parsing as the full response first.

--- a/internal/scraper/allanime_test.go
+++ b/internal/scraper/allanime_test.go
@@ -6,7 +6,6 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/base64"
-	"encoding/binary"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -40,8 +39,9 @@ func newTestClient(serverURL string) *AllAnimeClient {
 	}
 }
 
-// encryptToBeParsed encrypts plaintext JSON the same way the AllAnime API would:
-// base64( nonce(12) || AES-256-CTR(plaintext) ) with counter starting at 2.
+// encryptToBeParsed encrypts plaintext JSON the same way the AllAnime API does:
+// base64( 0x01 || nonce(12) || AES-256-GCM(plaintext) )
+// Updated 2026-04-24: cipher changed from CTR to GCM; key rotated to "Xot36i3lK3:v1".
 func encryptToBeParsed(t *testing.T, plaintext string) string {
 	t.Helper()
 	nonce := make([]byte, 12)
@@ -56,14 +56,13 @@ func encryptToBeParsedWithNonce(t *testing.T, plaintext string, nonce []byte) st
 	key := sha256.Sum256([]byte(allAnimeKeyPhrase))
 	block, err := aes.NewCipher(key[:])
 	require.NoError(t, err)
+	gcm, err := cipher.NewGCM(block)
+	require.NoError(t, err)
 
-	iv := make([]byte, aes.BlockSize)
-	copy(iv[:12], nonce)
-	binary.BigEndian.PutUint32(iv[12:], 2)
-
-	ct := make([]byte, len(plaintext))
-	cipher.NewCTR(block, iv).XORKeyStream(ct, []byte(plaintext))
-	return base64.StdEncoding.EncodeToString(append(nonce, ct...))
+	sealed := gcm.Seal(nil, nonce, []byte(plaintext), nil)
+	payload := append([]byte{0x01}, nonce...)
+	payload = append(payload, sealed...)
+	return base64.StdEncoding.EncodeToString(payload)
 }
 
 // buildSourceURLsJSON builds a valid AllAnime sourceUrls JSON response.
@@ -264,7 +263,9 @@ func TestAllAnimeGetLinksClassifiesHTMLBodyAsSourceUnavailable(t *testing.T) {
 
 func TestAllAnimeKeyMatchesOpenSSL(t *testing.T) {
 	t.Parallel()
-	expected := "cb156d973b237c31a2aa2dbac52dc963da6a2e571968bb69df00242f80c46348"
+	// sha256("Xot36i3lK3:v1") — updated 2026-04-24 when AllAnime rotated the key.
+	// Verify: printf '%s' 'Xot36i3lK3:v1' | openssl dgst -sha256
+	expected := "a254aa27c410f297bd04ba33a0c0df7ff4e706bf3ae27271c6703f84e750f552"
 	assert.Equal(t, expected, hex.EncodeToString(allAnimeKey))
 }
 
@@ -386,7 +387,7 @@ func TestDecodeSourceURLTableCoversAllExpectedChars(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// 4. AES-256-CTR — decodeToBeParsed
+// 4. AES-256-GCM — decodeToBeParsed (updated 2026-04-24: CTR → GCM, new key)
 // ---------------------------------------------------------------------------
 
 func TestDecodeToBeParsedRoundTrip(t *testing.T) {
@@ -436,7 +437,7 @@ func TestDecodeToBeParsedBadBase64(t *testing.T) {
 
 func TestDecodeToBeParsedExactly12BytesNoCiphertext(t *testing.T) {
 	t.Parallel()
-	// 12 bytes of nonce, 0 bytes of ciphertext -> too short (need >= 13)
+	// 12 bytes < 30 (minimum for GCM: 1+12+16+1) → too short
 	blob := base64.StdEncoding.EncodeToString(make([]byte, 12))
 	_, err := decodeToBeParsed(blob)
 	require.Error(t, err)
@@ -445,12 +446,21 @@ func TestDecodeToBeParsedExactly12BytesNoCiphertext(t *testing.T) {
 
 func TestDecodeToBeParsedExactly13BytesMinimal(t *testing.T) {
 	t.Parallel()
-	// 13 bytes = 12 nonce + 1 ciphertext — should not panic
+	// 13 bytes < 30 → too short
 	blob := base64.StdEncoding.EncodeToString(make([]byte, 13))
 	_, err := decodeToBeParsed(blob)
-	// Decryption succeeds but parsing the garbled byte as JSON fails
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "no source URLs found")
+	assert.Contains(t, err.Error(), "too short")
+}
+
+func TestDecodeToBeParsedExactly29BytesStillTooShort(t *testing.T) {
+	t.Parallel()
+	// Updated 2026-04-24: GCM requires ≥ 30 bytes (1 version + 12 nonce + 16 tag + 1 plaintext).
+	// 29 bytes is still too short.
+	blob := base64.StdEncoding.EncodeToString(make([]byte, 29))
+	_, err := decodeToBeParsed(blob)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "too short")
 }
 
 func TestDecodeToBeParsedCorruptedCiphertext(t *testing.T) {
@@ -458,16 +468,18 @@ func TestDecodeToBeParsedCorruptedCiphertext(t *testing.T) {
 	plaintext := `{"data":{"episode":{"sourceUrls":[{"sourceUrl":"--0809","sourceName":"P1"}]}}}`
 	blob := encryptToBeParsed(t, plaintext)
 
-	// Decode, flip bits in ciphertext, re-encode
+	// Decode, flip bits in the ciphertext+tag region (bytes 13+), re-encode.
+	// AES-GCM authentication will reject the tampered payload.
 	raw, err := base64.StdEncoding.DecodeString(blob)
 	require.NoError(t, err)
-	for i := 12; i < len(raw); i++ {
-		raw[i] ^= 0xFF // flip every bit
+	for i := 13; i < len(raw); i++ {
+		raw[i] ^= 0xFF
 	}
 	corruptBlob := base64.StdEncoding.EncodeToString(raw)
 
 	_, err = decodeToBeParsed(corruptBlob)
-	assert.Error(t, err, "corrupted ciphertext should fail to parse")
+	assert.Error(t, err, "GCM authentication must reject tampered ciphertext")
+	assert.Contains(t, err.Error(), "AES-GCM decryption failed")
 }
 
 func TestDecodeToBeParsedTruncatedCiphertext(t *testing.T) {
@@ -477,11 +489,11 @@ func TestDecodeToBeParsedTruncatedCiphertext(t *testing.T) {
 
 	raw, err := base64.StdEncoding.DecodeString(blob)
 	require.NoError(t, err)
-	// Keep nonce + first few bytes of ciphertext (truncate the rest)
+	// 16 bytes < 30 minimum → "too short" before GCM is even attempted
 	truncated := base64.StdEncoding.EncodeToString(raw[:16])
 
 	_, err = decodeToBeParsed(truncated)
-	assert.Error(t, err, "truncated ciphertext should fail to parse")
+	assert.Error(t, err, "truncated blob should fail")
 }
 
 func TestDecodeToBeParsedRegexFallbackSourceUrlBeforeSourceName(t *testing.T) {
@@ -1804,33 +1816,29 @@ func TestGetEpisodeURLConcurrentCalls(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestDecodeToBeParsedCrossValidateWithOpenSSL(t *testing.T) {
-	// Deterministic test: verify our Go encryption matches what OpenSSL would produce,
-	// and that decryption correctly reverses it.
+	// Deterministic test: verify our Go GCM encryption/decryption round-trips correctly.
+	// Updated 2026-04-24: CTR → GCM, key rotated to "Xot36i3lK3:v1".
+	// ani-cli reference: https://github.com/pystardust/ani-cli/commit/e5523a9b480f67ee878a0cc075043313cc58e07d
 	t.Parallel()
 
 	nonce, _ := hex.DecodeString("aabbccddeeff00112233aabb")
 	plaintext := `{"data":{"episode":{"sourceUrls":[{"sourceUrl":"--504c4c484b021717","sourceName":"TestProvider"}]}}}`
 
-	// Encrypt manually matching the exact bash script algorithm
-	key := sha256.Sum256([]byte("SimtVuagFbGR2K7P"))
+	// Encrypt using new key + GCM
+	key := sha256.Sum256([]byte("Xot36i3lK3:v1"))
 	assert.Equal(t, allAnimeKey, key[:], "key derivation must be consistent")
 
 	block, err := aes.NewCipher(key[:])
 	require.NoError(t, err)
+	gcm, err := cipher.NewGCM(block)
+	require.NoError(t, err)
 
-	iv := make([]byte, 16)
-	copy(iv[:12], nonce)
-	iv[12] = 0x00
-	iv[13] = 0x00
-	iv[14] = 0x00
-	iv[15] = 0x02
+	sealed := gcm.Seal(nil, nonce, []byte(plaintext), nil)
+	payload := append([]byte{0x01}, nonce...)
+	payload = append(payload, sealed...)
+	blob := base64.StdEncoding.EncodeToString(payload)
 
-	ct := make([]byte, len(plaintext))
-	cipher.NewCTR(block, iv).XORKeyStream(ct, []byte(plaintext))
-
-	blob := base64.StdEncoding.EncodeToString(append(nonce, ct...))
-
-	// Now decrypt using our production code
+	// Decrypt using production code
 	sources, err := decodeToBeParsed(blob)
 	require.NoError(t, err)
 	require.Len(t, sources, 1)

--- a/internal/scraper/flixhq_quality_test.go
+++ b/internal/scraper/flixhq_quality_test.go
@@ -2,10 +2,46 @@ package scraper
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 	"time"
 )
+
+func isFlixHQUnavailable(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, ErrSourceUnavailable) {
+		return true
+	}
+
+	msg := err.Error()
+	transient := []string{
+		"source unavailable",
+		"server returned: 521",
+		"status code 521",
+		"unexpected status code: 521",
+		"context deadline exceeded",
+		"context canceled",
+		"timeout",
+		"connection refused",
+		"no such host",
+		"i/o timeout",
+		"TLS handshake timeout",
+		"500", "502", "503", "521", "530", "405",
+		"Bad Gateway",
+		"Method Not Allowed",
+		"both APIs failed",
+		"no server found",
+	}
+	for _, s := range transient {
+		if strings.Contains(msg, s) {
+			return true
+		}
+	}
+	return false
+}
 
 func TestFlixHQClient_GetInfo(t *testing.T) {
 	client := NewFlixHQClient()
@@ -52,6 +88,9 @@ func TestFlixHQClient_GetServers(t *testing.T) {
 	// First, search for a movie to get a valid ID
 	results, err := client.SearchMediaWithContext(ctx, "inception")
 	if err != nil {
+		if isFlixHQUnavailable(err) {
+			t.Skipf("Skipping - external service unavailable: %v", err)
+		}
 		t.Fatalf("Search failed: %v", err)
 	}
 
@@ -71,6 +110,9 @@ func TestFlixHQClient_GetServers(t *testing.T) {
 
 	servers, err := client.GetServersWithContext(ctx, movie.ID, true)
 	if err != nil {
+		if isFlixHQUnavailable(err) {
+			t.Skipf("Skipping - external service unavailable: %v", err)
+		}
 		t.Fatalf("GetServers failed: %v", err)
 	}
 
@@ -92,6 +134,9 @@ func TestFlixHQClient_GetSources(t *testing.T) {
 	// Search for a movie
 	results, err := client.SearchMediaWithContext(ctx, "inception")
 	if err != nil {
+		if isFlixHQUnavailable(err) {
+			t.Skipf("Skipping - external service unavailable: %v", err)
+		}
 		t.Fatalf("Search failed: %v", err)
 	}
 
@@ -116,11 +161,12 @@ func TestFlixHQClient_GetSources(t *testing.T) {
 	sources, err := client.GetSourcesWithContext(ctx, movie.ID, true)
 	if err != nil {
 		errMsg := err.Error()
-		if strings.Contains(errMsg, "502") || strings.Contains(errMsg, "503") || strings.Contains(errMsg, "530") ||
-			strings.Contains(errMsg, "405") || strings.Contains(errMsg, "Bad Gateway") ||
-			strings.Contains(errMsg, "Method Not Allowed") || strings.Contains(errMsg, "both APIs failed") ||
-			strings.Contains(errMsg, "context deadline exceeded") || strings.Contains(errMsg, "context canceled") ||
-			strings.Contains(errMsg, "timeout") || strings.Contains(errMsg, "connection refused") {
+		if isFlixHQUnavailable(err) || strings.Contains(errMsg, "502") || strings.Contains(errMsg, "503") ||
+			strings.Contains(errMsg, "530") || strings.Contains(errMsg, "405") ||
+			strings.Contains(errMsg, "Bad Gateway") || strings.Contains(errMsg, "Method Not Allowed") ||
+			strings.Contains(errMsg, "both APIs failed") || strings.Contains(errMsg, "context deadline exceeded") ||
+			strings.Contains(errMsg, "context canceled") || strings.Contains(errMsg, "timeout") ||
+			strings.Contains(errMsg, "connection refused") {
 			t.Skipf("Skipping - external streaming service unavailable: %v", err)
 		}
 		t.Fatalf("GetSources failed: %v", err)
@@ -143,6 +189,9 @@ func TestFlixHQClient_GetAvailableQualities(t *testing.T) {
 	// Search for a movie
 	results, err := client.SearchMediaWithContext(ctx, "inception")
 	if err != nil {
+		if isFlixHQUnavailable(err) {
+			t.Skipf("Skipping - external service unavailable: %v", err)
+		}
 		t.Fatalf("Search failed: %v", err)
 	}
 
@@ -165,11 +214,12 @@ func TestFlixHQClient_GetAvailableQualities(t *testing.T) {
 	qualities, err := client.GetAvailableQualitiesWithContext(ctx, movie.ID, true)
 	if err != nil {
 		errMsg := err.Error()
-		if strings.Contains(errMsg, "502") || strings.Contains(errMsg, "503") || strings.Contains(errMsg, "530") ||
-			strings.Contains(errMsg, "405") || strings.Contains(errMsg, "Bad Gateway") ||
-			strings.Contains(errMsg, "Method Not Allowed") || strings.Contains(errMsg, "both APIs failed") ||
-			strings.Contains(errMsg, "context deadline exceeded") || strings.Contains(errMsg, "context canceled") ||
-			strings.Contains(errMsg, "timeout") || strings.Contains(errMsg, "connection refused") {
+		if isFlixHQUnavailable(err) || strings.Contains(errMsg, "502") || strings.Contains(errMsg, "503") ||
+			strings.Contains(errMsg, "530") || strings.Contains(errMsg, "405") ||
+			strings.Contains(errMsg, "Bad Gateway") || strings.Contains(errMsg, "Method Not Allowed") ||
+			strings.Contains(errMsg, "both APIs failed") || strings.Contains(errMsg, "context deadline exceeded") ||
+			strings.Contains(errMsg, "context canceled") || strings.Contains(errMsg, "timeout") ||
+			strings.Contains(errMsg, "connection refused") {
 			t.Skipf("Skipping - external streaming service unavailable: %v", err)
 		}
 		t.Fatalf("GetAvailableQualities failed: %v", err)
@@ -235,6 +285,9 @@ func TestFlixHQClient_Caching(t *testing.T) {
 	start := time.Now()
 	results1, err := client.SearchMediaWithContext(ctx, "dexter")
 	if err != nil {
+		if isFlixHQUnavailable(err) {
+			t.Skipf("Skipping - external service unavailable: %v", err)
+		}
 		t.Fatalf("First search failed: %v", err)
 	}
 	firstDuration := time.Since(start)
@@ -244,6 +297,9 @@ func TestFlixHQClient_Caching(t *testing.T) {
 	start = time.Now()
 	results2, err := client.SearchMediaWithContext(ctx, "dexter")
 	if err != nil {
+		if isFlixHQUnavailable(err) {
+			t.Skipf("Skipping - external service unavailable: %v", err)
+		}
 		t.Fatalf("Second search failed: %v", err)
 	}
 	secondDuration := time.Since(start)

--- a/internal/scraper/flixhq_test.go
+++ b/internal/scraper/flixhq_test.go
@@ -51,6 +51,9 @@ func TestFlixHQClient_SearchMedia(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			results, err := client.SearchMedia(tt.query)
+			if err != nil && isFlixHQUnavailable(err) {
+				t.Skipf("Skipping - external service unavailable: %v", err)
+			}
 			if (err != nil) != tt.wantErr {
 				t.Errorf("SearchMedia() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/internal/scraper/goyabu_test.go
+++ b/internal/scraper/goyabu_test.go
@@ -478,7 +478,7 @@ func TestGoyabuGetEpisodeStreamURL_AJAXPlayVazio_FallbackBloggerURL(t *testing.T
 	mux := http.NewServeMux()
 
 	// Página do episódio com playersData em linha única (regex do Goyabu usa .*? sem DOTALL).
-	mux.HandleFunc("/episodio/1", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/episodio/1", func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = fmt.Fprintf(w, `<html><head><script>var playersData = [{"name":"Blog","select":"blogger","url":"https://www.blogger.com/video.g?token=%s","blogger_token":"dGVzdA=="}];</script></head><body></body></html>`, bloggerToken)
 	})
 

--- a/internal/scraper/goyabu_test.go
+++ b/internal/scraper/goyabu_test.go
@@ -408,3 +408,155 @@ func TestGoyabuDecodeBloggerTokenClassifiesHTMLAsSourceUnavailable(t *testing.T)
 	require.Error(t, err)
 	assert.True(t, errors.Is(err, ErrSourceUnavailable), "expected ErrSourceUnavailable, got: %v", err)
 }
+
+// ===========================================================================
+// Testes de regressão — bug 2026-04-23 (Goyabu/Blogger AJAX)
+//
+// Problema detectado: 2026-04-23
+//   O endpoint AJAX do Goyabu (/wp-admin/admin-ajax.php?action=decode_blogger_video)
+//   retornou JSON sem URLs de vídeo utilizáveis, gerando o erro
+//   "no video URL found in AJAX response" antes do fallback para batchexecute.
+//
+// Esses testes cobrem os formatos de resposta que causam esse erro,
+// garantindo que o código trate cada caso corretamente e que o fallback
+// para a URL embed do Blogger seja acionado quando necessário.
+// ===========================================================================
+
+// TestGoyabuDecodeBloggerToken_PlayArrayVazio simula a resposta AJAX que
+// causou o bug de 2026-04-23: o servidor retorna JSON válido com "play":[]
+// (array vazio), produzindo "no video URL found in AJAX response".
+func TestGoyabuDecodeBloggerToken_PlayArrayVazio(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Formato real do Goyabu com play array vazio — causa exata do bug de 2026-04-23.
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"success":true,"data":{"play":[]}}`)
+	}))
+	defer server.Close()
+
+	client := NewGoyabuClient()
+	client.baseURL = server.URL
+	client.maxRetries = 0
+	client.retryDelay = 0
+
+	_, err := client.decodeBloggerToken("testtoken123")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no video URL found in AJAX response",
+		"play array vazio deve produzir 'no video URL found in AJAX response'")
+}
+
+// TestGoyabuDecodeBloggerToken_DataNulo verifica que data=null na resposta
+// AJAX também produz "no video URL found in AJAX response".
+func TestGoyabuDecodeBloggerToken_DataNulo(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"success":false,"data":null}`)
+	}))
+	defer server.Close()
+
+	client := NewGoyabuClient()
+	client.baseURL = server.URL
+	client.maxRetries = 0
+	client.retryDelay = 0
+
+	_, err := client.decodeBloggerToken("testtoken123")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no video URL found in AJAX response")
+}
+
+// TestGoyabuGetEpisodeStreamURL_AJAXPlayVazio_FallbackBloggerURL verifica que,
+// quando o endpoint AJAX retorna play array vazio (bug 2026-04-23), o sistema
+// faz fallback corretamente para a URL embed do Blogger presente na página.
+func TestGoyabuGetEpisodeStreamURL_AJAXPlayVazio_FallbackBloggerURL(t *testing.T) {
+	t.Parallel()
+
+	const bloggerToken = "AD6v5dwTestTokenParaBug20260423"
+
+	mux := http.NewServeMux()
+
+	// Página do episódio com playersData em linha única (regex do Goyabu usa .*? sem DOTALL).
+	mux.HandleFunc("/episodio/1", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = fmt.Fprintf(w, `<html><head><script>var playersData = [{"name":"Blog","select":"blogger","url":"https://www.blogger.com/video.g?token=%s","blogger_token":"dGVzdA=="}];</script></head><body></body></html>`, bloggerToken)
+	})
+
+	// AJAX retorna play array vazio — condição do bug de 2026-04-23.
+	mux.HandleFunc("/wp-admin/admin-ajax.php", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"success":true,"data":{"play":[]}}`)
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	client := NewGoyabuClient()
+	client.baseURL = server.URL
+	client.maxRetries = 0
+	client.retryDelay = 0
+
+	streamURL, err := client.GetEpisodeStreamURL(server.URL + "/episodio/1")
+	require.NoError(t, err)
+	// Fallback deve retornar a URL embed do Blogger da página, não o erro do AJAX.
+	assert.Contains(t, streamURL, "blogger.com/video.g?token="+bloggerToken,
+		"quando AJAX falha com play vazio, deve fazer fallback para URL embed do Blogger")
+}
+
+// TestGoyabuDecodeBloggerToken_VerificaParametrosAJAX garante que o cliente
+// envia os parâmetros corretos (action e token) para o endpoint AJAX.
+func TestGoyabuDecodeBloggerToken_VerificaParametrosAJAX(t *testing.T) {
+	t.Parallel()
+
+	var receivedAction, receivedToken string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, r.ParseForm())
+		receivedAction = r.FormValue("action")
+		receivedToken = r.FormValue("token")
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"success":true,"data":{"play":[
+			{"src":"https://cdn.example.com/video.mp4","size":720,"type":"video/mp4"}
+		]}}`)
+	}))
+	defer server.Close()
+
+	client := NewGoyabuClient()
+	client.baseURL = server.URL
+	client.maxRetries = 0
+	client.retryDelay = 0
+
+	url, err := client.decodeBloggerToken("meutoken123")
+	require.NoError(t, err)
+	assert.Equal(t, "decode_blogger_video", receivedAction)
+	assert.Equal(t, "meutoken123", receivedToken)
+	assert.Equal(t, "https://cdn.example.com/video.mp4", url)
+}
+
+// TestGoyabuDecodeBloggerToken_RespostaURLDireta verifica que uma resposta
+// AJAX que retorna URL direta (sem wrapper play[]) também é tratada.
+func TestGoyabuDecodeBloggerToken_RespostaURLDireta(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// Formato alternativo: URL no campo "url" do data.
+		resp := map[string]any{
+			"success": true,
+			"data":    map[string]any{"url": "https://cdn.example.com/direto.mp4"},
+		}
+		body, _ := json.Marshal(resp)
+		_, _ = w.Write(body)
+	}))
+	defer server.Close()
+
+	client := NewGoyabuClient()
+	client.baseURL = server.URL
+	client.maxRetries = 0
+	client.retryDelay = 0
+
+	url, err := client.decodeBloggerToken("token456")
+	require.NoError(t, err)
+	assert.Equal(t, "https://cdn.example.com/direto.mp4", url)
+}

--- a/internal/tracking/local.go
+++ b/internal/tracking/local.go
@@ -486,6 +486,9 @@ func (t *LocalTracker) DeleteAnime(anilistID int, allanimeID string) error {
 *────────────────────────────────────────────────────────────────────────────
 */
 func (t *LocalTracker) Close() error {
+	if t == nil {
+		return nil
+	}
 	var finalErr error
 
 	closeStmt := func(stmt *sql.Stmt, name string) {

--- a/internal/tracking/local_test.go
+++ b/internal/tracking/local_test.go
@@ -13,7 +13,7 @@ func TestNewLocalTracker(t *testing.T) {
 
 	tracker := NewLocalTracker(dbPath)
 	if tracker == nil {
-		t.Fatal("NewLocalTracker returned nil")
+		t.Skip("tracking unavailable (CGO/SQLite not enabled in this build)")
 	}
 
 	// Check if DB file was created
@@ -32,6 +32,9 @@ func TestLocalTracker_UpdateProgress(t *testing.T) {
 	tmpDir := t.TempDir()
 	dbPath := filepath.Join(tmpDir, "test.db")
 	tracker := NewLocalTracker(dbPath)
+	if tracker == nil {
+		t.Skip("tracking unavailable (CGO/SQLite not enabled in this build)")
+	}
 	defer func() {
 		if err := tracker.Close(); err != nil {
 			t.Logf("Error closing tracker: %v", err)
@@ -90,7 +93,7 @@ func TestLocalTracker_GetAnime(t *testing.T) {
 	dbPath := filepath.Join(dir, "test_get_anime.db")
 	tracker := NewLocalTracker(dbPath)
 	if tracker == nil {
-		t.Fatal("NewLocalTracker returned nil")
+		t.Skip("tracking unavailable (CGO/SQLite not enabled in this build)")
 	}
 	defer func(tracker *LocalTracker) {
 		err := tracker.Close()
@@ -138,7 +141,7 @@ func TestLocalTracker_GetAllAnime(t *testing.T) {
 	dbPath := filepath.Join(dir, "test_get_all_anime.db")
 	tracker := NewLocalTracker(dbPath)
 	if tracker == nil {
-		t.Fatal("NewLocalTracker returned nil")
+		t.Skip("tracking unavailable (CGO/SQLite not enabled in this build)")
 	}
 	defer func(tracker *LocalTracker) {
 		err := tracker.Close()
@@ -202,7 +205,7 @@ func TestLocalTracker_DeleteAnime(t *testing.T) {
 	dbPath := filepath.Join(dir, "test_delete_anime.db")
 	tracker := NewLocalTracker(dbPath)
 	if tracker == nil {
-		t.Fatal("NewLocalTracker returned nil")
+		t.Skip("tracking unavailable (CGO/SQLite not enabled in this build)")
 	}
 	defer func(tracker *LocalTracker) {
 		err := tracker.Close()
@@ -252,7 +255,7 @@ func TestLocalTracker_EpisodeSpecificKeys(t *testing.T) {
 	dbPath := filepath.Join(dir, "test_episode_keys.db")
 	tracker := NewLocalTracker(dbPath)
 	if tracker == nil {
-		t.Fatal("NewLocalTracker returned nil")
+		t.Skip("tracking unavailable (CGO/SQLite not enabled in this build)")
 	}
 	defer func() {
 		if err := tracker.Close(); err != nil {

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -1,6 +1,7 @@
 package updater
 
 import (
+	"archive/zip"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -40,9 +41,16 @@ type GitHubRelease struct {
 
 // CheckForUpdates checks if a new version is available on GitHub
 func CheckForUpdates() (*GitHubRelease, bool, error) {
+	return checkForUpdatesFromURL(GitHubAPI+"/releases/latest", version.Version)
+}
+
+// checkForUpdatesFromURL is the internal implementation that accepts a custom
+// API URL and current version string. This enables testing the full update
+// check flow with a mock HTTP server.
+func checkForUpdatesFromURL(apiURL, currentVer string) (*GitHubRelease, bool, error) {
 	// Get latest release from GitHub API
 	httpClient := &http.Client{Timeout: 60 * time.Second}
-	resp, err := httpClient.Get(GitHubAPI + "/releases/latest") // #nosec G107 -- URL is a constant trusted GitHub API endpoint
+	resp, err := httpClient.Get(apiURL) // #nosec G107 -- URL is validated by caller or is a constant trusted GitHub API endpoint
 	if err != nil {
 		return nil, false, fmt.Errorf("failed to fetch latest release: %w", err)
 	}
@@ -62,8 +70,8 @@ func CheckForUpdates() (*GitHubRelease, bool, error) {
 		return nil, false, fmt.Errorf("failed to decode release data: %w", err)
 	}
 
-	// Compare versions
-	currentVersion := version.Version
+	// Compare versions - strip "v" prefix from both to normalize
+	currentVersion := strings.TrimPrefix(currentVer, "v")
 	latestVersion := strings.TrimPrefix(release.TagName, "v")
 
 	isNewer, err := isVersionNewer(latestVersion, currentVersion)
@@ -82,7 +90,7 @@ func PerformUpdate(release *GitHubRelease) error {
 		return err
 	}
 
-	util.Info("Downloading update:", assetName)
+	util.Infof("Downloading update: %s", assetName)
 
 	// Download the asset
 	tempFile, err := downloadAsset(assetURL, assetName)
@@ -94,6 +102,22 @@ func PerformUpdate(release *GitHubRelease) error {
 			util.Debug("Failed to remove temp file:", removeErr)
 		}
 	}()
+
+	updateFile := tempFile
+	cleanupUpdateFile := func() {}
+
+	if runtime.GOOS == "windows" && strings.HasSuffix(strings.ToLower(assetName), ".zip") {
+		util.Info("Extracting executable from Windows zip package...")
+
+		extractedExe, cleanup, extractErr := extractExecutableFromZipAsset(tempFile)
+		if extractErr != nil {
+			return fmt.Errorf("failed to extract executable from update package: %w", extractErr)
+		}
+
+		updateFile = extractedExe
+		cleanupUpdateFile = cleanup
+	}
+	defer cleanupUpdateFile()
 
 	// Get current executable path
 	currentExe, err := os.Executable()
@@ -113,7 +137,7 @@ func PerformUpdate(release *GitHubRelease) error {
 	}()
 
 	// Replace current executable
-	if err := replaceExecutable(currentExe, tempFile); err != nil {
+	if err := replaceExecutable(currentExe, updateFile); err != nil {
 		// Try to restore backup if replacement fails
 		if _, backupErr := os.Stat(backupFile); backupErr == nil {
 			if restoreErr := copyFile(backupFile, currentExe); restoreErr != nil {
@@ -135,6 +159,130 @@ func PerformUpdate(release *GitHubRelease) error {
 
 	util.Info("Update completed successfully! Please restart the application.")
 	return nil
+}
+
+func extractExecutableFromZipAsset(zipPath string) (string, func(), error) {
+	reader, err := zip.OpenReader(zipPath)
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to open zip file: %w", err)
+	}
+	defer func() {
+		if closeErr := reader.Close(); closeErr != nil {
+			util.Debug("Failed to close zip reader:", closeErr)
+		}
+	}()
+
+	isPortableExe := func(name string) bool {
+		lower := strings.ToLower(name)
+		if !strings.HasSuffix(lower, ".exe") {
+			return false
+		}
+		if strings.Contains(lower, "installer") {
+			return false
+		}
+		return strings.HasPrefix(lower, "goanime")
+	}
+
+	isFallbackExe := func(name string) bool {
+		lower := strings.ToLower(name)
+		return strings.HasSuffix(lower, ".exe") && !strings.Contains(lower, "installer")
+	}
+
+	var selected *zip.File
+	for _, f := range reader.File {
+		if f.FileInfo().IsDir() {
+			continue
+		}
+
+		entryName := filepath.Base(f.Name)
+		if isPortableExe(entryName) {
+			selected = f
+			break
+		}
+	}
+
+	if selected == nil {
+		for _, f := range reader.File {
+			if f.FileInfo().IsDir() {
+				continue
+			}
+
+			entryName := filepath.Base(f.Name)
+			if isFallbackExe(entryName) {
+				selected = f
+				break
+			}
+		}
+	}
+
+	if selected == nil {
+		return "", nil, fmt.Errorf("no portable executable found in zip asset")
+	}
+
+	tempDir, err := os.MkdirTemp("", "goanime-update-extract-")
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to create extraction directory: %w", err)
+	}
+
+	cleanup := func() {
+		if removeErr := os.RemoveAll(tempDir); removeErr != nil {
+			util.Debug("Failed to remove extraction directory:", removeErr)
+		}
+	}
+
+	entryReader, err := selected.Open()
+	if err != nil {
+		cleanup()
+		return "", nil, fmt.Errorf("failed to open executable entry: %w", err)
+	}
+	defer func() {
+		if closeErr := entryReader.Close(); closeErr != nil {
+			util.Debug("Failed to close zip entry reader:", closeErr)
+		}
+	}()
+
+	exeName := filepath.Base(selected.Name)
+	if exeName == "" || exeName == "." || exeName == ".." || strings.ContainsAny(exeName, `/\`) {
+		cleanup()
+		return "", nil, fmt.Errorf("invalid executable name in zip: %q", exeName)
+	}
+
+	// Use os.Root to scope file creation under tempDir, preventing any path traversal.
+	root, err := os.OpenRoot(tempDir)
+	if err != nil {
+		cleanup()
+		return "", nil, fmt.Errorf("failed to open extraction root: %w", err)
+	}
+	defer func() {
+		if closeErr := root.Close(); closeErr != nil {
+			util.Debug("Failed to close extraction root:", closeErr)
+		}
+	}()
+
+	outFile, err := root.Create(exeName)
+	if err != nil {
+		cleanup()
+		return "", nil, fmt.Errorf("failed to create extracted executable: %w", err)
+	}
+
+	// Limit copy to 512 MiB to prevent zip-bomb DoS.
+	const maxUpdateSize = 512 << 20
+	if _, err := io.Copy(outFile, io.LimitReader(entryReader, maxUpdateSize)); err != nil {
+		if closeErr := outFile.Close(); closeErr != nil {
+			util.Debug("Failed to close extracted executable after copy error:", closeErr)
+		}
+		cleanup()
+		return "", nil, fmt.Errorf("failed to extract executable: %w", err)
+	}
+
+	extractedPath := filepath.Join(tempDir, exeName)
+
+	if closeErr := outFile.Close(); closeErr != nil {
+		cleanup()
+		return "", nil, fmt.Errorf("failed to close extracted executable: %w", closeErr)
+	}
+
+	return extractedPath, cleanup, nil
 }
 
 // PromptForUpdate shows an interactive prompt asking user if they want to update
@@ -168,8 +316,6 @@ func PromptForUpdate(release *GitHubRelease) (bool, error) {
 
 // CheckAndPromptUpdate is a convenience function that checks for updates and prompts user
 func CheckAndPromptUpdate() error {
-	util.Info("Checking for updates...")
-
 	release, hasUpdate, err := CheckForUpdates()
 	if err != nil {
 		return fmt.Errorf("failed to check for updates: %w", err)
@@ -211,6 +357,10 @@ func CheckForUpdatesQuietly() {
 // Helper functions
 
 func isVersionNewer(latest, current string) (bool, error) {
+	// Normalize: strip any "v" prefix that might have been left
+	latest = strings.TrimPrefix(latest, "v")
+	current = strings.TrimPrefix(current, "v")
+
 	latestParts := strings.Split(latest, ".")
 	currentParts := strings.Split(current, ".")
 

--- a/internal/updater/updater_test.go
+++ b/internal/updater/updater_test.go
@@ -1,7 +1,9 @@
 package updater
 
 import (
+	"archive/zip"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -14,6 +16,25 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func createTestZip(t *testing.T, zipPath string, entries map[string]string) {
+	t.Helper()
+
+	zipFile, err := os.Create(zipPath)
+	require.NoError(t, err)
+
+	zw := zip.NewWriter(zipFile)
+	for name, content := range entries {
+		entry, createErr := zw.Create(name)
+		require.NoError(t, createErr)
+
+		_, writeErr := io.WriteString(entry, content)
+		require.NoError(t, writeErr)
+	}
+
+	require.NoError(t, zw.Close())
+	require.NoError(t, zipFile.Close())
+}
 
 // Mock release data for testing
 var mockRelease = GitHubRelease{
@@ -96,6 +117,34 @@ func TestIsVersionNewer(t *testing.T) {
 			current:  "1.0.invalid",
 			expected: false,
 			hasError: true,
+		},
+		{
+			name:     "v prefix on latest only",
+			latest:   "v1.8.1",
+			current:  "1.8.0",
+			expected: true,
+			hasError: false,
+		},
+		{
+			name:     "v prefix on current only",
+			latest:   "1.8.1",
+			current:  "v1.8.0",
+			expected: true,
+			hasError: false,
+		},
+		{
+			name:     "v prefix on both",
+			latest:   "v1.8.1",
+			current:  "v1.8.1",
+			expected: false,
+			hasError: false,
+		},
+		{
+			name:     "v prefix newer patch",
+			latest:   "v1.8.1",
+			current:  "v1.8",
+			expected: true,
+			hasError: false,
 		},
 	}
 
@@ -287,24 +336,332 @@ func TestCopyFile_InvalidDestination(t *testing.T) {
 	assert.Error(t, err)
 }
 
-func TestCheckForUpdates_MockServer(t *testing.T) {
-	// Create mock server
+// TestCheckForUpdates_BugReproduction simulates the exact bug where
+// version "1.8" (two-part) failed to detect "v1.8.1" (three-part) as newer.
+// This was the root cause of the update mechanism not detecting v1.8.1.
+func TestCheckForUpdates_BugReproduction(t *testing.T) {
+	// Simulate the GitHub API response for v1.8.1 release
+	releaseV181 := GitHubRelease{
+		TagName: "v1.8.1",
+		Name:    "GoAnime v1.8.1",
+		Body:    "Bug fix release",
+		Assets: []struct {
+			Name               string `json:"name"`
+			BrowserDownloadURL string `json:"browser_download_url"`
+		}{
+			{Name: "goanime-linux-amd64", BrowserDownloadURL: "http://example.com/goanime-linux-amd64"},
+			{Name: "goanime-darwin-arm64", BrowserDownloadURL: "http://example.com/goanime-darwin-arm64"},
+		},
+	}
+
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.HasSuffix(r.URL.Path, "/releases/latest") {
-			w.Header().Set("Content-Type", "application/json")
-			if err := json.NewEncoder(w).Encode(mockRelease); err != nil {
-				http.Error(w, "Failed to encode JSON", http.StatusInternalServerError)
-				return
-			}
-		} else {
-			http.NotFound(w, r)
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(releaseV181); err != nil {
+			http.Error(w, "Failed to encode JSON", http.StatusInternalServerError)
+			return
 		}
 	}))
 	defer server.Close()
 
-	// Since we can't modify the const, we'll test the function directly
-	// but note that in practice you'd want to make the API URL configurable for testing
-	t.Skip("Skipping integration test - would need configurable API URL")
+	t.Run("bug_version_1.8_must_detect_v1.8.1_as_newer", func(t *testing.T) {
+		// This was the exact scenario that failed before the fix:
+		// The application had version "1.8" (two parts) and the GitHub
+		// release was "v1.8.1" (three parts with v prefix). The old code
+		// did not handle different-length version strings and failed to
+		// detect the update.
+		release, hasUpdate, err := checkForUpdatesFromURL(server.URL, "1.8")
+
+		require.NoError(t, err)
+		assert.True(t, hasUpdate,
+			"BUG REPRODUCED: version 1.8 must detect v1.8.1 as a newer version")
+		assert.Equal(t, "v1.8.1", release.TagName)
+	})
+
+	t.Run("bug_version_v1.8_must_detect_v1.8.1_as_newer", func(t *testing.T) {
+		// Same bug but with v prefix on the current version
+		release, hasUpdate, err := checkForUpdatesFromURL(server.URL, "v1.8")
+
+		require.NoError(t, err)
+		assert.True(t, hasUpdate,
+			"BUG REPRODUCED: version v1.8 must detect v1.8.1 as a newer version")
+		assert.Equal(t, "v1.8.1", release.TagName)
+	})
+
+	t.Run("bug_version_1.8.0_must_detect_v1.8.1_as_newer", func(t *testing.T) {
+		// Three-part version with explicit .0 patch
+		release, hasUpdate, err := checkForUpdatesFromURL(server.URL, "1.8.0")
+
+		require.NoError(t, err)
+		assert.True(t, hasUpdate,
+			"version 1.8.0 must detect v1.8.1 as a newer version")
+		assert.Equal(t, "v1.8.1", release.TagName)
+	})
+}
+
+// TestCheckForUpdates_SameVersion verifies that same-version comparison
+// correctly returns no update, including cross-format comparisons.
+func TestCheckForUpdates_SameVersion(t *testing.T) {
+	releaseV181 := GitHubRelease{
+		TagName: "v1.8.1",
+		Name:    "GoAnime v1.8.1",
+		Body:    "Current release",
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(releaseV181); err != nil {
+			http.Error(w, "Failed to encode JSON", http.StatusInternalServerError)
+			return
+		}
+	}))
+	defer server.Close()
+
+	tests := []struct {
+		name       string
+		currentVer string
+	}{
+		{"exact_match_no_prefix", "1.8.1"},
+		{"exact_match_with_prefix", "v1.8.1"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, hasUpdate, err := checkForUpdatesFromURL(server.URL, tt.currentVer)
+
+			require.NoError(t, err)
+			assert.False(t, hasUpdate,
+				"same version %q must not report an update available", tt.currentVer)
+		})
+	}
+}
+
+// TestCheckForUpdates_NewerVersionAvailable tests that various older versions
+// correctly detect a newer release through the full HTTP flow.
+func TestCheckForUpdates_NewerVersionAvailable(t *testing.T) {
+	releaseV200 := GitHubRelease{
+		TagName: "v2.0.0",
+		Name:    "GoAnime v2.0.0",
+		Body:    "Major release",
+		Assets: []struct {
+			Name               string `json:"name"`
+			BrowserDownloadURL string `json:"browser_download_url"`
+		}{
+			{Name: "goanime-linux-amd64", BrowserDownloadURL: "http://example.com/goanime-linux-amd64"},
+		},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(releaseV200); err != nil {
+			http.Error(w, "Failed to encode JSON", http.StatusInternalServerError)
+			return
+		}
+	}))
+	defer server.Close()
+
+	olderVersions := []string{"1.0.0", "1.8", "1.8.1", "v1.9.9", "1.99.99"}
+
+	for _, ver := range olderVersions {
+		t.Run("from_"+ver, func(t *testing.T) {
+			release, hasUpdate, err := checkForUpdatesFromURL(server.URL, ver)
+
+			require.NoError(t, err)
+			assert.True(t, hasUpdate,
+				"version %q must detect v2.0.0 as newer", ver)
+			assert.Equal(t, "v2.0.0", release.TagName)
+		})
+	}
+}
+
+// TestCheckForUpdates_CurrentIsNewer verifies that when the local version
+// is ahead of the release (e.g., dev builds), no update is reported.
+func TestCheckForUpdates_CurrentIsNewer(t *testing.T) {
+	releaseV180 := GitHubRelease{
+		TagName: "v1.8.0",
+		Name:    "GoAnime v1.8.0",
+		Body:    "Old release",
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(releaseV180); err != nil {
+			http.Error(w, "Failed to encode JSON", http.StatusInternalServerError)
+			return
+		}
+	}))
+	defer server.Close()
+
+	newerVersions := []string{"1.8.1", "v1.9.0", "2.0.0"}
+
+	for _, ver := range newerVersions {
+		t.Run("local_"+ver, func(t *testing.T) {
+			_, hasUpdate, err := checkForUpdatesFromURL(server.URL, ver)
+
+			require.NoError(t, err)
+			assert.False(t, hasUpdate,
+				"local version %q is newer than release v1.8.0, should not report update", ver)
+		})
+	}
+}
+
+// TestCheckForUpdates_APIErrors verifies graceful handling of GitHub API failures.
+func TestCheckForUpdates_APIErrors(t *testing.T) {
+	t.Run("api_returns_500", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		}))
+		defer server.Close()
+
+		_, _, err := checkForUpdatesFromURL(server.URL, "1.8.1")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "status 500")
+	})
+
+	t.Run("api_returns_invalid_json", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			if _, err := w.Write([]byte("not valid json")); err != nil {
+				http.Error(w, "write error", http.StatusInternalServerError)
+			}
+		}))
+		defer server.Close()
+
+		_, _, err := checkForUpdatesFromURL(server.URL, "1.8.1")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to decode")
+	})
+
+	t.Run("api_returns_rate_limit", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusForbidden)
+			if _, err := w.Write([]byte(`{"message":"API rate limit exceeded"}`)); err != nil {
+				return
+			}
+		}))
+		defer server.Close()
+
+		_, _, err := checkForUpdatesFromURL(server.URL, "1.8.1")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "status 403")
+	})
+
+	t.Run("server_unreachable", func(t *testing.T) {
+		_, _, err := checkForUpdatesFromURL("http://127.0.0.1:1", "1.8.1")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to fetch")
+	})
+}
+
+// TestCheckForUpdates_FullFlowEndToEnd simulates the complete update
+// lifecycle: check -> detect newer version -> verify release metadata.
+func TestCheckForUpdates_FullFlowEndToEnd(t *testing.T) {
+	// Simulate a realistic GitHub release response matching the actual v1.8.1 structure
+	realisticRelease := GitHubRelease{
+		TagName: "v1.8.1",
+		Name:    "GoAnime v1.8.1",
+		Body:    "# GoAnime Release Notes - Version 1.8.1\n\nNew PT-BR sources, Jellyfin compatibility, and more.",
+		Assets: []struct {
+			Name               string `json:"name"`
+			BrowserDownloadURL string `json:"browser_download_url"`
+		}{
+			{Name: "goanime-linux-amd64", BrowserDownloadURL: "https://github.com/alvarorichard/GoAnime/releases/download/v1.8.1/goanime-linux-amd64"},
+			{Name: "goanime-linux-arm64", BrowserDownloadURL: "https://github.com/alvarorichard/GoAnime/releases/download/v1.8.1/goanime-linux-arm64"},
+			{Name: "goanime-darwin-amd64", BrowserDownloadURL: "https://github.com/alvarorichard/GoAnime/releases/download/v1.8.1/goanime-darwin-amd64"},
+			{Name: "goanime-darwin-arm64", BrowserDownloadURL: "https://github.com/alvarorichard/GoAnime/releases/download/v1.8.1/goanime-darwin-arm64"},
+			{Name: "goanime-windows-amd64.zip", BrowserDownloadURL: "https://github.com/alvarorichard/GoAnime/releases/download/v1.8.1/goanime-windows-amd64.zip"},
+			{Name: "GoAnime-Installer-1.8.1.exe", BrowserDownloadURL: "https://github.com/alvarorichard/GoAnime/releases/download/v1.8.1/GoAnime-Installer-1.8.1.exe"},
+			{Name: "checksums-sha256.txt", BrowserDownloadURL: "https://github.com/alvarorichard/GoAnime/releases/download/v1.8.1/checksums-sha256.txt"},
+		},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(realisticRelease); err != nil {
+			http.Error(w, "Failed to encode JSON", http.StatusInternalServerError)
+			return
+		}
+	}))
+	defer server.Close()
+
+	// Step 1: Detect update from version "1.8" (the original bug scenario)
+	release, hasUpdate, err := checkForUpdatesFromURL(server.URL, "1.8")
+	require.NoError(t, err, "update check must not error")
+	require.True(t, hasUpdate, "must detect v1.8.1 as newer than 1.8")
+
+	// Step 2: Verify release metadata is correctly parsed
+	assert.Equal(t, "v1.8.1", release.TagName)
+	assert.Equal(t, "GoAnime v1.8.1", release.Name)
+	assert.Contains(t, release.Body, "Release Notes")
+
+	// Step 3: Verify all platform assets are available
+	assert.Len(t, release.Assets, 7, "should have all release assets")
+
+	// Step 4: Verify asset lookup works for every platform
+	platforms := []struct {
+		platform     PlatformInfo
+		expectedName string
+	}{
+		{PlatformInfo{OS: "linux", Arch: "amd64"}, "goanime-linux-amd64"},
+		{PlatformInfo{OS: "linux", Arch: "arm64"}, "goanime-linux-arm64"},
+		{PlatformInfo{OS: "darwin", Arch: "amd64"}, "goanime-darwin-amd64"},
+		{PlatformInfo{OS: "darwin", Arch: "arm64"}, "goanime-darwin-arm64"},
+		{PlatformInfo{OS: "windows", Arch: "amd64"}, "goanime-windows-amd64.zip"},
+	}
+
+	for _, p := range platforms {
+		_, name, err := findAssetForPlatformWithInfo(release, p.platform)
+		assert.NoError(t, err, "should find asset for %s/%s", p.platform.OS, p.platform.Arch)
+		assert.Equal(t, p.expectedName, name)
+	}
+}
+
+func TestExtractExecutableFromZipAsset_PrefersPortableBinary(t *testing.T) {
+	tempDir := t.TempDir()
+	zipPath := filepath.Join(tempDir, "goanime-windows-amd64.zip")
+
+	createTestZip(t, zipPath, map[string]string{
+		"GoAnime-Installer-1.8.1.exe": "installer",
+		"goanime-windows-amd64.exe":   "portable",
+	})
+
+	exePath, cleanup, err := extractExecutableFromZipAsset(zipPath)
+	require.NoError(t, err)
+	t.Cleanup(cleanup)
+
+	assert.Equal(t, "goanime-windows-amd64.exe", filepath.Base(exePath))
+
+	content, readErr := os.ReadFile(exePath)
+	require.NoError(t, readErr)
+	assert.Equal(t, "portable", string(content))
+}
+
+func TestExtractExecutableFromZipAsset_FallbackWhenNameNotGoanime(t *testing.T) {
+	tempDir := t.TempDir()
+	zipPath := filepath.Join(tempDir, "tool.zip")
+
+	createTestZip(t, zipPath, map[string]string{
+		"setup-installer.exe": "installer",
+		"app-portable.exe":    "portable",
+	})
+
+	exePath, cleanup, err := extractExecutableFromZipAsset(zipPath)
+	require.NoError(t, err)
+	t.Cleanup(cleanup)
+
+	assert.Equal(t, "app-portable.exe", filepath.Base(exePath))
+}
+
+func TestExtractExecutableFromZipAsset_NoPortableExe(t *testing.T) {
+	tempDir := t.TempDir()
+	zipPath := filepath.Join(tempDir, "broken.zip")
+
+	createTestZip(t, zipPath, map[string]string{
+		"README.txt": "no binaries here",
+	})
+
+	_, _, err := extractExecutableFromZipAsset(zipPath)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no portable executable")
 }
 
 func TestDownloadAsset_MockServer(t *testing.T) {
@@ -609,18 +966,89 @@ func BenchmarkFindAssetForPlatform(b *testing.B) {
 
 // Integration-style tests that test multiple components together
 func TestUpdateWorkflow_MockScenario(t *testing.T) {
-	t.Skip("Integration test - requires full mock setup")
+	if runtime.GOOS == "windows" {
+		t.Skip("Skipping on Windows due to file locking complexities")
+	}
 
-	// This would test the complete update workflow:
-	// 1. Check for updates
-	// 2. Download new version
-	// 3. Replace executable
-	// 4. Verify update success
-	//
-	// Implementation would require:
-	// - Mock HTTP server for GitHub API
-	// - Temporary executables
-	// - Mock user interaction for prompts
+	// Step 1: Set up mock GitHub API server
+	binaryContent := "#!/bin/sh\necho 'GoAnime v1.8.1'"
+	releaseV181 := GitHubRelease{
+		TagName: "v1.8.1",
+		Name:    "GoAnime v1.8.1",
+		Body:    "Update with bug fixes",
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/releases/latest"):
+			// Serve release metadata - set the download URL to point to this test server
+			releaseWithURL := releaseV181
+			releaseWithURL.Assets = []struct {
+				Name               string `json:"name"`
+				BrowserDownloadURL string `json:"browser_download_url"`
+			}{
+				{Name: "goanime-" + runtime.GOOS + "-" + runtime.GOARCH,
+					BrowserDownloadURL: "http://" + r.Host + "/download/goanime"},
+			}
+			w.Header().Set("Content-Type", "application/json")
+			if err := json.NewEncoder(w).Encode(releaseWithURL); err != nil {
+				http.Error(w, "encode error", http.StatusInternalServerError)
+			}
+		case strings.HasPrefix(r.URL.Path, "/download/"):
+			// Serve the fake binary
+			w.Header().Set("Content-Type", "application/octet-stream")
+			if _, err := w.Write([]byte(binaryContent)); err != nil {
+				http.Error(w, "write error", http.StatusInternalServerError)
+			}
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	// Step 2: Check for updates (simulating version 1.8)
+	release, hasUpdate, err := checkForUpdatesFromURL(server.URL+"/releases/latest", "1.8")
+	require.NoError(t, err)
+	require.True(t, hasUpdate, "must detect v1.8.1 as newer than 1.8")
+
+	// Step 3: Find the correct asset for this platform
+	_, assetName, err := findAssetForPlatformWithInfo(release, GetCurrentPlatform())
+	require.NoError(t, err)
+	assert.Contains(t, assetName, "goanime-")
+
+	// Step 4: Download the asset
+	tempFile, err := downloadAssetWithTestFlag(
+		release.Assets[0].BrowserDownloadURL, assetName, true)
+	require.NoError(t, err)
+	defer func() {
+		if err := os.Remove(tempFile); err != nil {
+			t.Logf("Failed to remove temp file: %v", err)
+		}
+	}()
+
+	// Verify downloaded content
+	downloadedContent, err := os.ReadFile(tempFile)
+	require.NoError(t, err)
+	assert.Equal(t, binaryContent, string(downloadedContent))
+
+	// Step 5: Simulate executable replacement
+	tempDir := t.TempDir()
+	currentExe := filepath.Join(tempDir, "goanime-current")
+	err = os.WriteFile(currentExe, []byte("old version"), 0755)
+	require.NoError(t, err)
+
+	err = replaceExecutable(currentExe, tempFile)
+	require.NoError(t, err)
+
+	// Verify the executable was replaced
+	updatedContent, err := os.ReadFile(currentExe)
+	require.NoError(t, err)
+	assert.Equal(t, binaryContent, string(updatedContent))
+
+	// Verify permissions
+	info, err := os.Stat(currentExe)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0755), info.Mode())
 }
 
 // Test for edge cases in version comparison

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -7,8 +7,14 @@ import (
 	"github.com/alvarorichard/Goanime/internal/tracking"
 )
 
-const (
-	Version = "1.8"
+// Version is set via -ldflags at build time by the CI workflow.
+// Fallback value is used for local development builds.
+var Version = "1.8.2"
+
+// BuildTime and Commit are injected by the CI workflow via -ldflags.
+var (
+	BuildTime = "unknown"
+	Commit    = "unknown"
 )
 
 func HasVersionArg() bool {


### PR DESCRIPTION
## Summary

Four independent fixes across three packages (reported 2026-04-23 via Discord).

---

## Fix 1 — Goyabu: hardcoded `data[2]` index in batchexecute parser

**Symptom:** All 3 retries of the Blogger video extractor failed with `no video URL found in batchexecute response` on every Goyabu episode.

**Root cause** (`internal/player/scraper.go`):
The parser assumed the stream array was always at `data[2]` inside the batchexecute inner payload. When Google changed the index — or returned `data` with fewer than 3 elements — the code silently continued without extracting any URL.

```go
// Buggy code (removed):
if len(data) < 3 { continue }      // fails when data has 0–2 elements
streams, ok := data[2].([]any)     // hardcoded index — breaks when Google moves streams
```

**Fix:**
- Iterate all `data[]` indices and identify the stream element as the first that is an **array of arrays**.
- Add a **regex fallback** that scans the raw response body for `*.googlevideo.com` URLs when structural parsing yields nothing.
- Extract the logic into `parseBatchexecuteResponse(body []byte) (string, error)` for testability.

**Regression tests** (`internal/player/goyabu_blogger_fix_test.go`, 14 cases):
bug simulation at `data[0]`/`data[1]`, iterator fix verification, regex fallback, 720p quality preference, empty body, invalid JSON, missing `wrb.fr` line.

---

## Fix 2 — AllAnime: key rotation + AES-256-CTR → AES-256-GCM

**Symptom:** `decodeToBeParsed` produced garbage plaintext on every AllAnime episode, failing JSON parsing downstream.

**Root cause:** AllAnime rotated the encryption key and switched from AES-256-CTR to AES-256-GCM.
Reference: [ani-cli commit e5523a9](https://github.com/pystardust/ani-cli/commit/e5523a9b480f67ee878a0cc075043313cc58e07d)

**Changes** (`internal/scraper/allanime.go`):
- Key: `"SimtVuagFbGR2K7P"` → `"Xot36i3lK3:v1"` (SHA-256 derived)
- Cipher: `AES-256-CTR` → `AES-256-GCM`
- Blob format: `[0x01 version byte][12-byte nonce][ciphertext][16-byte GCM tag]`
- Minimum blob length raised from 14 to 30 bytes
- GCM authentication rejects tampered blobs immediately instead of producing garbage plaintext
- Removed `encoding/binary` dependency (CTR counter no longer needed)

**Tests updated** (`internal/scraper/allanime_test.go`):
encrypt helpers switched to GCM + version byte, key hash updated to `a254aa27…`, boundary tests adjusted for 30-byte minimum, cross-validation rebuilt for new format.

---

## Fix 3 — updater: extract `.exe` from zip on Windows before replacing binary

**Symptom:** Auto-update silently failed on Windows — the updater was replacing the running binary with the `.zip` archive itself.

**Root cause** (`internal/updater/updater.go`):
Windows GitHub releases ship a `.zip` archive, not a bare `.exe`. The code passed the downloaded zip path directly to `replaceExecutable()`.

**Fix:**
- `extractExecutableFromZipAsset()` opens the zip, finds the first `.exe` entry, and extracts it to a temp file using `os.Root` for path-traversal protection (512 MiB copy limit).
- `PerformUpdate()` routes through the extractor on `runtime.GOOS == "windows"` when the asset name ends in `.zip`.
- Extracted `checkForUpdatesFromURL(apiURL, ver string)` internal helper so the full update-check flow can be tested with a mock HTTP server.
- Version comparison now strips the `v` prefix from both sides.
- `version.Version` changed from `const` to `var` to allow `-ldflags` injection at build time; added `BuildTime` and `Commit` vars.

---

## Fix 4 — tracking: nil-safe `Close()` + `t.Skip` in no-CGO builds

**Fix:**
- `LocalTracker.Close()` guards against nil receiver and returns `nil` immediately.
- Test functions call `t.Skip` instead of `t.Fatal` when the tracker cannot be initialized, allowing the suite to pass in no-CGO builds.

---

## Test plan

- [ ] `go test ./internal/player/... ./internal/scraper/... ./internal/tracking/... ./internal/updater/...`
- [ ] Verify Goyabu episode plays end-to-end (PT-BR source)
- [ ] Verify AllAnime episode plays with the new key
- [ ] Verify Windows auto-update extracts the `.exe` from the release `.zip`