### PR TITLE
fix: keep AllAnime fast4speed direct fallback

### DIFF
--- a/docs/SCRAPING_INTEGRATION.md
+++ b/docs/SCRAPING_INTEGRATION.md
@@ -84,6 +84,26 @@ type UnifiedScraper interface {
 5. **Error Handling with Fallbacks**
 6. **Metadata Extraction**
 
+### AllAnime Provider Notes
+
+The AllAnime implementation follows the current `ani-cli` provider behavior for
+source resolution:
+
+- GraphQL requests use `https://api.allanime.day/api`.
+- Provider and playback requests use `https://allmanga.to` as the referer.
+- Encoded `/clock` source URLs are decoded with the ani-cli hex substitution
+  table and normalized to `/clock.json`.
+- `tools.fast4speed.rsvp` entries are treated as direct playable URLs. Some
+  shows expose this provider while the `/apivtwo/clock.json` providers return
+  server errors, so the resolver keeps the direct URL as a fallback instead of
+  requiring it to return a secondary JSON link list.
+
+Regression coverage:
+
+```bash
+go test ./internal/scraper -run TestProcessSourceURLsConcurrentFallsBackToFast4SpeedDirectSource -count=1
+```
+
 
 
 ### Command Equivalents

--- a/internal/api/allanime_enhanced.go
+++ b/internal/api/allanime_enhanced.go
@@ -106,6 +106,9 @@ func GetAllAnimeEpisodeURLDirect(anime *models.Anime, episodeNumber string, qual
 	if err != nil {
 		return "", nil, fmt.Errorf("failed to get episode URL: %w", err)
 	}
+	if referer, ok := metadata["referer"]; ok && referer != "" {
+		util.SetGlobalReferer(referer)
+	}
 
 	// Add additional metadata
 	metadata["navigator"] = "allanime"

--- a/internal/player/playvideo.go
+++ b/internal/player/playvideo.go
@@ -36,6 +36,25 @@ var ErrBackToDownloadOptions = errors.New("back to download options")
 // dubSubTagRe strips parenthesized dub/sub tags from anime names for display
 var dubSubTagRe = regexp.MustCompile(`\s*\((?i:Dublado|Legendado|SUB|DUB|Subbed|Dubbed)\)\s*`)
 
+const defaultHLSReferer = "https://streameeeeee.site/"
+
+func appendPlaybackRefererArgs(mpvArgs []string, videoURL string, isHLSStream bool) ([]string, string) {
+	lowerURL := strings.ToLower(strings.TrimSpace(videoURL))
+	if !strings.HasPrefix(lowerURL, "http://") && !strings.HasPrefix(lowerURL, "https://") {
+		return mpvArgs, ""
+	}
+
+	referer := util.GetGlobalReferer()
+	if referer == "" && isHLSStream {
+		referer = defaultHLSReferer
+	}
+	if referer == "" {
+		return mpvArgs, ""
+	}
+
+	return append(mpvArgs, fmt.Sprintf("--http-header-fields=Referer: %s", referer)), referer
+}
+
 // waitForVideoReady waits for the HLS video to be ready for playback
 // Returns true if video is ready, false if timeout
 func waitForVideoReady(socketPath string) bool {
@@ -350,17 +369,20 @@ func playVideo(
 		is9Anime = updater.GetAnime().Source == "9Anime"
 	}
 
-	if isHLSStream {
-		// Use the stored global referer if available (set by source-specific stream resolvers),
-		// otherwise fall back to the default referer for legacy sources
-		referer := util.GetGlobalReferer()
-		if referer == "" {
-			referer = "https://streameeeeee.site/"
+	mpvArgs, playbackReferer := appendPlaybackRefererArgs(mpvArgs, videoURL, isHLSStream)
+	if playbackReferer != "" {
+		if isHLSStream {
+			util.Debugf("HLS stream detected - Referer: %s", playbackReferer)
+		} else {
+			util.Debugf("HTTP stream detected - Referer: %s", playbackReferer)
 		}
-		mpvArgs = append(mpvArgs,
-			fmt.Sprintf("--http-header-fields=Referer: %s", referer),
-		)
-		util.Debugf("HLS stream detected - Referer: %s", referer)
+	}
+
+	if isHLSStream {
+		referer := playbackReferer
+		if referer == "" {
+			referer = defaultHLSReferer
+		}
 
 		// For 9Anime (and other Cloudflare-protected CDNs), route playback through
 		// yt-dlp with Chrome TLS impersonation to bypass Cloudflare fingerprint checks.

--- a/internal/player/playvideo_args_test.go
+++ b/internal/player/playvideo_args_test.go
@@ -1,0 +1,41 @@
+package player
+
+import (
+	"testing"
+
+	"github.com/alvarorichard/Goanime/internal/util"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAppendPlaybackRefererArgsAddsGlobalRefererForDirectHTTP(t *testing.T) {
+	restore := snapshotGlobalReferer()
+	defer restore()
+	util.SetGlobalReferer("https://allmanga.to")
+
+	args, referer := appendPlaybackRefererArgs(nil, "https://tools.fast4speed.rsvp//media9/videos/id/sub/4?v=22", false)
+
+	assert.Equal(t, "https://allmanga.to", referer)
+	assert.Contains(t, args, "--http-header-fields=Referer: https://allmanga.to")
+}
+
+func TestAppendPlaybackRefererArgsKeepsHLSFallbackReferer(t *testing.T) {
+	restore := snapshotGlobalReferer()
+	defer restore()
+	util.ClearGlobalReferer()
+
+	args, referer := appendPlaybackRefererArgs(nil, "https://cdn.example.com/master.m3u8", true)
+
+	assert.Equal(t, defaultHLSReferer, referer)
+	assert.Contains(t, args, "--http-header-fields=Referer: "+defaultHLSReferer)
+}
+
+func TestAppendPlaybackRefererArgsSkipsLocalFiles(t *testing.T) {
+	restore := snapshotGlobalReferer()
+	defer restore()
+	util.SetGlobalReferer("https://allmanga.to")
+
+	args, referer := appendPlaybackRefererArgs([]string{"--cache=yes"}, "/tmp/episode.mp4", false)
+
+	assert.Empty(t, referer)
+	assert.Equal(t, []string{"--cache=yes"}, args)
+}

--- a/internal/scraper/allanime.go
+++ b/internal/scraper/allanime.go
@@ -676,6 +676,16 @@ func (c *AllAnimeClient) processSourceURLsConcurrent(sourceURLs []string, qualit
 
 	for i, sourceURL := range sourceURLs {
 		go func(idx int, url string) {
+			if c.isDirectProviderURL(url) {
+				results <- result{
+					index:     idx,
+					sourceURL: url,
+					links: map[string]string{
+						"direct": url,
+					},
+				}
+				return
+			}
 
 			links, err := c.getLinks(url)
 			if err != nil {
@@ -776,6 +786,10 @@ func (c *AllAnimeClient) getPriorityScore(url string) int {
 		}
 	}
 	return 0
+}
+
+func (c *AllAnimeClient) isDirectProviderURL(sourceURL string) bool {
+	return strings.Contains(sourceURL, "tools.fast4speed.rsvp")
 }
 
 // extractSourceURLs extracts source URLs from the API response
@@ -905,8 +919,8 @@ func (c *AllAnimeClient) getLinks(sourceURL string) (map[string]string, error) {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
 
-	// Use the same headers as Curd for better compatibility
-	req.Header.Set("Referer", "https://allanime.to")
+	// Match ani-cli: AllAnime's current providers expect the allmanga referer.
+	req.Header.Set("Referer", c.referer)
 	req.Header.Set("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:109.0) Gecko/20100101 Firefox/121.0")
 
 	resp, err := c.client.Do(req) // #nosec G704
@@ -1076,6 +1090,13 @@ func (c *AllAnimeClient) selectQuality(links map[string]string, requestedQuality
 	if url, exists := links["hls"]; exists {
 		metadata["quality"] = "hls"
 		metadata["type"] = "m3u8"
+		return url, metadata
+	}
+
+	if url, exists := links["direct"]; exists {
+		metadata["quality"] = "direct"
+		metadata["type"] = "direct"
+		metadata["referer"] = c.referer
 		return url, metadata
 	}
 

--- a/internal/scraper/allanime_test.go
+++ b/internal/scraper/allanime_test.go
@@ -1369,7 +1369,7 @@ func TestGetLinksVerifiesRefererHeader(t *testing.T) {
 	defer server.Close()
 
 	_, _ = newTestClient(server.URL).getLinks(server.URL)
-	assert.Equal(t, "https://allanime.to", capturedReferer)
+	assert.Equal(t, AllAnimeReferer, capturedReferer)
 }
 
 // ---------------------------------------------------------------------------
@@ -1516,6 +1516,31 @@ func TestProcessSourceURLsConcurrentPartialFailure(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "https://cdn.example.com/720.mp4", url)
 	assert.Less(t, time.Since(startedAt), 2*time.Second, "successful fallback should not wait for the global timeout")
+}
+
+func TestProcessSourceURLsConcurrentFallsBackToFast4SpeedDirectSource(t *testing.T) {
+	t.Parallel()
+
+	failServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer failServer.Close()
+
+	client := newTestClient(failServer.URL)
+	directURL := "https://tools.fast4speed.rsvp//media9/videos/gHQe2eBBh57QdC9hZ/sub/1"
+
+	url, meta, err := client.processSourceURLsConcurrent(
+		[]string{failServer.URL + "/clock.json", directURL},
+		"worst", "gHQe2eBBh57QdC9hZ", "1",
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, directURL, url)
+	assert.Equal(t, "direct", meta["quality"])
+	assert.Equal(t, "direct", meta["type"])
+	assert.Equal(t, AllAnimeReferer, meta["referer"])
+	assert.Equal(t, "gHQe2eBBh57QdC9hZ", meta["anime_id"])
+	assert.Equal(t, "1", meta["episode"])
 }
 
 func TestProcessSourceURLsConcurrentHighPriorityWins(t *testing.T) {


### PR DESCRIPTION
## Summary
- match ani-cli by treating tools.fast4speed.rsvp AllAnime sources as direct playable URLs
- use the current allmanga referer for AllAnime provider link requests and propagate direct-source referer to playback/download
- document the AllAnime provider behavior and add regression coverage for the reported fallback path

## Validation
- go test ./internal/scraper -run TestProcessSourceURLsConcurrentFallsBackToFast4SpeedDirectSource -count=1 -v
- go test ./internal/download ./internal/downloader/... ./internal/player ./internal/scraper ./internal/api -count=1
- live probe: The Angel Next Door Spoils Me Rotten ep. 1 resolves to tools.fast4speed.rsvp with referer https://allmanga.to