### PR TITLE
feat: add source diagnostics health checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,11 @@ jobs:
         shell: bash
         run: go test -race -v -coverprofile=coverage.out ./...
 
+      - name: Run source health diagnostics
+        if: runner.os == 'Linux'
+        shell: bash
+        run: go test -tags sourcehealth -run TestSourceHealthLive -count=1 -v ./internal/scraper
+
   build-binaries:
     needs: test
     runs-on: ${{ matrix.os }}

--- a/docs/source-diagnostics-test-plan.md
+++ b/docs/source-diagnostics-test-plan.md
@@ -1,0 +1,63 @@
+# Source diagnostics test plan
+
+Este roteiro ajuda a separar indisponibilidade da source de bug no GoAnime.
+
+## Objetivo
+
+- `SourceUnavailable`: 521, 522, 523, 524, 530, DNS error, timeout de conexao ou origem fora devem virar skip no health check.
+- `BlockedOrChallenge`: 403, 429, 1020, captcha ou challenge devem virar skip no health check.
+- `ParserBroken`: resposta 200 OK sem seletores, JSON ou resultados esperados deve falhar no health check.
+- `DecryptBroken`: decrypt/API retornou formato invalido deve falhar no health check.
+- `DownloadExpired`: link CDN extraido retornou 403/404 deve ser diagnosticado como link expirado.
+- `InternalBug`: panic, nil pointer, loop infinito ou erro local deve falhar.
+
+## Comandos locais
+
+Rode estes comandos antes de abrir ou atualizar a PR:
+
+```powershell
+go test ./internal/scraper -count=1 -v
+go test ./internal/player -count=1 -v
+go test -tags sourcehealth -run TestSourceHealthLive -count=1 -v ./internal/scraper
+$env:CI='true'; go test ./... -count=1
+go vet ./...
+golangci-lint run --timeout=15m
+gosec ./...
+govulncheck ./...
+git diff --check
+```
+
+## Health check live
+
+O teste `TestSourceHealthLive` faz uma busca conhecida por provider:
+
+- Anime/geral: `naruto`
+- Filmes/series: `dexter`
+
+Resultado esperado:
+
+- Source offline, Cloudflare 521/522/523/524/530, DNS ou timeout: `t.Skip`.
+- Captcha, challenge, 403/429/1020: `t.Skip`.
+- 200 OK com parser quebrado ou zero resultados para query conhecida: `t.Fatal`.
+- Decrypt quebrado ou erro interno: `t.Fatal`.
+
+## App e logs
+
+Mensagens esperadas:
+
+- `FlixHQ temporariamente indisponivel: Cloudflare 521/origem fora`
+- `SFlix bloqueou a requisicao: captcha/challenge`
+- `Goyabu respondeu, mas o parser nao encontrou os dados esperados`
+- `Download link de download expirou ou foi negado: HTTP 404`
+
+Depois de 3 falhas consecutivas de origem/bloqueio, o circuit breaker pula a source por 10 minutos para evitar martelar servidor fora.
+
+## Discord
+
+O projeto ja possui Discord Rich Presence local, mas isso nao e a mesma coisa que alertas de saude do projeto. Para publicar diagnosticos em um canal do Discord com seguranca, use uma PR separada com:
+
+- `DISCORD_WEBHOOK_URL` configurado como GitHub secret.
+- Um job agendado ou manual que rode `go test -tags sourcehealth -run TestSourceHealthLive -count=1 -v ./internal/scraper`.
+- Um passo que envie apenas o resumo de sources `healthy`, `skipped` e `failed`, sem expor tokens, cookies ou URLs privadas.
+
+Sem esse secret configurado, a opcao segura e manter as informacoes no log do CI e no output local.

--- a/internal/api/flixhq_flow_test.go
+++ b/internal/api/flixhq_flow_test.go
@@ -3,7 +3,6 @@
 package api
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/alvarorichard/Goanime/internal/models"
@@ -17,26 +16,7 @@ func isTransientError(err error) bool {
 	if err == nil {
 		return false
 	}
-	msg := err.Error()
-	transient := []string{
-		"context deadline exceeded",
-		"connection refused",
-		"no such host",
-		"timeout",
-		"500", "502", "503", "530", "405",
-		"Bad Gateway",
-		"Method Not Allowed",
-		"both APIs failed",
-		"i/o timeout",
-		"TLS handshake timeout",
-		"no server found",
-	}
-	for _, s := range transient {
-		if strings.Contains(msg, s) {
-			return true
-		}
-	}
-	return false
+	return scraper.DiagnoseError("FlixHQ", "integration", err).ShouldSkipHealthCheck()
 }
 
 func TestFlixHQFullFlow(t *testing.T) {

--- a/internal/player/download.go
+++ b/internal/player/download.go
@@ -24,6 +24,7 @@ import (
 	"github.com/alvarorichard/Goanime/internal/api"
 	"github.com/alvarorichard/Goanime/internal/downloader/hls"
 	"github.com/alvarorichard/Goanime/internal/models"
+	"github.com/alvarorichard/Goanime/internal/scraper"
 	"github.com/alvarorichard/Goanime/internal/tui"
 	"github.com/alvarorichard/Goanime/internal/util"
 	"github.com/ktr0731/go-fuzzyfinder"
@@ -87,10 +88,15 @@ func downloadPart(url string, from, to int64, part int, client *http.Client, des
 		}
 
 		if resp.StatusCode != http.StatusPartialContent && resp.StatusCode != http.StatusOK {
+			statusCode := resp.StatusCode
+			status := resp.Status
 			if cErr := resp.Body.Close(); cErr != nil {
 				util.Logger.Warn("Error closing response body", "error", cErr)
 			}
-			util.Debugf("Download part %d: unexpected status %d", part, resp.StatusCode)
+			if statusCode == http.StatusForbidden || statusCode == http.StatusNotFound {
+				return scraper.NewDownloadExpiredError("Download", "http-range", statusCode, fmt.Errorf("HTTP %d: %s", statusCode, status))
+			}
+			util.Debugf("Download part %d: unexpected status %d", part, statusCode)
 			staleRetries++
 			continue
 		}
@@ -1018,6 +1024,9 @@ func downloadDirectHTTPWithClient(videoURL, path string, m *model, client *http.
 	}()
 
 	if resp.StatusCode != http.StatusOK {
+		if resp.StatusCode == http.StatusForbidden || resp.StatusCode == http.StatusNotFound {
+			return scraper.NewDownloadExpiredError("Download", "http", resp.StatusCode, fmt.Errorf("HTTP %d: %s", resp.StatusCode, resp.Status))
+		}
 		return fmt.Errorf("HTTP %d: %s", resp.StatusCode, resp.Status)
 	}
 

--- a/internal/player/download_regression_test.go
+++ b/internal/player/download_regression_test.go
@@ -16,6 +16,7 @@ import (
 
 	"charm.land/log/v2"
 	"github.com/alvarorichard/Goanime/internal/models"
+	"github.com/alvarorichard/Goanime/internal/scraper"
 	"github.com/alvarorichard/Goanime/internal/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -296,6 +297,9 @@ func TestDownloadDirectHTTPWithClientReturnsHTTPStatusErrorFromMockCDN(t *testin
 	err := downloadDirectHTTPWithClient(server.URL+"/missing.mp4", outPath, &model{}, server.Client())
 	require.Error(t, err)
 	assert.True(t, isHTTPStatusError(err, http.StatusNotFound), "error should be recognized as HTTP 404: %v", err)
+	diagnostic := scraper.DiagnoseError("Download", "http", err)
+	require.NotNil(t, diagnostic)
+	assert.Equal(t, scraper.DiagnosticDownloadExpired, diagnostic.Kind)
 
 	_, statErr := os.Stat(outPath)
 	assert.True(t, os.IsNotExist(statErr), "404 response must not create a completed file")

--- a/internal/player/scraper.go
+++ b/internal/player/scraper.go
@@ -125,6 +125,9 @@ func getContentLength(url string, client *http.Client) (int64, error) {
 
 	// Checks if the server responded with a 200 OK or 206 Partial Content status.
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusPartialContent {
+		if resp.StatusCode == http.StatusForbidden || resp.StatusCode == http.StatusNotFound {
+			return 0, scraper.NewDownloadExpiredError("Download", "content-length", resp.StatusCode, fmt.Errorf("HTTP %d: %s", resp.StatusCode, resp.Status))
+		}
 		// Returns an error if the server does not support partial content (required for ranged requests).
 		return 0, fmt.Errorf("server does not support partial content: status code %d", resp.StatusCode)
 	}

--- a/internal/scraper/errors.go
+++ b/internal/scraper/errors.go
@@ -23,12 +23,8 @@ var ErrInvalidStreamURL = errors.New("invalid stream url")
 // checkHTTPStatus wraps blocking upstream statuses with ErrSourceUnavailable so
 // callers can differentiate provider-side issues from local parsing failures.
 func checkHTTPStatus(resp *http.Response, source string) error {
-	switch resp.StatusCode {
-	case http.StatusForbidden, http.StatusTooManyRequests, http.StatusServiceUnavailable:
-		return fmt.Errorf("%s returned status %d (source blocked?): %w", source, resp.StatusCode, ErrSourceUnavailable)
-	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return fmt.Errorf("%s returned status %d", source, resp.StatusCode)
+		return NewHTTPStatusError(source, "http", resp.StatusCode)
 	}
 	return nil
 }
@@ -37,12 +33,12 @@ func checkHTTPStatus(resp *http.Response, source string) error {
 // are expected.
 func checkHTMLResponse(resp *http.Response, body []byte, source string) error {
 	if strings.Contains(strings.ToLower(resp.Header.Get("Content-Type")), "text/html") {
-		return fmt.Errorf("%s returned HTML instead of JSON (source blocked?): %w", source, ErrSourceUnavailable)
+		return NewBlockedChallengeError(source, "http", "returned HTML instead of JSON", nil)
 	}
 
 	trimmed := bytes.TrimLeft(body, " \t\r\n")
 	if len(trimmed) > 0 && trimmed[0] == '<' {
-		return fmt.Errorf("%s returned HTML instead of JSON (source blocked?): %w", source, ErrSourceUnavailable)
+		return NewBlockedChallengeError(source, "http", "returned HTML instead of JSON", nil)
 	}
 
 	return nil
@@ -53,16 +49,16 @@ func checkHTMLResponse(resp *http.Response, body []byte, source string) error {
 func checkChallengeDocument(doc *goquery.Document, source string) error {
 	title := strings.ToLower(strings.TrimSpace(doc.Find("title").First().Text()))
 	if strings.Contains(title, "just a moment") {
-		return fmt.Errorf("%s returned a challenge page: %w", source, ErrSourceUnavailable)
+		return NewBlockedChallengeError(source, "http", "returned a challenge page", nil)
 	}
 
 	if doc.Find("#cf-wrapper").Length() > 0 || doc.Find("#challenge-form").Length() > 0 {
-		return fmt.Errorf("%s returned a challenge page: %w", source, ErrSourceUnavailable)
+		return NewBlockedChallengeError(source, "http", "returned a challenge page", nil)
 	}
 
 	body := strings.ToLower(doc.Text())
 	if strings.Contains(body, "cf-error") || strings.Contains(body, "cloudflare") {
-		return fmt.Errorf("%s returned a challenge page: %w", source, ErrSourceUnavailable)
+		return NewBlockedChallengeError(source, "http", "returned a challenge page", nil)
 	}
 
 	return nil

--- a/internal/scraper/source_circuit.go
+++ b/internal/scraper/source_circuit.go
@@ -1,0 +1,135 @@
+package scraper
+
+import (
+	"fmt"
+	"sync"
+	"time"
+)
+
+const (
+	defaultSourceFailureThreshold = 3
+	defaultSourceCooldown         = 10 * time.Minute
+)
+
+type sourceCircuitState struct {
+	failures       int
+	openUntil      time.Time
+	lastDiagnostic *SourceDiagnostic
+}
+
+type sourceCircuitBreaker struct {
+	mu        sync.Mutex
+	threshold int
+	cooldown  time.Duration
+	now       func() time.Time
+	states    map[ScraperType]*sourceCircuitState
+}
+
+func newSourceCircuitBreaker() *sourceCircuitBreaker {
+	return &sourceCircuitBreaker{
+		threshold: defaultSourceFailureThreshold,
+		cooldown:  defaultSourceCooldown,
+		now:       time.Now,
+		states:    make(map[ScraperType]*sourceCircuitState),
+	}
+}
+
+func (cb *sourceCircuitBreaker) isOpen(source ScraperType) (time.Time, *SourceDiagnostic, bool) {
+	if cb == nil {
+		return time.Time{}, nil, false
+	}
+
+	cb.mu.Lock()
+	defer cb.mu.Unlock()
+
+	state := cb.states[source]
+	if state == nil || state.openUntil.IsZero() {
+		return time.Time{}, nil, false
+	}
+
+	now := cb.now()
+	if !now.Before(state.openUntil) {
+		state.openUntil = time.Time{}
+		state.failures = 0
+		state.lastDiagnostic = nil
+		return time.Time{}, nil, false
+	}
+
+	return state.openUntil, state.lastDiagnostic, true
+}
+
+func (cb *sourceCircuitBreaker) recordSuccess(source ScraperType) {
+	if cb == nil {
+		return
+	}
+
+	cb.mu.Lock()
+	defer cb.mu.Unlock()
+	delete(cb.states, source)
+}
+
+func (cb *sourceCircuitBreaker) recordFailure(source ScraperType, diagnostic *SourceDiagnostic) bool {
+	if cb == nil || diagnostic == nil || !diagnostic.ShouldOpenCircuit() {
+		return false
+	}
+
+	cb.mu.Lock()
+	defer cb.mu.Unlock()
+
+	state := cb.states[source]
+	if state == nil {
+		state = &sourceCircuitState{}
+		cb.states[source] = state
+	}
+
+	state.failures++
+	state.lastDiagnostic = diagnostic
+	if state.failures < cb.threshold {
+		return false
+	}
+
+	state.openUntil = cb.now().Add(cb.cooldown)
+	return true
+}
+
+func (sm *ScraperManager) ensureCircuitBreaker() *sourceCircuitBreaker {
+	sm.breakerMu.Lock()
+	defer sm.breakerMu.Unlock()
+
+	if sm.breaker == nil {
+		sm.breaker = newSourceCircuitBreaker()
+	}
+	return sm.breaker
+}
+
+func (sm *ScraperManager) circuitOpenDiagnostic(source ScraperType) (*SourceDiagnostic, time.Duration, bool) {
+	breaker := sm.ensureCircuitBreaker()
+	openUntil, lastDiagnostic, ok := breaker.isOpen(source)
+	if !ok {
+		return nil, 0, false
+	}
+
+	sourceName := sm.getScraperDisplayName(source)
+	message := fmt.Sprintf("circuit breaker open until %s", openUntil.Format(time.RFC3339))
+	if lastDiagnostic != nil {
+		message = fmt.Sprintf("%s; last failure: %s", message, lastDiagnostic.UserMessage())
+	}
+
+	diagnostic := &SourceDiagnostic{
+		Source:  sourceName,
+		Layer:   "circuit-breaker",
+		Kind:    DiagnosticSourceUnavailable,
+		Message: message,
+		Err:     ErrSourceUnavailable,
+	}
+
+	return diagnostic, time.Until(openUntil), true
+}
+
+func (sm *ScraperManager) recordSourceSuccess(source ScraperType) {
+	sm.ensureCircuitBreaker().recordSuccess(source)
+}
+
+func (sm *ScraperManager) recordSourceFailure(source ScraperType, diagnostic *SourceDiagnostic) bool {
+	return sm.ensureCircuitBreaker().recordFailure(source, diagnostic)
+}

--- a/internal/scraper/source_circuit.go
+++ b/internal/scraper/source_circuit.go
@@ -1,3 +1,4 @@
+// Package scraper implements provider search, stream extraction, and source diagnostics.
 package scraper
 
 import (

--- a/internal/scraper/source_diagnostic.go
+++ b/internal/scraper/source_diagnostic.go
@@ -1,0 +1,380 @@
+package scraper
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"strconv"
+	"strings"
+)
+
+// DiagnosticKind identifies the layer where a provider failure happened.
+type DiagnosticKind string
+
+const (
+	// DiagnosticUnknown is used when no more specific classification exists.
+	DiagnosticUnknown DiagnosticKind = "Unknown"
+	// DiagnosticSourceUnavailable means the upstream origin/network is down.
+	DiagnosticSourceUnavailable DiagnosticKind = "SourceUnavailable"
+	// DiagnosticBlockedChallenge means the upstream blocked or challenged us.
+	DiagnosticBlockedChallenge DiagnosticKind = "BlockedOrChallenge"
+	// DiagnosticParserBroken means the response shape changed after a successful request.
+	DiagnosticParserBroken DiagnosticKind = "ParserBroken"
+	// DiagnosticDecryptBroken means a decrypt/decode layer changed or returned invalid data.
+	DiagnosticDecryptBroken DiagnosticKind = "DecryptBroken"
+	// DiagnosticDownloadExpired means an extracted CDN URL expired or was rejected.
+	DiagnosticDownloadExpired DiagnosticKind = "DownloadExpired"
+	// DiagnosticInternalBug means the failure appears to be local application logic.
+	DiagnosticInternalBug DiagnosticKind = "InternalBug"
+)
+
+// SourceDiagnostic carries machine-readable context while still behaving like a
+// normal wrapped error.
+type SourceDiagnostic struct {
+	Source     string
+	Layer      string
+	Kind       DiagnosticKind
+	StatusCode int
+	Message    string
+	Err        error
+}
+
+func (d *SourceDiagnostic) Error() string {
+	if d == nil {
+		return "<nil>"
+	}
+
+	message := d.Message
+	if message == "" {
+		message = string(d.Kind)
+	}
+	if d.StatusCode > 0 && !strings.Contains(message, strconv.Itoa(d.StatusCode)) {
+		message = fmt.Sprintf("%s (HTTP %d)", message, d.StatusCode)
+	}
+
+	switch {
+	case d.Source != "" && d.Layer != "":
+		return fmt.Sprintf("%s %s: %s", d.Source, d.Layer, message)
+	case d.Source != "":
+		return fmt.Sprintf("%s: %s", d.Source, message)
+	default:
+		return message
+	}
+}
+
+func (d *SourceDiagnostic) Unwrap() error {
+	if d == nil {
+		return nil
+	}
+	return d.Err
+}
+
+func (d *SourceDiagnostic) Is(target error) bool {
+	if d == nil {
+		return false
+	}
+	if target == ErrSourceUnavailable {
+		return d.Kind == DiagnosticSourceUnavailable || d.Kind == DiagnosticBlockedChallenge
+	}
+	return errors.Is(d.Err, target)
+}
+
+// UserMessage is safe to show in app logs.
+func (d *SourceDiagnostic) UserMessage() string {
+	if d == nil {
+		return "source diagnostic unavailable"
+	}
+
+	source := d.Source
+	if source == "" {
+		source = "Source"
+	}
+
+	switch d.Kind {
+	case DiagnosticSourceUnavailable:
+		if isCloudflareOriginStatus(d.StatusCode) {
+			return fmt.Sprintf("%s temporariamente indisponivel: Cloudflare %d/origem fora", source, d.StatusCode)
+		}
+		if d.StatusCode > 0 {
+			return fmt.Sprintf("%s temporariamente indisponivel: HTTP %d", source, d.StatusCode)
+		}
+		return fmt.Sprintf("%s temporariamente indisponivel: %s", source, d.reason())
+	case DiagnosticBlockedChallenge:
+		if d.StatusCode > 0 {
+			return fmt.Sprintf("%s bloqueou a requisicao: HTTP %d/challenge", source, d.StatusCode)
+		}
+		return fmt.Sprintf("%s bloqueou a requisicao: captcha/challenge", source)
+	case DiagnosticParserBroken:
+		return fmt.Sprintf("%s respondeu, mas o parser nao encontrou os dados esperados: %s", source, d.reason())
+	case DiagnosticDecryptBroken:
+		return fmt.Sprintf("%s decrypt falhou: formato ou chave pode ter mudado", source)
+	case DiagnosticDownloadExpired:
+		if d.StatusCode > 0 {
+			return fmt.Sprintf("%s link de download expirou ou foi negado: HTTP %d", source, d.StatusCode)
+		}
+		return fmt.Sprintf("%s link de download expirou ou foi negado", source)
+	case DiagnosticInternalBug:
+		return fmt.Sprintf("%s erro interno no app: %s", source, d.reason())
+	default:
+		return fmt.Sprintf("%s falhou: %s", source, d.reason())
+	}
+}
+
+func (d *SourceDiagnostic) reason() string {
+	if d == nil {
+		return "unknown"
+	}
+	if d.Message != "" {
+		return d.Message
+	}
+	if d.Err != nil {
+		return d.Err.Error()
+	}
+	return string(d.Kind)
+}
+
+// ShouldSkipHealthCheck returns true for provider-side failures. CI health checks
+// should skip these instead of failing a PR.
+func (d *SourceDiagnostic) ShouldSkipHealthCheck() bool {
+	if d == nil {
+		return false
+	}
+	return d.Kind == DiagnosticSourceUnavailable || d.Kind == DiagnosticBlockedChallenge
+}
+
+// ShouldOpenCircuit returns true when retrying immediately is likely to hammer a
+// dead or blocked upstream provider.
+func (d *SourceDiagnostic) ShouldOpenCircuit() bool {
+	if d == nil {
+		return false
+	}
+	return d.Kind == DiagnosticSourceUnavailable || d.Kind == DiagnosticBlockedChallenge
+}
+
+// NewHTTPStatusError classifies an upstream HTTP status into a diagnostic error.
+func NewHTTPStatusError(source, layer string, statusCode int) error {
+	kind := DiagnosticParserBroken
+	message := fmt.Sprintf("returned HTTP %d", statusCode)
+
+	switch {
+	case isBlockedStatus(statusCode):
+		kind = DiagnosticBlockedChallenge
+		message = fmt.Sprintf("blocked or challenged with HTTP %d", statusCode)
+	case isOriginUnavailableStatus(statusCode):
+		kind = DiagnosticSourceUnavailable
+		message = fmt.Sprintf("upstream unavailable with HTTP %d", statusCode)
+	}
+
+	return &SourceDiagnostic{
+		Source:     source,
+		Layer:      layer,
+		Kind:       kind,
+		StatusCode: statusCode,
+		Message:    message,
+		Err:        sentinelForDiagnosticKind(kind),
+	}
+}
+
+// NewBlockedChallengeError creates a diagnostic for captcha/challenge blocks.
+func NewBlockedChallengeError(source, layer, message string, err error) error {
+	return &SourceDiagnostic{
+		Source:  source,
+		Layer:   layer,
+		Kind:    DiagnosticBlockedChallenge,
+		Message: message,
+		Err:     joinDiagnosticErr(err, ErrSourceUnavailable),
+	}
+}
+
+// NewParserError creates a diagnostic for source markup/API shape changes.
+func NewParserError(source, layer, message string, err error) error {
+	return &SourceDiagnostic{
+		Source:  source,
+		Layer:   layer,
+		Kind:    DiagnosticParserBroken,
+		Message: message,
+		Err:     err,
+	}
+}
+
+// NewDecryptError creates a diagnostic for broken decrypt/decode layers.
+func NewDecryptError(source, layer, message string, err error) error {
+	return &SourceDiagnostic{
+		Source:  source,
+		Layer:   layer,
+		Kind:    DiagnosticDecryptBroken,
+		Message: message,
+		Err:     err,
+	}
+}
+
+// NewDownloadExpiredError creates a diagnostic for expired or rejected CDN links.
+func NewDownloadExpiredError(source, layer string, statusCode int, err error) error {
+	return &SourceDiagnostic{
+		Source:     source,
+		Layer:      layer,
+		Kind:       DiagnosticDownloadExpired,
+		StatusCode: statusCode,
+		Message:    fmt.Sprintf("download URL expired or rejected with HTTP %d", statusCode),
+		Err:        err,
+	}
+}
+
+// NewInternalBugError creates a diagnostic for local application errors.
+func NewInternalBugError(source, layer, message string, err error) error {
+	return &SourceDiagnostic{
+		Source:  source,
+		Layer:   layer,
+		Kind:    DiagnosticInternalBug,
+		Message: message,
+		Err:     err,
+	}
+}
+
+// DiagnoseError classifies legacy/plain errors so callers can log and decide
+// whether a CI health check should fail or skip.
+func DiagnoseError(source, layer string, err error) *SourceDiagnostic {
+	if err == nil {
+		return nil
+	}
+
+	var diag *SourceDiagnostic
+	if errors.As(err, &diag) {
+		copyDiag := *diag
+		if copyDiag.Source == "" {
+			copyDiag.Source = source
+		}
+		if copyDiag.Layer == "" {
+			copyDiag.Layer = layer
+		}
+		return &copyDiag
+	}
+
+	if isNetworkUnavailable(err) {
+		return &SourceDiagnostic{
+			Source:  source,
+			Layer:   layer,
+			Kind:    DiagnosticSourceUnavailable,
+			Message: err.Error(),
+			Err:     joinDiagnosticErr(err, ErrSourceUnavailable),
+		}
+	}
+
+	lower := strings.ToLower(err.Error())
+	if status := statusFromMessage(lower); status > 0 {
+		typedErr := NewHTTPStatusError(source, layer, status)
+		var typedDiag *SourceDiagnostic
+		if errors.As(typedErr, &typedDiag) {
+			typedDiag.Err = joinDiagnosticErr(err, typedDiag.Err)
+			return typedDiag
+		}
+	}
+
+	switch {
+	case containsAny(lower, "captcha", "challenge", "cloudflare", "access denied", "error 1020", "forbidden", "rate limit"):
+		return &SourceDiagnostic{Source: source, Layer: layer, Kind: DiagnosticBlockedChallenge, Message: err.Error(), Err: joinDiagnosticErr(err, ErrSourceUnavailable)}
+	case containsAny(lower, "decrypt", "decryption", "aes-gcm", "base64 decode", "tobeparsed"):
+		return &SourceDiagnostic{Source: source, Layer: layer, Kind: DiagnosticDecryptBroken, Message: err.Error(), Err: err}
+	case containsAny(lower, "no source url", "no source urls", "no suitable quality", "no server found", "no embed", "no video url", "no video sources", "failed to parse", "selector", "expected payload"):
+		return &SourceDiagnostic{Source: source, Layer: layer, Kind: DiagnosticParserBroken, Message: err.Error(), Err: err}
+	case containsAny(lower, "panic", "nil pointer", "deadlock", "loop infinito", "infinite loop"):
+		return &SourceDiagnostic{Source: source, Layer: layer, Kind: DiagnosticInternalBug, Message: err.Error(), Err: err}
+	default:
+		return &SourceDiagnostic{Source: source, Layer: layer, Kind: DiagnosticInternalBug, Message: err.Error(), Err: err}
+	}
+}
+
+func isNetworkUnavailable(err error) bool {
+	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+		return true
+	}
+
+	var dnsErr *net.DNSError
+	if errors.As(err, &dnsErr) {
+		return true
+	}
+
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return true
+	}
+
+	lower := strings.ToLower(err.Error())
+	return containsAny(lower,
+		"no such host",
+		"connection refused",
+		"connection reset",
+		"i/o timeout",
+		"tls handshake timeout",
+		"context deadline exceeded",
+		"timed out",
+		"timeout",
+	)
+}
+
+func isBlockedStatus(statusCode int) bool {
+	return statusCode == http.StatusForbidden ||
+		statusCode == http.StatusTooManyRequests ||
+		statusCode == 1020
+}
+
+func isOriginUnavailableStatus(statusCode int) bool {
+	switch statusCode {
+	case http.StatusInternalServerError,
+		http.StatusBadGateway,
+		http.StatusServiceUnavailable,
+		http.StatusGatewayTimeout,
+		521, 522, 523, 524, 530:
+		return true
+	default:
+		return false
+	}
+}
+
+func isCloudflareOriginStatus(statusCode int) bool {
+	switch statusCode {
+	case 521, 522, 523, 524, 530:
+		return true
+	default:
+		return false
+	}
+}
+
+func statusFromMessage(lower string) int {
+	statuses := []int{1020, 530, 524, 523, 522, 521, 504, 503, 502, 500, 429, 404, 403, 405}
+	for _, status := range statuses {
+		if strings.Contains(lower, strconv.Itoa(status)) {
+			return status
+		}
+	}
+	return 0
+}
+
+func sentinelForDiagnosticKind(kind DiagnosticKind) error {
+	if kind == DiagnosticSourceUnavailable || kind == DiagnosticBlockedChallenge {
+		return ErrSourceUnavailable
+	}
+	return nil
+}
+
+func joinDiagnosticErr(err, sentinel error) error {
+	switch {
+	case err == nil:
+		return sentinel
+	case sentinel == nil:
+		return err
+	default:
+		return errors.Join(err, sentinel)
+	}
+}
+
+func containsAny(s string, needles ...string) bool {
+	for _, needle := range needles {
+		if strings.Contains(s, needle) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/scraper/source_diagnostic.go
+++ b/internal/scraper/source_diagnostic.go
@@ -1,3 +1,4 @@
+// Package scraper implements provider search, stream extraction, and source diagnostics.
 package scraper
 
 import (
@@ -71,6 +72,7 @@ func (d *SourceDiagnostic) Unwrap() error {
 	return d.Err
 }
 
+// Is lets errors.Is match ErrSourceUnavailable for source-side diagnostics.
 func (d *SourceDiagnostic) Is(target error) bool {
 	if d == nil {
 		return false

--- a/internal/scraper/source_diagnostic_test.go
+++ b/internal/scraper/source_diagnostic_test.go
@@ -1,0 +1,128 @@
+package scraper
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/alvarorichard/Goanime/internal/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewHTTPStatusErrorClassifiesCloudflareOriginDown(t *testing.T) {
+	t.Parallel()
+
+	err := NewHTTPStatusError("FlixHQ", "search", 521)
+	diagnostic := DiagnoseError("FlixHQ", "search", err)
+
+	require.NotNil(t, diagnostic)
+	assert.Equal(t, DiagnosticSourceUnavailable, diagnostic.Kind)
+	assert.Equal(t, 521, diagnostic.StatusCode)
+	assert.True(t, errors.Is(err, ErrSourceUnavailable))
+	assert.True(t, diagnostic.ShouldSkipHealthCheck())
+	assert.Contains(t, diagnostic.UserMessage(), "Cloudflare 521")
+}
+
+func TestNewHTTPStatusErrorClassifiesBlockedChallenge(t *testing.T) {
+	t.Parallel()
+
+	err := NewHTTPStatusError("SFlix", "search", http.StatusTooManyRequests)
+	diagnostic := DiagnoseError("SFlix", "search", err)
+
+	require.NotNil(t, diagnostic)
+	assert.Equal(t, DiagnosticBlockedChallenge, diagnostic.Kind)
+	assert.True(t, errors.Is(err, ErrSourceUnavailable))
+	assert.True(t, diagnostic.ShouldOpenCircuit())
+}
+
+func TestDiagnoseErrorClassifiesParserAndDecryptFailures(t *testing.T) {
+	t.Parallel()
+
+	parserDiagnostic := DiagnoseError("Goyabu", "episode", errors.New("no video URL found in AJAX response"))
+	require.NotNil(t, parserDiagnostic)
+	assert.Equal(t, DiagnosticParserBroken, parserDiagnostic.Kind)
+	assert.False(t, parserDiagnostic.ShouldSkipHealthCheck())
+
+	decryptDiagnostic := DiagnoseError("AllAnime", "episode", errors.New("AES-GCM decryption failed: cipher: message authentication failed"))
+	require.NotNil(t, decryptDiagnostic)
+	assert.Equal(t, DiagnosticDecryptBroken, decryptDiagnostic.Kind)
+	assert.False(t, decryptDiagnostic.ShouldSkipHealthCheck())
+}
+
+func TestDiagnoseErrorClassifiesTimeoutAsSourceUnavailable(t *testing.T) {
+	t.Parallel()
+
+	diagnostic := DiagnoseError("9Anime", "search", context.DeadlineExceeded)
+
+	require.NotNil(t, diagnostic)
+	assert.Equal(t, DiagnosticSourceUnavailable, diagnostic.Kind)
+	assert.True(t, errors.Is(diagnostic, ErrSourceUnavailable))
+	assert.True(t, diagnostic.ShouldSkipHealthCheck())
+}
+
+func TestSourceCircuitBreakerSkipsAfterRepeatedOriginFailures(t *testing.T) {
+	unavailableErr := NewHTTPStatusError("AllAnime", "search", 521)
+	allAnimeMock := &MockScraper{
+		searchFunc: func(_ string) ([]*models.Anime, error) {
+			return nil, unavailableErr
+		},
+	}
+	animefireMock := &MockScraper{
+		searchFunc: func(_ string) ([]*models.Anime, error) {
+			return []*models.Anime{{Name: "Naruto", URL: "ok"}}, nil
+		},
+	}
+
+	manager := createTestManager(allAnimeMock, animefireMock)
+	manager.breaker = newSourceCircuitBreaker()
+	manager.breaker.threshold = 2
+	manager.breaker.cooldown = time.Minute
+
+	for i := 0; i < 2; i++ {
+		results, err := manager.SearchAnime("naruto", nil)
+		require.NoError(t, err)
+		require.Len(t, results, 1)
+	}
+
+	results, err := manager.SearchAnime("naruto", nil)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, int32(2), allAnimeMock.searchCallCount.Load(), "open circuit should skip the failing source")
+	assert.Equal(t, int32(3), animefireMock.searchCallCount.Load())
+}
+
+func TestCheckSourceHealthFailsOnParserBreakButSkipsOffline(t *testing.T) {
+	t.Parallel()
+
+	manager := &ScraperManager{
+		scrapers: map[ScraperType]UnifiedScraper{
+			AllAnimeType: &MockScraper{
+				scraperType: AllAnimeType,
+				searchFunc: func(_ string) ([]*models.Anime, error) {
+					return nil, NewHTTPStatusError("AllAnime", "search", 521)
+				},
+			},
+			AnimefireType: &MockScraper{
+				scraperType: AnimefireType,
+				searchFunc: func(_ string) ([]*models.Anime, error) {
+					return nil, fmt.Errorf("no video URL found in AJAX response")
+				},
+			},
+		},
+		breaker: newSourceCircuitBreaker(),
+	}
+
+	offline := manager.CheckSourceHealth(context.Background(), AllAnimeType, "naruto")
+	assert.Equal(t, SourceHealthSkipped, offline.Status)
+	require.NotNil(t, offline.Diagnostic)
+	assert.Equal(t, DiagnosticSourceUnavailable, offline.Diagnostic.Kind)
+
+	parserBroken := manager.CheckSourceHealth(context.Background(), AnimefireType, "naruto")
+	assert.Equal(t, SourceHealthFailed, parserBroken.Status)
+	require.NotNil(t, parserBroken.Diagnostic)
+	assert.Equal(t, DiagnosticParserBroken, parserBroken.Diagnostic.Kind)
+}

--- a/internal/scraper/source_health.go
+++ b/internal/scraper/source_health.go
@@ -1,3 +1,4 @@
+// Package scraper implements provider search, stream extraction, and source diagnostics.
 package scraper
 
 import (

--- a/internal/scraper/source_health.go
+++ b/internal/scraper/source_health.go
@@ -1,0 +1,148 @@
+package scraper
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/alvarorichard/Goanime/internal/models"
+)
+
+// SourceHealthStatus is the result class for a provider health probe.
+type SourceHealthStatus string
+
+const (
+	// SourceHealthHealthy means the provider returned parseable search results.
+	SourceHealthHealthy SourceHealthStatus = "healthy"
+	// SourceHealthSkipped means the provider is offline/blocked and CI should not fail.
+	SourceHealthSkipped SourceHealthStatus = "skipped"
+	// SourceHealthFailed means the provider responded but GoAnime likely needs a fix.
+	SourceHealthFailed SourceHealthStatus = "failed"
+)
+
+// SourceHealthResult describes a single provider health probe.
+type SourceHealthResult struct {
+	Source      ScraperType
+	SourceName  string
+	Query       string
+	Status      SourceHealthStatus
+	Results     int
+	Duration    time.Duration
+	Diagnostic  *SourceDiagnostic
+	Description string
+}
+
+// DefaultHealthCheckQuery returns a stable query expected to produce results.
+func DefaultHealthCheckQuery(source ScraperType) string {
+	switch source {
+	case FlixHQType, SFlixType, SuperFlixType:
+		return "dexter"
+	default:
+		return "naruto"
+	}
+}
+
+// AvailableSources returns registered scraper types in deterministic order.
+func (sm *ScraperManager) AvailableSources() []ScraperType {
+	sources := make([]ScraperType, 0, len(sm.scrapers))
+	for source := range sm.scrapers {
+		sources = append(sources, source)
+	}
+	sort.Slice(sources, func(i, j int) bool {
+		return sources[i] < sources[j]
+	})
+	return sources
+}
+
+// CheckSourceHealth probes one provider and classifies the result for CI/app diagnostics.
+func (sm *ScraperManager) CheckSourceHealth(ctx context.Context, source ScraperType, query string) SourceHealthResult {
+	sourceName := sm.getScraperDisplayName(source)
+	if query == "" {
+		query = DefaultHealthCheckQuery(source)
+	}
+
+	startedAt := time.Now()
+	result := SourceHealthResult{
+		Source:     source,
+		SourceName: sourceName,
+		Query:      query,
+	}
+
+	scraper, exists := sm.scrapers[source]
+	if !exists {
+		diagnostic := NewInternalBugError(sourceName, "health-check", "scraper not registered", nil)
+		result.Status = SourceHealthFailed
+		result.Diagnostic = DiagnoseError(sourceName, "health-check", diagnostic)
+		result.Duration = time.Since(startedAt)
+		result.Description = result.Diagnostic.UserMessage()
+		return result
+	}
+
+	if diagnostic, retryAfter, open := sm.circuitOpenDiagnostic(source); open {
+		diagnostic.Message = fmt.Sprintf("%s; retry after %s", diagnostic.Message, retryAfter.Round(time.Second))
+		result.Status = SourceHealthSkipped
+		result.Diagnostic = diagnostic
+		result.Duration = time.Since(startedAt)
+		result.Description = diagnostic.UserMessage()
+		return result
+	}
+
+	type searchOutcome struct {
+		results []*models.Anime
+		err     error
+	}
+
+	done := make(chan searchOutcome, 1)
+	go func() {
+		results, err := scraper.SearchAnime(query)
+		done <- searchOutcome{results: results, err: err}
+	}()
+
+	select {
+	case outcome := <-done:
+		result.Duration = time.Since(startedAt)
+		if outcome.err != nil {
+			diagnostic := DiagnoseError(sourceName, "health-check", outcome.err)
+			result.Diagnostic = diagnostic
+			result.Description = diagnostic.UserMessage()
+			if diagnostic.ShouldSkipHealthCheck() {
+				result.Status = SourceHealthSkipped
+				return result
+			}
+			result.Status = SourceHealthFailed
+			return result
+		}
+
+		result.Results = len(outcome.results)
+		if len(outcome.results) == 0 {
+			diagnostic := DiagnoseError(sourceName, "health-check", NewParserError(sourceName, "health-check", "known query returned zero results", nil))
+			result.Status = SourceHealthFailed
+			result.Diagnostic = diagnostic
+			result.Description = diagnostic.UserMessage()
+			return result
+		}
+
+		result.Status = SourceHealthHealthy
+		result.Description = fmt.Sprintf("%s healthy: query %q returned %d result(s)", sourceName, query, len(outcome.results))
+		return result
+
+	case <-ctx.Done():
+		result.Duration = time.Since(startedAt)
+		diagnostic := DiagnoseError(sourceName, "health-check", ctx.Err())
+		result.Status = SourceHealthSkipped
+		result.Diagnostic = diagnostic
+		result.Description = diagnostic.UserMessage()
+		return result
+	}
+}
+
+// CheckAllSourcesHealth probes all registered providers in deterministic order.
+func (sm *ScraperManager) CheckAllSourcesHealth(ctx context.Context) []SourceHealthResult {
+	sources := sm.AvailableSources()
+	results := make([]SourceHealthResult, 0, len(sources))
+	for _, source := range sources {
+		results = append(results, sm.CheckSourceHealth(ctx, source, DefaultHealthCheckQuery(source)))
+	}
+	return results
+}

--- a/internal/scraper/source_health_live_test.go
+++ b/internal/scraper/source_health_live_test.go
@@ -1,0 +1,33 @@
+//go:build sourcehealth
+
+package scraper
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestSourceHealthLive(t *testing.T) {
+	manager := NewScraperManager()
+
+	for _, source := range manager.AvailableSources() {
+		source := source
+		t.Run(manager.getScraperDisplayName(source), func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+			defer cancel()
+
+			result := manager.CheckSourceHealth(ctx, source, DefaultHealthCheckQuery(source))
+			switch result.Status {
+			case SourceHealthHealthy:
+				t.Logf("%s", result.Description)
+			case SourceHealthSkipped:
+				t.Skipf("%s", result.Description)
+			case SourceHealthFailed:
+				t.Fatalf("%s", result.Description)
+			default:
+				t.Fatalf("unknown source health status: %s", result.Status)
+			}
+		})
+	}
+}

--- a/internal/scraper/unified.go
+++ b/internal/scraper/unified.go
@@ -48,7 +48,9 @@ type UnifiedScraper interface {
 
 // ScraperManager manages multiple scrapers
 type ScraperManager struct {
-	scrapers map[ScraperType]UnifiedScraper
+	scrapers  map[ScraperType]UnifiedScraper
+	breaker   *sourceCircuitBreaker
+	breakerMu sync.Mutex
 }
 
 // Singleton ScraperManager — scrapers are stateless HTTP clients, no need to recreate
@@ -69,6 +71,7 @@ func NewScraperManager() *ScraperManager {
 	globalScraperManagerOnce.Do(func() {
 		manager := &ScraperManager{
 			scrapers: make(map[ScraperType]UnifiedScraper),
+			breaker:  newSourceCircuitBreaker(),
 		}
 
 		// Initialize scrapers
@@ -112,18 +115,29 @@ func (sm *ScraperManager) searchSpecificScraper(query string, scraperType Scrape
 		return nil, fmt.Errorf("scraper type %v not found", scraperType)
 	}
 
-	util.Debug("Searching specific scraper", "scraper", sm.getScraperDisplayName(scraperType))
+	sourceName := sm.getScraperDisplayName(scraperType)
+	if diagnostic, retryAfter, open := sm.circuitOpenDiagnostic(scraperType); open {
+		util.Warn("Search source skipped", "source", sourceName, "diagnostic", diagnostic.UserMessage(), "retry_after", retryAfter.Round(time.Second))
+		return nil, fmt.Errorf("busca pulada em %s: %w", sourceName, diagnostic)
+	}
+
+	util.Debug("Searching specific scraper", "scraper", sourceName)
 
 	results, err := scraper.SearchAnime(query)
 	if err != nil {
-		return nil, fmt.Errorf("busca falhou em %s: %w", sm.getScraperDisplayName(scraperType), err)
+		diagnostic := DiagnoseError(sourceName, "search", err)
+		if sm.recordSourceFailure(scraperType, diagnostic) {
+			util.Warn("Source circuit breaker opened", "source", sourceName, "diagnostic", diagnostic.UserMessage())
+		}
+		return nil, fmt.Errorf("busca falhou em %s: %w", sourceName, diagnostic)
 	}
+	sm.recordSourceSuccess(scraperType)
 
 	// Add language tags
 	sm.tagResults(results, scraperType)
 
 	if len(results) > 0 {
-		util.Debug("Search completed", "scraper", sm.getScraperDisplayName(scraperType), "results", len(results))
+		util.Debug("Search completed", "scraper", sourceName, "results", len(results))
 	}
 
 	return results, nil
@@ -159,6 +173,14 @@ func (sm *ScraperManager) searchAllScrapersConcurrent(query string) ([]*models.A
 
 	// Launch all scrapers concurrently
 	for sType, scraper := range sm.scrapers {
+		sourceName := sm.getScraperDisplayName(sType)
+		if diagnostic, retryAfter, open := sm.circuitOpenDiagnostic(sType); open {
+			util.Warn("Search source skipped", "source", sourceName, "diagnostic", diagnostic.UserMessage(), "retry_after", retryAfter.Round(time.Second))
+			searchErrors = append(searchErrors, diagnostic.UserMessage())
+			searchSourceErrors = append(searchSourceErrors, fmt.Errorf("%s: %w", sourceName, diagnostic))
+			continue
+		}
+
 		wg.Add(1)
 		go func(st ScraperType, s UnifiedScraper) {
 			defer wg.Done()
@@ -185,13 +207,18 @@ func (sm *ScraperManager) searchAllScrapersConcurrent(query string) ([]*models.A
 			if res.err != nil {
 				errorsMutex.Lock()
 				sourceName := sm.getScraperDisplayName(res.scraperType)
-				util.Debug("Search error", "source", sourceName, "error", res.err)
-				searchErrors = append(searchErrors, fmt.Sprintf("%s: %v", sourceName, res.err))
-				searchSourceErrors = append(searchSourceErrors, fmt.Errorf("%s: %w", sourceName, res.err))
+				diagnostic := DiagnoseError(sourceName, "search", res.err)
+				util.Debug("Search error", "source", sourceName, "kind", diagnostic.Kind, "error", diagnostic)
+				if sm.recordSourceFailure(res.scraperType, diagnostic) {
+					util.Warn("Source circuit breaker opened", "source", sourceName, "diagnostic", diagnostic.UserMessage())
+				}
+				searchErrors = append(searchErrors, diagnostic.UserMessage())
+				searchSourceErrors = append(searchSourceErrors, fmt.Errorf("%s: %w", sourceName, diagnostic))
 				errorsMutex.Unlock()
 				continue
 			}
 
+			sm.recordSourceSuccess(res.scraperType)
 			if len(res.results) > 0 {
 				sm.tagResults(res.results, res.scraperType)
 				resultsMutex.Lock()
@@ -214,7 +241,7 @@ done:
 	errorsMutex.Lock()
 	if len(searchErrors) > 0 {
 		for _, errMsg := range searchErrors {
-			util.Warn("Search source unavailable", "details", errMsg)
+			util.Warn("Search source diagnostic", "details", errMsg)
 		}
 	}
 	errorsMutex.Unlock()

--- a/internal/scraper/unified_test.go
+++ b/internal/scraper/unified_test.go
@@ -56,6 +56,7 @@ func (m *MockScraper) GetType() ScraperType {
 func createTestManager(allAnimeMock, animefireMock *MockScraper) *ScraperManager {
 	manager := &ScraperManager{
 		scrapers: make(map[ScraperType]UnifiedScraper),
+		breaker:  newSourceCircuitBreaker(),
 	}
 	if allAnimeMock != nil {
 		allAnimeMock.scraperType = AllAnimeType


### PR DESCRIPTION
﻿## Summary

- Add source diagnostics to separate upstream outages, blocking/challenges, parser regressions, decrypt issues, expired download links, and internal bugs.
- Add source health checks that skip provider outages in CI but fail real parser/decrypt/internal regressions.
- Add a circuit breaker for repeated source outages and classify expired CDN download links.
- Document the test plan and safe Discord webhook path without adding secrets or webhook configuration.

## Validation

- `go test ./internal/scraper -count=1 -v`
- `go test ./internal/player -count=1 -v`
- `go test -tags sourcehealth -run TestSourceHealthLive -count=1 -v ./internal/scraper`
- `$env:CI='true'; go test ./... -count=1`
- `go vet ./...`
- `golangci-lint run --timeout=15m`
- `gosec ./...`
- `govulncheck ./...`
- `git diff --check`

## Live source health

- Healthy: AllAnime, Animefire.io, Goyabu, SuperFlix.
- Skipped as upstream unavailable: FlixHQ, SFlix, 9Anime returned Cloudflare 521.
