### PR TITLE
chore: use English source diagnostics

### DIFF
--- a/docs/source-diagnostics-test-plan.md
+++ b/docs/source-diagnostics-test-plan.md
@@ -1,19 +1,19 @@
-# Source diagnostics test plan
+# Source Diagnostics Test Plan
 
-Este roteiro ajuda a separar indisponibilidade da source de bug no GoAnime.
+This checklist helps separate provider downtime from GoAnime bugs.
 
-## Objetivo
+## Goal
 
-- `SourceUnavailable`: 521, 522, 523, 524, 530, DNS error, timeout de conexao ou origem fora devem virar skip no health check.
-- `BlockedOrChallenge`: 403, 429, 1020, captcha ou challenge devem virar skip no health check.
-- `ParserBroken`: resposta 200 OK sem seletores, JSON ou resultados esperados deve falhar no health check.
-- `DecryptBroken`: decrypt/API retornou formato invalido deve falhar no health check.
-- `DownloadExpired`: link CDN extraido retornou 403/404 deve ser diagnosticado como link expirado.
-- `InternalBug`: panic, nil pointer, loop infinito ou erro local deve falhar.
+- `SourceUnavailable`: 521, 522, 523, 524, 530, DNS errors, connection timeouts, or origin outages should skip the health check.
+- `BlockedOrChallenge`: 403, 429, 1020, captcha, or challenge pages should skip the health check.
+- `ParserBroken`: 200 OK responses without expected selectors, JSON, or results should fail the health check.
+- `DecryptBroken`: decrypt/API responses with invalid payloads should fail the health check.
+- `DownloadExpired`: extracted CDN links returning 403/404 should be diagnosed as expired links.
+- `InternalBug`: panics, nil pointers, infinite loops, or local logic errors should fail.
 
-## Comandos locais
+## Local Commands
 
-Rode estes comandos antes de abrir ou atualizar a PR:
+Run these commands before opening or updating the PR:
 
 ```powershell
 go test ./internal/scraper -count=1 -v
@@ -27,37 +27,37 @@ govulncheck ./...
 git diff --check
 ```
 
-## Health check live
+## Live Health Check
 
-O teste `TestSourceHealthLive` faz uma busca conhecida por provider:
+`TestSourceHealthLive` runs a known search for each provider:
 
-- Anime/geral: `naruto`
-- Filmes/series: `dexter`
+- Anime/general providers: `naruto`
+- Movie/TV providers: `dexter`
 
-Resultado esperado:
+Expected behavior:
 
-- Source offline, Cloudflare 521/522/523/524/530, DNS ou timeout: `t.Skip`.
+- Source offline, Cloudflare 521/522/523/524/530, DNS, or timeout: `t.Skip`.
 - Captcha, challenge, 403/429/1020: `t.Skip`.
-- 200 OK com parser quebrado ou zero resultados para query conhecida: `t.Fatal`.
-- Decrypt quebrado ou erro interno: `t.Fatal`.
+- 200 OK with a broken parser or zero results for a known query: `t.Fatal`.
+- Broken decrypt or internal app error: `t.Fatal`.
 
-## App e logs
+## App Logs
 
-Mensagens esperadas:
+Expected messages:
 
-- `FlixHQ temporariamente indisponivel: Cloudflare 521/origem fora`
-- `SFlix bloqueou a requisicao: captcha/challenge`
-- `Goyabu respondeu, mas o parser nao encontrou os dados esperados`
-- `Download link de download expirou ou foi negado: HTTP 404`
+- `FlixHQ temporarily unavailable: Cloudflare 521/origin down`
+- `SFlix blocked the request: captcha/challenge`
+- `Goyabu responded, but the parser did not find the expected data`
+- `Download link expired or was rejected: HTTP 404`
 
-Depois de 3 falhas consecutivas de origem/bloqueio, o circuit breaker pula a source por 10 minutos para evitar martelar servidor fora.
+After 3 consecutive origin/block failures, the circuit breaker skips the source for 10 minutes to avoid hammering a dead provider.
 
 ## Discord
 
-O projeto ja possui Discord Rich Presence local, mas isso nao e a mesma coisa que alertas de saude do projeto. Para publicar diagnosticos em um canal do Discord com seguranca, use uma PR separada com:
+The project already has local Discord Rich Presence, but that is not the same as project health alerts. To publish diagnostics to a Discord channel safely, use a separate PR with:
 
-- `DISCORD_WEBHOOK_URL` configurado como GitHub secret.
-- Um job agendado ou manual que rode `go test -tags sourcehealth -run TestSourceHealthLive -count=1 -v ./internal/scraper`.
-- Um passo que envie apenas o resumo de sources `healthy`, `skipped` e `failed`, sem expor tokens, cookies ou URLs privadas.
+- `DISCORD_WEBHOOK_URL` configured as a GitHub secret.
+- A scheduled or manual job that runs `go test -tags sourcehealth -run TestSourceHealthLive -count=1 -v ./internal/scraper`.
+- A step that sends only a summary of `healthy`, `skipped`, and `failed` sources, without exposing tokens, cookies, or private URLs.
 
-Sem esse secret configurado, a opcao segura e manter as informacoes no log do CI e no output local.
+Without that secret configured, the safe option is to keep diagnostics in CI logs and local debug output.

--- a/internal/scraper/source_diagnostic.go
+++ b/internal/scraper/source_diagnostic.go
@@ -113,10 +113,14 @@ func (d *SourceDiagnostic) UserMessage() string {
 	case DiagnosticDecryptBroken:
 		return fmt.Sprintf("%s decrypt failed: format or key may have changed", source)
 	case DiagnosticDownloadExpired:
-		if d.StatusCode > 0 {
-			return fmt.Sprintf("%s download link expired or was rejected: HTTP %d", source, d.StatusCode)
+		downloadSubject := source + " download link"
+		if strings.EqualFold(source, "download") {
+			downloadSubject = "Download link"
 		}
-		return fmt.Sprintf("%s download link expired or was rejected", source)
+		if d.StatusCode > 0 {
+			return fmt.Sprintf("%s expired or was rejected: HTTP %d", downloadSubject, d.StatusCode)
+		}
+		return fmt.Sprintf("%s expired or was rejected", downloadSubject)
 	case DiagnosticInternalBug:
 		return fmt.Sprintf("%s internal app error: %s", source, d.reason())
 	default:

--- a/internal/scraper/source_diagnostic_test.go
+++ b/internal/scraper/source_diagnostic_test.go
@@ -25,6 +25,7 @@ func TestNewHTTPStatusErrorClassifiesCloudflareOriginDown(t *testing.T) {
 	assert.True(t, errors.Is(err, ErrSourceUnavailable))
 	assert.True(t, diagnostic.ShouldSkipHealthCheck())
 	assert.Contains(t, diagnostic.UserMessage(), "Cloudflare 521")
+	assert.Contains(t, diagnostic.UserMessage(), "temporarily unavailable")
 }
 
 func TestNewHTTPStatusErrorClassifiesBlockedChallenge(t *testing.T) {
@@ -62,6 +63,17 @@ func TestDiagnoseErrorClassifiesTimeoutAsSourceUnavailable(t *testing.T) {
 	assert.Equal(t, DiagnosticSourceUnavailable, diagnostic.Kind)
 	assert.True(t, errors.Is(diagnostic, ErrSourceUnavailable))
 	assert.True(t, diagnostic.ShouldSkipHealthCheck())
+}
+
+func TestDownloadExpiredUserMessageUsesEnglish(t *testing.T) {
+	t.Parallel()
+
+	err := NewDownloadExpiredError("Download", "http", http.StatusNotFound, errors.New("404 Not Found"))
+	diagnostic := DiagnoseError("Download", "http", err)
+
+	require.NotNil(t, diagnostic)
+	assert.Equal(t, DiagnosticDownloadExpired, diagnostic.Kind)
+	assert.Equal(t, "Download link expired or was rejected: HTTP 404", diagnostic.UserMessage())
 }
 
 func TestSourceCircuitBreakerSkipsAfterRepeatedOriginFailures(t *testing.T) {

--- a/internal/scraper/unified.go
+++ b/internal/scraper/unified.go
@@ -118,7 +118,7 @@ func (sm *ScraperManager) searchSpecificScraper(query string, scraperType Scrape
 	sourceName := sm.getScraperDisplayName(scraperType)
 	if diagnostic, retryAfter, open := sm.circuitOpenDiagnostic(scraperType); open {
 		util.Warn("Search source skipped", "source", sourceName, "diagnostic", diagnostic.UserMessage(), "retry_after", retryAfter.Round(time.Second))
-		return nil, fmt.Errorf("busca pulada em %s: %w", sourceName, diagnostic)
+		return nil, fmt.Errorf("search skipped in %s: %w", sourceName, diagnostic)
 	}
 
 	util.Debug("Searching specific scraper", "scraper", sourceName)
@@ -129,7 +129,7 @@ func (sm *ScraperManager) searchSpecificScraper(query string, scraperType Scrape
 		if sm.recordSourceFailure(scraperType, diagnostic) {
 			util.Warn("Source circuit breaker opened", "source", sourceName, "diagnostic", diagnostic.UserMessage())
 		}
-		return nil, fmt.Errorf("busca falhou em %s: %w", sourceName, diagnostic)
+		return nil, fmt.Errorf("search failed in %s: %w", sourceName, diagnostic)
 	}
 	sm.recordSourceSuccess(scraperType)
 

--- a/internal/scraper/unified_test.go
+++ b/internal/scraper/unified_test.go
@@ -514,7 +514,7 @@ func TestSearchAnime_SpecificScraper_Fails(t *testing.T) {
 
 	require.Error(t, err)
 	assert.Nil(t, results)
-	assert.Contains(t, err.Error(), "busca falhou")
+	assert.Contains(t, err.Error(), "search failed")
 	assert.Contains(t, err.Error(), "Cloudflare challenge")
 }
 


### PR DESCRIPTION
## Summary
- Keep source diagnostics and the source diagnostics test plan in English.
- Preserve the current `dev` wording while avoiding awkward `Download download link...` output.
- Translate specific-source search wrapper errors to `search skipped` / `search failed`.

## Validation
- `go test -tags sourcehealth -run TestSourceHealthLive -count=1 -v ./internal/scraper`
- `CI=true go test ./... -count=1`
- `go vet ./...`
- `golangci-lint run --timeout=15m`
- `gosec ./...`
- `govulncheck ./...`
- `git diff --check upstream/dev...HEAD`