### PR TITLE
fix: stabilize download retries

### DIFF
--- a/internal/player/download.go
+++ b/internal/player/download.go
@@ -32,8 +32,9 @@ import (
 
 // Pre-compiled regexes for download quality parsing
 var (
-	digitsRe        = regexp.MustCompile(`\d+`)
-	resolutionMp4Re = regexp.MustCompile(`(\d{3,4})p?\.mp4`)
+	digitsRe               = regexp.MustCompile(`\d+`)
+	resolutionMp4Re        = regexp.MustCompile(`(\d{3,4})p?\.mp4`)
+	downloadPartRetryDelay = 500 * time.Millisecond
 )
 
 // downloadPart downloads a part of the video file using HTTP Range Requests.
@@ -64,7 +65,7 @@ func downloadPart(url string, from, to int64, part int, client *http.Client, des
 		}
 		if attempt > 0 {
 			util.Debugf("Download part %d: resuming at byte %d (attempt %d)", part, current, attempt+1)
-			time.Sleep(500 * time.Millisecond)
+			time.Sleep(downloadPartRetryDelay)
 		}
 
 		beforeRead := current

--- a/internal/player/download_regression_test.go
+++ b/internal/player/download_regression_test.go
@@ -2,6 +2,7 @@ package player
 
 import (
 	"bytes"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -11,6 +12,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"charm.land/log/v2"
 	"github.com/alvarorichard/Goanime/internal/models"
@@ -95,6 +97,74 @@ func TestDownloadPartAddsAllAnimeReferer(t *testing.T) {
 	got, err := os.ReadFile(outPath + ".part0")
 	require.NoError(t, err)
 	assert.Equal(t, payload, got)
+}
+
+func TestDownloadPartStopsAfterRepeatedRequestErrors(t *testing.T) {
+	restore := setDownloadPartRetryDelayForTest(0)
+	defer restore()
+
+	var attempts int
+	client := &http.Client{
+		Transport: roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+			attempts++
+			return nil, errors.New("temporary network failure")
+		}),
+	}
+
+	err := downloadPart(
+		"https://allanime.day/video/episode.mp4",
+		0,
+		6,
+		0,
+		client,
+		filepath.Join(t.TempDir(), "episode.mp4"),
+		&model{},
+	)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "max retries (20) exceeded")
+	assert.Equal(t, 20, attempts)
+}
+
+func TestDownloadPartStopsAfterRepeatedHTTPStatusWithoutProgress(t *testing.T) {
+	restore := setDownloadPartRetryDelayForTest(0)
+	defer restore()
+
+	var attempts int
+	client := &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			attempts++
+			return &http.Response{
+				StatusCode: http.StatusServiceUnavailable,
+				Status:     "503 Service Unavailable",
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader("source unavailable")),
+				Request:    req,
+			}, nil
+		}),
+	}
+
+	err := downloadPart(
+		"https://allanime.day/video/episode.mp4",
+		0,
+		6,
+		0,
+		client,
+		filepath.Join(t.TempDir(), "episode.mp4"),
+		&model{},
+	)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "max retries (20) exceeded")
+	assert.Equal(t, 20, attempts)
+}
+
+func setDownloadPartRetryDelayForTest(delay time.Duration) func() {
+	original := downloadPartRetryDelay
+	downloadPartRetryDelay = delay
+	return func() {
+		downloadPartRetryDelay = original
+	}
 }
 
 func TestGetContentLengthAddsAllAnimeReferer(t *testing.T) {

--- a/internal/scraper/allanime.go
+++ b/internal/scraper/allanime.go
@@ -711,14 +711,19 @@ func (c *AllAnimeClient) processSourceURLsConcurrent(sourceURLs []string, qualit
 
 	// Collect results with timeout
 	timeout := time.After(6 * time.Second)
-	successCount := 0
+	processedCount := 0
 	var bestURL string
 	var bestMetadata map[string]string
+	var firstErr error
 
-	for successCount < len(sourceURLs) {
+	for processedCount < len(sourceURLs) {
 		select {
 		case res := <-results:
+			processedCount++
 			if res.err != nil {
+				if firstErr == nil {
+					firstErr = res.err
+				}
 				continue
 			}
 
@@ -740,11 +745,13 @@ func (c *AllAnimeClient) processSourceURLsConcurrent(sourceURLs []string, qualit
 					}
 				}
 			}
-			successCount++
 
 		case <-timeout:
 			if bestURL != "" {
 				return bestURL, bestMetadata, nil
+			}
+			if firstErr != nil {
+				return "", nil, fmt.Errorf("timeout waiting for results after %d/%d sources: %w", processedCount, len(sourceURLs), firstErr)
 			}
 			return "", nil, fmt.Errorf("timeout waiting for results")
 		}
@@ -752,6 +759,10 @@ func (c *AllAnimeClient) processSourceURLsConcurrent(sourceURLs []string, qualit
 
 	if bestURL != "" {
 		return bestURL, bestMetadata, nil
+	}
+
+	if firstErr != nil {
+		return "", nil, fmt.Errorf("no suitable quality found from any source: %w", firstErr)
 	}
 
 	return "", nil, fmt.Errorf("no suitable quality found from any source")

--- a/internal/scraper/allanime_test.go
+++ b/internal/scraper/allanime_test.go
@@ -1478,11 +1478,14 @@ func TestProcessSourceURLsConcurrentAllFail(t *testing.T) {
 	defer failServer.Close()
 
 	client := newTestClient(failServer.URL)
+	startedAt := time.Now()
 	_, _, err := client.processSourceURLsConcurrent(
 		[]string{failServer.URL + "/1", failServer.URL + "/2"},
 		"best", "anime-id", "1",
 	)
-	assert.Error(t, err)
+	require.Error(t, err)
+	assert.Less(t, time.Since(startedAt), 2*time.Second, "failed sources should not wait for the global timeout")
+	assert.NotContains(t, err.Error(), "timeout waiting for results")
 }
 
 func TestProcessSourceURLsConcurrentPartialFailure(t *testing.T) {
@@ -1505,12 +1508,14 @@ func TestProcessSourceURLsConcurrentPartialFailure(t *testing.T) {
 	defer server.Close()
 
 	client := newTestClient(server.URL)
+	startedAt := time.Now()
 	url, _, err := client.processSourceURLsConcurrent(
 		[]string{server.URL + "/fail", server.URL + "/ok"},
 		"best", "anime-id", "1",
 	)
 	require.NoError(t, err)
 	assert.Equal(t, "https://cdn.example.com/720.mp4", url)
+	assert.Less(t, time.Since(startedAt), 2*time.Second, "successful fallback should not wait for the global timeout")
 }
 
 func TestProcessSourceURLsConcurrentHighPriorityWins(t *testing.T) {
@@ -1622,16 +1627,16 @@ func TestHTTPStatusCodes(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		code         int
+		code                int
 		shouldBeUnavailable bool
 	}{
 		{200, false},
-		{301, true},  // redirect is non-2xx
-		{400, true},  // bad request
-		{403, true},  // forbidden -> ErrSourceUnavailable
-		{429, true},  // rate limited -> ErrSourceUnavailable
-		{500, true},  // internal server error
-		{503, true},  // service unavailable -> ErrSourceUnavailable
+		{301, true}, // redirect is non-2xx
+		{400, true}, // bad request
+		{403, true}, // forbidden -> ErrSourceUnavailable
+		{429, true}, // rate limited -> ErrSourceUnavailable
+		{500, true}, // internal server error
+		{503, true}, // service unavailable -> ErrSourceUnavailable
 	}
 
 	for _, tt := range tests {
@@ -1929,12 +1934,12 @@ func TestDecodeToBeParsedNoPanicOnMalformed(t *testing.T) {
 	t.Parallel()
 
 	inputs := []string{
-		"",                          // empty
-		"AA==",                      // 1 byte
-		"AAAAAAAAAAAAAAAA",          // 12 bytes exactly (nonce only, too short)
-		"AAAAAAAAAAAAAAAAAAAA",      // 15 bytes
+		"",                     // empty
+		"AA==",                 // 1 byte
+		"AAAAAAAAAAAAAAAA",     // 12 bytes exactly (nonce only, too short)
+		"AAAAAAAAAAAAAAAAAAAA", // 15 bytes
 		base64.StdEncoding.EncodeToString(make([]byte, 100)), // 100 zero bytes
-		"YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXo=",             // "abcdefghijklmnopqrstuvwxyz"
+		"YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXo=",               // "abcdefghijklmnopqrstuvwxyz"
 	}
 
 	for i, input := range inputs {


### PR DESCRIPTION
## Summary
- add missing Referer handling for AllAnime CDN download URLs
- stop Blogger chunk downloads from retrying forever when no bytes are received
- add regression tests for repeated request/status failures in Blogger chunk downloads

## Validation
- go test ./internal/download ./internal/downloader/... ./internal/player -count=1
- go test ./internal/downloader/... ./internal/player -run Download -count=5
- golangci-lint run ./internal/player/... ./internal/downloader/... --timeout=15m