### PR TITLE
test: add deterministic QA versioning coverage

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -1,0 +1,3 @@
+---
+exclude_paths:
+  - "test/e2e/**"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,10 @@ jobs:
         shell: bash
         run: go test -race -v -coverprofile=coverage.out ./...
 
+      - name: Run deterministic E2E tests
+        shell: bash
+        run: go test -tags e2e -count=1 -v ./test/e2e
+
       - name: Run source health diagnostics
         if: runner.os == 'Linux'
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,10 @@ jobs:
           args: --timeout=15m
 
       - name: Run tests
-        run: go test -v -race -coverprofile=coverage.out -covermode=atomic ./... || true
+        run: go test -v -race -coverprofile=coverage.out -covermode=atomic ./...
+
+      - name: Run deterministic E2E tests
+        run: go test -tags e2e -count=1 -v ./test/e2e
 
       - name: Check test coverage
         run: |

--- a/docs/QA_E2E_VERSIONING.md
+++ b/docs/QA_E2E_VERSIONING.md
@@ -47,7 +47,7 @@ The QA agent is responsible for each version:
 
 Minimum commands before creating a tag:
 
-```powershell
+```bash
 go mod verify
 go fmt ./...
 go vet ./...
@@ -67,7 +67,7 @@ publishing. A deterministic failure blocks release.
 
 Command:
 
-```powershell
+```bash
 go test -tags e2e -count=1 -v ./test/e2e
 ```
 
@@ -84,6 +84,11 @@ Current coverage:
 
 The suite avoids real scraping, real downloads, opening `mpv`, and video
 processing. This keeps the gate reliable for CI and release.
+
+The E2E binary is built with `CGO_ENABLED=0`. Real SQLite tracking coverage
+stays in the unit suite at `internal/tracking/local_test.go`; the deterministic
+E2E gate only validates the no-CGO contract covered by
+`internal/tracking/local_nocgo_test.go`.
 
 ## Complementary offline tests
 
@@ -103,7 +108,7 @@ for skips accepted during live QA.
 
 Use this when preparing a version or investigating provider failures:
 
-```powershell
+```bash
 go test -tags sourcehealth -run TestSourceHealthLive -count=1 -v ./internal/scraper
 go test -tags integration -run TestFlixHQFullFlow -count=1 -v ./internal/api
 go test ./pkg/goanime -run Integration -count=1 -v

--- a/docs/QA_E2E_VERSIONING.md
+++ b/docs/QA_E2E_VERSIONING.md
@@ -1,0 +1,172 @@
+# QA E2E versioning gate
+
+This guide defines the QA role for GoAnime versioning. The work is split into
+two blocks: a deterministic suite that blocks releases, and a live/manual pass
+that validates external sources before publishing a version.
+
+## PM + QA acceptance criteria
+
+A version can only be promoted when the deterministic gate passes, the live pass
+is classified, and every exception has explicit PM + QA approval.
+
+Release blockers:
+
+- Panic, deadlock, crash, or fatal error during CLI/TUI initialization.
+- Argument parsing failure or command routing regression for primary commands.
+- Failure in the standard Go suite, lint, vet, security scan, or deterministic
+  E2E suite.
+- Search, selection, playback/download, or tracking failure when covered by
+  mocks, fixtures, or a controlled environment.
+- Binary build failure or artifact/checksum generation failure.
+- Writes outside temporary directories during automated tests.
+- External 200 OK response with broken parser/decrypt logic, nil pointer, panic,
+  or internal contract regression.
+
+Can be skipped without blocking release when recorded:
+
+- DNS, timeout, Cloudflare, captcha, rate limit, or external provider outage.
+- Discord RPC unavailable or no valid local Discord session.
+- Missing `mpv`, `ffmpeg`, GPU, or codec when the test is live/optional.
+- Performance differences caused by hardware, network, or external environment.
+
+Safety rule: an external skip is acceptable only when equivalent local coverage
+exists for GoAnime's main contract. Internal failures must not be reclassified as
+skips to unblock release.
+
+## QA agent
+
+The QA agent is responsible for each version:
+
+- Run the existing unit and integration tests.
+- Run the deterministic CLI E2E suite.
+- Run static analysis and security checks.
+- Run live source diagnostics when network access is available.
+- Record failures, external skips, and build evidence.
+
+## Required versioning gate
+
+Minimum commands before creating a tag:
+
+```powershell
+go mod verify
+go fmt ./...
+go vet ./...
+golangci-lint run --timeout=15m
+gosec ./...
+govulncheck ./...
+go test -v -race -coverprofile=coverage.out -covermode=atomic ./...
+go test -tags e2e -count=1 -v ./test/e2e
+go build -v ./cmd/goanime
+```
+
+The release workflow must run at least dependency verification, lint, Go tests
+with race, deterministic E2E, binary build, and artifact checksums before
+publishing. A deterministic failure blocks release.
+
+## Deterministic E2E suite
+
+Command:
+
+```powershell
+go test -tags e2e -count=1 -v ./test/e2e
+```
+
+Current coverage:
+
+| Area | Covered journey |
+| --- | --- |
+| CLI | `--help`, `-h`, `--version`, invalid input, and pre-network validation |
+| Playback | direct search route and media preferences |
+| Anime downloads | single episode, range, all episodes, source, quality, and custom output |
+| Movie/TV downloads | movie, TV episode, TV range, and all seasons |
+| Upscale | full image parse with output, scale, passes, fast mode, workers, missing `ffmpeg`, and `ffmpeg` shim |
+| Release | local build of the real binary used by smoke tests |
+
+The suite avoids real scraping, real downloads, opening `mpv`, and video
+processing. This keeps the gate reliable for CI and release.
+
+## Complementary offline tests
+
+In addition to the opt-in E2E package, composed flows now have deterministic
+contracts with fakes inside their source packages:
+
+| Package | Flows covered without network or real tools |
+| --- | --- |
+| `internal/handlers` | download delegation, movie download delegation, update, image upscale, `ffmpeg` validation, series playback, movie/single episode playback, and `ErrBackToSearch` recovery |
+| `internal/download` | anime single episode, all with `ErrUserQuit`, range with legacy fallback, 9Anime range, movie redirect, and movie/TV download without interactive selection |
+| `internal/tracking` | `!cgo` contract: local tracker does not initialize SQLite, does not create a database, and returns `ErrTrackerNotInited` nil-safely |
+
+These tests should run with `go test ./...` and act as local equivalent coverage
+for skips accepted during live QA.
+
+## Live QA pass
+
+Use this when preparing a version or investigating provider failures:
+
+```powershell
+go test -tags sourcehealth -run TestSourceHealthLive -count=1 -v ./internal/scraper
+go test -tags integration -run TestFlixHQFullFlow -count=1 -v ./internal/api
+go test ./pkg/goanime -run Integration -count=1 -v
+```
+
+Expected classifications:
+
+- Source outage, Cloudflare, DNS, timeout, captcha, or rate limit: record as
+  `skip`/external outage.
+- 200 response without expected data, broken parser, or broken decrypt:
+  blocking failure.
+- Panics, nil pointers, and local errors: blocking failure.
+- For a complete release, require at least one healthy anime source and one
+  healthy movie/TV source. Otherwise, PM must explicitly approve a degraded
+  release in the release note.
+
+Live tests may retry once to confirm external instability. If the failure
+continues, QA records it as `external skip` or `blocking failure` according to
+the classification above.
+
+## Required evidence
+
+For each release candidate, record in the PR, tag, or release note:
+
+- Tested hash, branch, or tag.
+- `go version`, operating system, and architecture.
+- CI/release workflow links.
+- Summarized output from required commands.
+- `coverage.out` or coverage summary.
+- Deterministic E2E suite result.
+- Live provider report: `healthy`, `external skip`, or `blocking failure`.
+- Generated artifacts and checksums.
+- Reason for each skip and PM/QA decision for every accepted risk.
+- Confirmation that tests did not write outside temporary directories.
+
+## First complete-pass checklist
+
+1. Environment: confirm `go version`, `mpv --version`, and, when applicable,
+   `ffmpeg -version`.
+2. Local quality: `go fmt ./...`, `go vet ./...`, `golangci-lint run --timeout=15m`.
+3. Security: `gosec ./...` and `govulncheck ./...`.
+4. Tests: `go test -v -race -coverprofile=coverage.out -covermode=atomic ./...`.
+5. Deterministic E2E: `go test -tags e2e -count=1 -v ./test/e2e`.
+6. Live sources: run source health and integrations when the network is stable.
+7. Build: generate binaries/installer through workflow or build scripts.
+8. Evidence: attach commands, status, coverage, and every external skip to the
+   PR or release note.
+
+## Exception policy
+
+A release can continue with skips or non-blocking failures only if:
+
+- The risk is classified as an external dependency or optional capability.
+- Critical flows remain covered by deterministic local tests.
+- There is a follow-up issue or record when applicable.
+- PM + QA explicitly approved the exception.
+
+## Next increments
+
+- Add a temporary `mpv` shim to E2E to validate playback handoff without opening
+  a real player.
+- Add HTTP mock servers to cover search-to-episode-to-stream without depending
+  on third-party sites.
+- Add a SQLite tracking test with CGO using a temporary database.
+- Keep `sourcehealth` as a manual/scheduled job or release-candidate step,
+  separate from mandatory PR checks when the outage is external.

--- a/internal/download/workflow.go
+++ b/internal/download/workflow.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
 	"strconv"
 	"strings"
 
@@ -657,55 +656,4 @@ func extractIDFromURL(urlStr string) string {
 		return parts[len(parts)-1]
 	}
 	return ""
-}
-
-// ExampleMovieDownload demonstrates movie download
-func ExampleMovieDownload() {
-	// Command: goanime -dm "Inception"
-	// This would create a DownloadRequest like:
-	request := &util.DownloadRequest{
-		AnimeName: "Inception",
-		IsMovie:   true,
-		Quality:   "1080",
-	}
-
-	if err := HandleMovieDownloadRequest(request); err != nil {
-		log.Printf("Movie download failed: %v", err)
-	}
-}
-
-// ExampleTVDownload demonstrates TV episode download
-func ExampleTVDownload() {
-	// Command: goanime -dm --type tv "Breaking Bad" 1 1
-	// This would create a DownloadRequest like:
-	request := &util.DownloadRequest{
-		AnimeName:  "Breaking Bad",
-		IsTV:       true,
-		SeasonNum:  1,
-		EpisodeNum: 1,
-		Quality:    "1080",
-	}
-
-	if err := HandleMovieDownloadRequest(request); err != nil {
-		log.Printf("TV download failed: %v", err)
-	}
-}
-
-// ExampleTVRangeDownload demonstrates TV episode range download
-func ExampleTVRangeDownload() {
-	// Command: goanime -dm -r "Game of Thrones" 1 1-5
-	// This would create a DownloadRequest like:
-	request := &util.DownloadRequest{
-		AnimeName:    "Game of Thrones",
-		IsTV:         true,
-		IsRange:      true,
-		SeasonNum:    1,
-		StartEpisode: 1,
-		EndEpisode:   5,
-		Quality:      "1080",
-	}
-
-	if err := HandleMovieDownloadRequest(request); err != nil {
-		log.Printf("TV range download failed: %v", err)
-	}
 }

--- a/internal/download/workflow.go
+++ b/internal/download/workflow.go
@@ -15,11 +15,64 @@ import (
 	"github.com/alvarorichard/Goanime/internal/api/providers/metadata"
 	"github.com/alvarorichard/Goanime/internal/appflow"
 	"github.com/alvarorichard/Goanime/internal/downloader"
+	"github.com/alvarorichard/Goanime/internal/models"
 	"github.com/alvarorichard/Goanime/internal/player"
 	"github.com/alvarorichard/Goanime/internal/scraper"
 	"github.com/alvarorichard/Goanime/internal/tui"
 	"github.com/alvarorichard/Goanime/internal/util"
 	"github.com/ktr0731/go-fuzzyfinder"
+)
+
+type episodeDownloader interface {
+	DownloadAllEpisodes() error
+	DownloadEpisodeRange(startEp, endEp int) error
+	DownloadSingleEpisode(episodeNum int) error
+}
+
+type nineAnimeDownloader interface {
+	DownloadAllEpisodes(anime *models.Anime) error
+	DownloadEpisodeRange(anime *models.Anime, startEp, endEp int) error
+	DownloadSingleEpisode(anime *models.Anime, episodeNum int) error
+}
+
+type movieDownloader interface {
+	DownloadMovie(media *models.Anime) error
+	DownloadTVEpisode(media *models.Anime, seasonNum, episodeNum int) error
+	DownloadTVEpisodeRange(media *models.Anime, seasonNum, startEp, endEp int) error
+	DownloadAllSeasons(media *models.Anime) error
+}
+
+type mediaCatalog interface {
+	SearchMoviesAndTV(query string) ([]*scraper.FlixHQMedia, error)
+	GetTVSeasons(mediaID string) ([]scraper.FlixHQSeason, error)
+	GetTVEpisodes(seasonID string) ([]scraper.FlixHQEpisode, error)
+}
+
+var (
+	searchAnimeWithRetry         = appflow.SearchAnimeWithRetry
+	getAnimeEpisodesEnhanced     = api.GetAnimeEpisodesEnhanced
+	getAnimeEpisodesLegacy       = appflow.GetAnimeEpisodesLegacy
+	downloadAllAnimeSmartRange   = api.DownloadAllAnimeSmartRange
+	downloadEpisodeRangeEnhanced = api.DownloadEpisodeRangeEnhanced
+	handleBatchDownload          = player.HandleBatchDownload
+	handleBatchDownloadRange     = player.HandleBatchDownloadRange
+	handleMovieDownloadWorkflow  = HandleMovieDownloadRequest
+	enrichAnimeMetadata          = func(ctx context.Context, anime *models.Anime) ([]metadata.SeasonMapping, error) {
+		return metadata.NewEnricher().EnrichAnime(ctx, anime)
+	}
+	enrichMovieMedia              = movie.EnrichMedia
+	newEpisodeDownloaderWithAnime = func(episodes []models.Episode, animeURL string, anime *models.Anime) episodeDownloader {
+		return downloader.NewEpisodeDownloaderWithAnime(episodes, animeURL, anime)
+	}
+	newNineAnimeDownloader = func(config downloader.NineAnimeDownloadConfig) nineAnimeDownloader {
+		return downloader.NewNineAnimeDownloader(config)
+	}
+	newMediaManager = func() mediaCatalog {
+		return scraper.NewMediaManager()
+	}
+	newMovieDownloaderWithConfig = func(config downloader.MovieDownloadConfig) movieDownloader {
+		return downloader.NewMovieDownloaderWithConfig(config)
+	}
 )
 
 // HandleDownloadRequest processes a download request from command line
@@ -36,7 +89,7 @@ func HandleDownloadRequest(request *util.DownloadRequest) error {
 	util.Infof("Using source: %s, quality: %s", source, quality)
 
 	// Try enhanced search with retry logic
-	anime, err := appflow.SearchAnimeWithRetry(request.AnimeName)
+	anime, err := searchAnimeWithRetry(request.AnimeName)
 	if err != nil {
 		util.Errorf("Failed to search for anime: %v", err)
 		return err
@@ -62,8 +115,7 @@ func HandleDownloadRequest(request *util.DownloadRequest) error {
 	})
 
 	// Enrich with AniList metadata for per-episode season resolution
-	enricher := metadata.NewEnricher()
-	seasonMap, _ := enricher.EnrichAnime(context.Background(), anime)
+	seasonMap, _ := enrichAnimeMetadata(context.Background(), anime)
 	player.SetSeasonMap(seasonMap)
 
 	// Update metadata after enrichment (AniList may have populated IDs)
@@ -87,14 +139,14 @@ func HandleDownloadRequest(request *util.DownloadRequest) error {
 			SubsLanguage: request.SubsLanguage,
 			OutputDir:    request.OutputDir,
 		}
-		return HandleMovieDownloadRequest(movieRequest)
+		return handleMovieDownloadWorkflow(movieRequest)
 	}
 
 	// If this is 9Anime content, use the dedicated 9anime downloader
 	// 9Anime episodes use data-id based resolution that is incompatible with legacy downloaders
 	if anime.Source == "9Anime" {
 		util.Infof("Detected 9Anime content: %s — using 9Anime downloader", anime.Name)
-		nad := downloader.NewNineAnimeDownloader(downloader.NineAnimeDownloadConfig{
+		nad := newNineAnimeDownloader(downloader.NineAnimeDownloadConfig{
 			AnimeName:    anime.Name,
 			Quality:      quality,
 			OutputDir:    request.OutputDir,
@@ -119,9 +171,9 @@ func HandleDownloadRequest(request *util.DownloadRequest) error {
 		util.Infof("Downloading ALL episodes of %s", anime.Name)
 
 		// Try enhanced episode fetch first, fallback to legacy
-		eps, err := api.GetAnimeEpisodesEnhanced(anime)
+		eps, err := getAnimeEpisodesEnhanced(anime)
 		if err == nil && len(eps) > 0 {
-			dlErr := player.HandleBatchDownload(eps, anime)
+			dlErr := handleBatchDownload(eps, anime)
 			if dlErr == nil || errors.Is(dlErr, player.ErrUserQuit) {
 				return nil
 			}
@@ -131,11 +183,11 @@ func HandleDownloadRequest(request *util.DownloadRequest) error {
 		}
 
 		// Fallback to legacy downloader
-		episodes, legacyErr := appflow.GetAnimeEpisodesLegacy(anime.URL)
+		episodes, legacyErr := getAnimeEpisodesLegacy(anime.URL)
 		if legacyErr != nil {
 			return fmt.Errorf("failed to fetch episodes: %w", legacyErr)
 		}
-		dl := downloader.NewEpisodeDownloaderWithAnime(episodes, anime.URL, anime)
+		dl := newEpisodeDownloaderWithAnime(episodes, anime.URL, anime)
 		return dl.DownloadAllEpisodes()
 	}
 
@@ -147,9 +199,9 @@ func HandleDownloadRequest(request *util.DownloadRequest) error {
 		if request.AllAnimeSmart && (anime.Source == "AllAnime" || source == "allanime" || source == "AllAnime") {
 			util.Info("AllAnime Smart Range enabled: mirror priority + AniSkip integration + progress UI")
 			// Use player batch downloader with provided range to get consistent progress UI
-			eps, err := api.GetAnimeEpisodesEnhanced(anime)
+			eps, err := getAnimeEpisodesEnhanced(anime)
 			if err == nil && len(eps) > 0 {
-				dlErr := player.HandleBatchDownloadRange(eps, anime, request.StartEpisode, request.EndEpisode)
+				dlErr := handleBatchDownloadRange(eps, anime, request.StartEpisode, request.EndEpisode)
 				if dlErr == nil || errors.Is(dlErr, player.ErrUserQuit) {
 					return nil
 				}
@@ -158,17 +210,17 @@ func HandleDownloadRequest(request *util.DownloadRequest) error {
 			} else if err != nil {
 				util.Infof("Enhanced episodes fetch failed for progress path: %v", err)
 			}
-			if err := api.DownloadAllAnimeSmartRange(anime, request.StartEpisode, request.EndEpisode, quality); err != nil {
+			if err := downloadAllAnimeSmartRange(anime, request.StartEpisode, request.EndEpisode, quality); err != nil {
 				util.Errorf("AllAnime Smart Range failed: %v", err)
 				// Fallback to normal enhanced
-				if err := api.DownloadEpisodeRangeEnhanced(anime, request.StartEpisode, request.EndEpisode, quality); err != nil {
+				if err := downloadEpisodeRangeEnhanced(anime, request.StartEpisode, request.EndEpisode, quality); err != nil {
 					util.Infof("Enhanced download failed, falling back to legacy: %v", err)
 					// Fallback to legacy downloader
-					episodes, legacyErr := appflow.GetAnimeEpisodesLegacy(anime.URL)
+					episodes, legacyErr := getAnimeEpisodesLegacy(anime.URL)
 					if legacyErr != nil {
 						return fmt.Errorf("legacy episode fetch also failed: %w", legacyErr)
 					}
-					dl := downloader.NewEpisodeDownloaderWithAnime(episodes, anime.URL, anime)
+					dl := newEpisodeDownloaderWithAnime(episodes, anime.URL, anime)
 					return dl.DownloadEpisodeRange(request.StartEpisode, request.EndEpisode)
 				}
 				return nil
@@ -177,9 +229,9 @@ func HandleDownloadRequest(request *util.DownloadRequest) error {
 		}
 
 		// Try batch downloader with progress UI first (works for AllAnime and other sources)
-		eps, err := api.GetAnimeEpisodesEnhanced(anime)
+		eps, err := getAnimeEpisodesEnhanced(anime)
 		if err == nil && len(eps) > 0 {
-			dlErr := player.HandleBatchDownloadRange(eps, anime, request.StartEpisode, request.EndEpisode)
+			dlErr := handleBatchDownloadRange(eps, anime, request.StartEpisode, request.EndEpisode)
 			if dlErr == nil || errors.Is(dlErr, player.ErrUserQuit) {
 				return nil
 			}
@@ -188,11 +240,11 @@ func HandleDownloadRequest(request *util.DownloadRequest) error {
 			util.Infof("Enhanced episodes fetch failed: %v", err)
 		}
 		// Fallback to legacy downloader
-		episodes, legacyErr := appflow.GetAnimeEpisodesLegacy(anime.URL)
+		episodes, legacyErr := getAnimeEpisodesLegacy(anime.URL)
 		if legacyErr != nil {
 			return fmt.Errorf("failed to fetch episodes: %w", legacyErr)
 		}
-		dl := downloader.NewEpisodeDownloaderWithAnime(episodes, anime.URL, anime)
+		dl := newEpisodeDownloaderWithAnime(episodes, anime.URL, anime)
 		return dl.DownloadEpisodeRange(request.StartEpisode, request.EndEpisode)
 	} else {
 		util.Infof("Downloading episode %d of %s",
@@ -200,11 +252,11 @@ func HandleDownloadRequest(request *util.DownloadRequest) error {
 
 		// Enhanced download is a placeholder - use legacy downloader
 		util.Infof("Using legacy downloader for episode %d", request.EpisodeNum)
-		episodes, legacyErr := appflow.GetAnimeEpisodesLegacy(anime.URL)
+		episodes, legacyErr := getAnimeEpisodesLegacy(anime.URL)
 		if legacyErr != nil {
 			return fmt.Errorf("failed to fetch episodes: %w", legacyErr)
 		}
-		dl := downloader.NewEpisodeDownloaderWithAnime(episodes, anime.URL, anime)
+		dl := newEpisodeDownloaderWithAnime(episodes, anime.URL, anime)
 		return dl.DownloadSingleEpisode(request.EpisodeNum)
 	}
 }
@@ -259,7 +311,7 @@ func HandleMovieDownloadRequest(request *util.DownloadRequest) error {
 	util.Infof("Searching for: %s (quality: %s)", request.AnimeName, quality)
 
 	// Create media manager and search
-	mediaManager := scraper.NewMediaManager()
+	mediaManager := newMediaManager()
 	results, err := mediaManager.SearchMoviesAndTV(request.AnimeName)
 	if err != nil {
 		return fmt.Errorf("failed to search for movie/TV: %w", err)
@@ -282,7 +334,7 @@ func HandleMovieDownloadRequest(request *util.DownloadRequest) error {
 	// Enrich with TMDB/OMDb metadata to get official title, year, and external IDs.
 	// This is essential for Plex/Jellyfin-compatible folder naming — without it,
 	// folders use the scraped (often localized) name instead of the official title.
-	if err := movie.EnrichMedia(anime); err != nil {
+	if err := enrichMovieMedia(anime); err != nil {
 		util.Debugf("TMDB/OMDb enrichment failed (non-critical): %v", err)
 	}
 
@@ -305,7 +357,7 @@ func HandleMovieDownloadRequest(request *util.DownloadRequest) error {
 	})
 
 	// Create movie downloader
-	md := downloader.NewMovieDownloaderWithConfig(downloader.MovieDownloadConfig{
+	md := newMovieDownloaderWithConfig(downloader.MovieDownloadConfig{
 		Quality:      scraper.Quality(quality),
 		SubsLanguage: subsLanguage,
 		Provider:     "Vidcloud",
@@ -513,7 +565,7 @@ func selectMovieFromResults(results []*scraper.FlixHQMedia, preferMovie, preferT
 }
 
 // selectSeason presents a selection UI for TV seasons
-func selectSeason(mm *scraper.MediaManager, mediaID string) (int, error) {
+func selectSeason(mm mediaCatalog, mediaID string) (int, error) {
 	seasons, err := mm.GetTVSeasons(mediaID)
 	if err != nil {
 		return 0, fmt.Errorf("failed to get seasons: %w", err)
@@ -543,7 +595,7 @@ func selectSeason(mm *scraper.MediaManager, mediaID string) (int, error) {
 }
 
 // selectEpisode presents a selection UI for TV episodes
-func selectEpisode(mm *scraper.MediaManager, mediaID string, seasonNum int) (int, error) {
+func selectEpisode(mm mediaCatalog, mediaID string, seasonNum int) (int, error) {
 	seasons, err := mm.GetTVSeasons(mediaID)
 	if err != nil {
 		return 0, fmt.Errorf("failed to get seasons: %w", err)
@@ -579,7 +631,7 @@ func selectEpisode(mm *scraper.MediaManager, mediaID string, seasonNum int) (int
 }
 
 // getSeasonEpisodeCount returns the number of episodes in a given season
-func getSeasonEpisodeCount(mm *scraper.MediaManager, mediaID string, seasonNum int) (int, error) {
+func getSeasonEpisodeCount(mm mediaCatalog, mediaID string, seasonNum int) (int, error) {
 	seasons, err := mm.GetTVSeasons(mediaID)
 	if err != nil {
 		return 0, fmt.Errorf("failed to get seasons: %w", err)

--- a/internal/download/workflow_test.go
+++ b/internal/download/workflow_test.go
@@ -1,5 +1,8 @@
 package download
 
+// Tests in this file mutate package-level vars used as DI seams.
+// Do not add t.Parallel(); these tests must run sequentially.
+
 import (
 	"context"
 	"errors"

--- a/internal/download/workflow_test.go
+++ b/internal/download/workflow_test.go
@@ -122,7 +122,7 @@ func TestHandleDownloadRequestRangeFallsBackToLegacyDownloader(t *testing.T) {
 	searchAnimeWithRetry = func(_ string) (*models.Anime, error) {
 		return anime, nil
 	}
-	getAnimeEpisodesEnhanced = func(gotAnime *models.Anime) ([]models.Episode, error) {
+	getAnimeEpisodesEnhanced = func(_ *models.Anime) ([]models.Episode, error) {
 		return nil, enhancedErr
 	}
 	getAnimeEpisodesLegacy = func(url string) ([]models.Episode, error) {

--- a/internal/download/workflow_test.go
+++ b/internal/download/workflow_test.go
@@ -1,0 +1,489 @@
+package download
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/alvarorichard/Goanime/internal/api/providers/metadata"
+	"github.com/alvarorichard/Goanime/internal/downloader"
+	"github.com/alvarorichard/Goanime/internal/models"
+	"github.com/alvarorichard/Goanime/internal/player"
+	"github.com/alvarorichard/Goanime/internal/scraper"
+	"github.com/alvarorichard/Goanime/internal/util"
+)
+
+func TestHandleDownloadRequestSingleAnimeUsesLegacyDownloader(t *testing.T) {
+	restoreWorkflowState(t)
+	installNoopMetadata(t)
+
+	anime := &models.Anime{
+		Name:      "Frieren",
+		URL:       "https://anime.example/frieren",
+		Source:    "AllAnime",
+		MediaType: models.MediaTypeAnime,
+	}
+	episodes := []models.Episode{{Number: "7", Num: 7, URL: "https://anime.example/frieren/7"}}
+
+	var searchedName, legacyURL string
+	searchAnimeWithRetry = func(name string) (*models.Anime, error) {
+		searchedName = name
+		return anime, nil
+	}
+	getAnimeEpisodesLegacy = func(url string) ([]models.Episode, error) {
+		legacyURL = url
+		return episodes, nil
+	}
+
+	var gotDownloaderURL string
+	var gotDownloaderAnime *models.Anime
+	var gotSingleEpisode int
+	newEpisodeDownloaderWithAnime = func(gotEpisodes []models.Episode, animeURL string, gotAnime *models.Anime) episodeDownloader {
+		if len(gotEpisodes) != len(episodes) || gotEpisodes[0].URL != episodes[0].URL {
+			t.Fatalf("episodes passed to downloader = %#v, want %#v", gotEpisodes, episodes)
+		}
+		gotDownloaderURL = animeURL
+		gotDownloaderAnime = gotAnime
+		return stubEpisodeDownloader{
+			downloadSingle: func(episodeNum int) error {
+				gotSingleEpisode = episodeNum
+				return nil
+			},
+		}
+	}
+
+	err := HandleDownloadRequest(&util.DownloadRequest{
+		AnimeName:  "Frieren",
+		EpisodeNum: 7,
+		Quality:    "720",
+	})
+	if err != nil {
+		t.Fatalf("HandleDownloadRequest() error = %v", err)
+	}
+	if searchedName != "Frieren" {
+		t.Fatalf("search name = %q, want Frieren", searchedName)
+	}
+	if legacyURL != anime.URL {
+		t.Fatalf("legacy episode URL = %q, want %q", legacyURL, anime.URL)
+	}
+	if gotDownloaderURL != anime.URL || gotDownloaderAnime != anime {
+		t.Fatalf("downloader got URL/anime = %q/%#v, want original anime", gotDownloaderURL, gotDownloaderAnime)
+	}
+	if gotSingleEpisode != 7 {
+		t.Fatalf("DownloadSingleEpisode called with %d, want 7", gotSingleEpisode)
+	}
+}
+
+func TestHandleDownloadRequestAllTreatsUserQuitAsSuccess(t *testing.T) {
+	restoreWorkflowState(t)
+	installNoopMetadata(t)
+
+	anime := &models.Anime{Name: "Bocchi", URL: "anime-id", Source: "AllAnime", MediaType: models.MediaTypeAnime}
+	episodes := []models.Episode{{Number: "1", Num: 1, URL: "episode-1"}}
+
+	searchAnimeWithRetry = func(name string) (*models.Anime, error) {
+		return anime, nil
+	}
+	getAnimeEpisodesEnhanced = func(gotAnime *models.Anime) ([]models.Episode, error) {
+		if gotAnime != anime {
+			t.Fatalf("enhanced episode fetch got %#v, want anime", gotAnime)
+		}
+		return episodes, nil
+	}
+
+	var batchCalled bool
+	handleBatchDownload = func(gotEpisodes []models.Episode, gotAnime *models.Anime) error {
+		batchCalled = true
+		if len(gotEpisodes) != 1 || gotEpisodes[0].URL != "episode-1" || gotAnime != anime {
+			t.Fatalf("batch download got episodes/anime = %#v/%#v", gotEpisodes, gotAnime)
+		}
+		return player.ErrUserQuit
+	}
+	newEpisodeDownloaderWithAnime = func([]models.Episode, string, *models.Anime) episodeDownloader {
+		t.Fatal("legacy downloader must not run when batch path returns ErrUserQuit")
+		return nil
+	}
+
+	if err := HandleDownloadRequest(&util.DownloadRequest{AnimeName: "Bocchi", IsAll: true}); err != nil {
+		t.Fatalf("HandleDownloadRequest() error = %v, want nil for ErrUserQuit", err)
+	}
+	if !batchCalled {
+		t.Fatal("batch download path was not called")
+	}
+}
+
+func TestHandleDownloadRequestRangeFallsBackToLegacyDownloader(t *testing.T) {
+	restoreWorkflowState(t)
+	installNoopMetadata(t)
+
+	anime := &models.Anime{Name: "Dungeon Meshi", URL: "anime-url", Source: "AllAnime", MediaType: models.MediaTypeAnime}
+	enhancedErr := errors.New("enhanced unavailable")
+
+	searchAnimeWithRetry = func(name string) (*models.Anime, error) {
+		return anime, nil
+	}
+	getAnimeEpisodesEnhanced = func(gotAnime *models.Anime) ([]models.Episode, error) {
+		return nil, enhancedErr
+	}
+	getAnimeEpisodesLegacy = func(url string) ([]models.Episode, error) {
+		if url != anime.URL {
+			t.Fatalf("legacy fetch URL = %q, want %q", url, anime.URL)
+		}
+		return []models.Episode{
+			{Number: "3", Num: 3, URL: "episode-3"},
+			{Number: "4", Num: 4, URL: "episode-4"},
+		}, nil
+	}
+
+	var gotStart, gotEnd int
+	newEpisodeDownloaderWithAnime = func([]models.Episode, string, *models.Anime) episodeDownloader {
+		return stubEpisodeDownloader{
+			downloadRange: func(startEp, endEp int) error {
+				gotStart, gotEnd = startEp, endEp
+				return nil
+			},
+		}
+	}
+
+	err := HandleDownloadRequest(&util.DownloadRequest{
+		AnimeName:    "Dungeon Meshi",
+		IsRange:      true,
+		StartEpisode: 3,
+		EndEpisode:   4,
+	})
+	if err != nil {
+		t.Fatalf("HandleDownloadRequest() error = %v", err)
+	}
+	if gotStart != 3 || gotEnd != 4 {
+		t.Fatalf("DownloadEpisodeRange called with %d-%d, want 3-4", gotStart, gotEnd)
+	}
+}
+
+func TestHandleDownloadRequestRoutesNineAnimeRange(t *testing.T) {
+	restoreWorkflowState(t)
+	installNoopMetadata(t)
+
+	anime := &models.Anime{Name: "Solo Leveling", URL: "solo-leveling-id", Source: "9Anime", MediaType: models.MediaTypeAnime}
+
+	searchAnimeWithRetry = func(name string) (*models.Anime, error) {
+		return anime, nil
+	}
+
+	var gotConfig downloader.NineAnimeDownloadConfig
+	var gotAnime *models.Anime
+	var gotStart, gotEnd int
+	newNineAnimeDownloader = func(config downloader.NineAnimeDownloadConfig) nineAnimeDownloader {
+		gotConfig = config
+		return stubNineAnimeDownloader{
+			downloadRange: func(anime *models.Anime, startEp, endEp int) error {
+				gotAnime, gotStart, gotEnd = anime, startEp, endEp
+				return nil
+			},
+		}
+	}
+
+	err := HandleDownloadRequest(&util.DownloadRequest{
+		AnimeName:     "Solo Leveling",
+		IsRange:       true,
+		StartEpisode:  2,
+		EndEpisode:    5,
+		Quality:       "1080p",
+		SeasonNum:     2,
+		SubsLanguage:  "portuguese",
+		OutputDir:     "D:/anime",
+		AllAnimeSmart: true,
+	})
+	if err != nil {
+		t.Fatalf("HandleDownloadRequest() error = %v", err)
+	}
+	if gotAnime != anime || gotStart != 2 || gotEnd != 5 {
+		t.Fatalf("9Anime range got anime/start/end = %#v/%d/%d", gotAnime, gotStart, gotEnd)
+	}
+	if gotConfig.AnimeName != anime.Name || gotConfig.Quality != "1080p" || gotConfig.Season != 2 ||
+		gotConfig.SubsLanguage != "portuguese" || gotConfig.OutputDir != "D:/anime" {
+		t.Fatalf("9Anime config = %+v, want request propagated", gotConfig)
+	}
+}
+
+func TestHandleDownloadRequestRedirectsMovieContent(t *testing.T) {
+	restoreWorkflowState(t)
+	installNoopMetadata(t)
+
+	searchAnimeWithRetry = func(name string) (*models.Anime, error) {
+		return &models.Anime{
+			Name:      "Inception",
+			URL:       "https://flixhq.to/movie/watch-inception-123",
+			Source:    "FlixHQ",
+			MediaType: models.MediaTypeMovie,
+		}, nil
+	}
+
+	var gotReq *util.DownloadRequest
+	handleMovieDownloadWorkflow = func(req *util.DownloadRequest) error {
+		gotReq = req
+		return nil
+	}
+
+	err := HandleDownloadRequest(&util.DownloadRequest{
+		AnimeName:    "Inception",
+		Quality:      "720",
+		SubsLanguage: "english",
+		OutputDir:    "D:/movies",
+	})
+	if err != nil {
+		t.Fatalf("HandleDownloadRequest() error = %v", err)
+	}
+	if gotReq == nil {
+		t.Fatal("movie workflow was not called")
+	}
+	if !gotReq.IsMovie || gotReq.AnimeName != "Inception" || gotReq.Quality != "720" ||
+		gotReq.SubsLanguage != "english" || gotReq.OutputDir != "D:/movies" {
+		t.Fatalf("movie redirect request = %+v, want movie request with original options", gotReq)
+	}
+}
+
+func TestHandleMovieDownloadRequestDownloadsMovieWithoutSelectionUI(t *testing.T) {
+	restoreWorkflowState(t)
+	installNoopMetadata(t)
+
+	newMediaManager = func() mediaCatalog {
+		return stubMediaCatalog{
+			results: []*scraper.FlixHQMedia{{
+				Title:  "Inception",
+				Type:   scraper.MediaTypeMovie,
+				URL:    "https://flixhq.to/movie/watch-inception-123",
+				Year:   "2010",
+				Source: "FlixHQ",
+			}},
+		}
+	}
+
+	var gotConfig downloader.MovieDownloadConfig
+	var gotMedia *models.Anime
+	newMovieDownloaderWithConfig = func(config downloader.MovieDownloadConfig) movieDownloader {
+		gotConfig = config
+		return stubMovieDownloader{
+			downloadMovie: func(media *models.Anime) error {
+				gotMedia = media
+				return nil
+			},
+		}
+	}
+
+	err := HandleMovieDownloadRequest(&util.DownloadRequest{
+		AnimeName:    "Inception",
+		IsMovie:      true,
+		Quality:      "720",
+		SubsLanguage: "portuguese",
+	})
+	if err != nil {
+		t.Fatalf("HandleMovieDownloadRequest() error = %v", err)
+	}
+	if gotMedia == nil || gotMedia.Name != "Inception" || gotMedia.MediaType != models.MediaTypeMovie || gotMedia.Source != "FlixHQ" {
+		t.Fatalf("movie downloader media = %#v, want selected movie model", gotMedia)
+	}
+	if gotConfig.Quality != scraper.Quality720 || gotConfig.SubsLanguage != "portuguese" || gotConfig.Provider != "Vidcloud" {
+		t.Fatalf("movie downloader config = %+v, want request quality/subs propagated", gotConfig)
+	}
+}
+
+func TestHandleMovieDownloadRequestDownloadsTVEpisodeWithoutSelectionUI(t *testing.T) {
+	restoreWorkflowState(t)
+	installNoopMetadata(t)
+
+	newMediaManager = func() mediaCatalog {
+		return stubMediaCatalog{
+			results: []*scraper.FlixHQMedia{{
+				Title:  "Breaking Bad",
+				Type:   scraper.MediaTypeTV,
+				URL:    "https://flixhq.to/tv/watch-breaking-bad-39506",
+				Year:   "2008",
+				Source: "FlixHQ",
+			}},
+		}
+	}
+
+	var gotMedia *models.Anime
+	var gotSeason, gotEpisode int
+	newMovieDownloaderWithConfig = func(config downloader.MovieDownloadConfig) movieDownloader {
+		return stubMovieDownloader{
+			downloadTVEpisode: func(media *models.Anime, seasonNum, episodeNum int) error {
+				gotMedia, gotSeason, gotEpisode = media, seasonNum, episodeNum
+				return nil
+			},
+		}
+	}
+
+	err := HandleMovieDownloadRequest(&util.DownloadRequest{
+		AnimeName:  "Breaking Bad",
+		IsTV:       true,
+		SeasonNum:  2,
+		EpisodeNum: 4,
+	})
+	if err != nil {
+		t.Fatalf("HandleMovieDownloadRequest() error = %v", err)
+	}
+	if gotMedia == nil || gotMedia.Name != "Breaking Bad" || gotMedia.MediaType != models.MediaTypeTV {
+		t.Fatalf("TV downloader media = %#v, want selected TV model", gotMedia)
+	}
+	if gotSeason != 2 || gotEpisode != 4 {
+		t.Fatalf("DownloadTVEpisode called with S%dE%d, want S2E4", gotSeason, gotEpisode)
+	}
+}
+
+type stubEpisodeDownloader struct {
+	downloadAll    func() error
+	downloadRange  func(startEp, endEp int) error
+	downloadSingle func(episodeNum int) error
+}
+
+func (s stubEpisodeDownloader) DownloadAllEpisodes() error {
+	if s.downloadAll != nil {
+		return s.downloadAll()
+	}
+	return nil
+}
+
+func (s stubEpisodeDownloader) DownloadEpisodeRange(startEp, endEp int) error {
+	if s.downloadRange != nil {
+		return s.downloadRange(startEp, endEp)
+	}
+	return nil
+}
+
+func (s stubEpisodeDownloader) DownloadSingleEpisode(episodeNum int) error {
+	if s.downloadSingle != nil {
+		return s.downloadSingle(episodeNum)
+	}
+	return nil
+}
+
+type stubNineAnimeDownloader struct {
+	downloadAll    func(anime *models.Anime) error
+	downloadRange  func(anime *models.Anime, startEp, endEp int) error
+	downloadSingle func(anime *models.Anime, episodeNum int) error
+}
+
+func (s stubNineAnimeDownloader) DownloadAllEpisodes(anime *models.Anime) error {
+	if s.downloadAll != nil {
+		return s.downloadAll(anime)
+	}
+	return nil
+}
+
+func (s stubNineAnimeDownloader) DownloadEpisodeRange(anime *models.Anime, startEp, endEp int) error {
+	if s.downloadRange != nil {
+		return s.downloadRange(anime, startEp, endEp)
+	}
+	return nil
+}
+
+func (s stubNineAnimeDownloader) DownloadSingleEpisode(anime *models.Anime, episodeNum int) error {
+	if s.downloadSingle != nil {
+		return s.downloadSingle(anime, episodeNum)
+	}
+	return nil
+}
+
+type stubMovieDownloader struct {
+	downloadMovie          func(media *models.Anime) error
+	downloadTVEpisode      func(media *models.Anime, seasonNum, episodeNum int) error
+	downloadTVEpisodeRange func(media *models.Anime, seasonNum, startEp, endEp int) error
+	downloadAllSeasons     func(media *models.Anime) error
+}
+
+func (s stubMovieDownloader) DownloadMovie(media *models.Anime) error {
+	if s.downloadMovie != nil {
+		return s.downloadMovie(media)
+	}
+	return nil
+}
+
+func (s stubMovieDownloader) DownloadTVEpisode(media *models.Anime, seasonNum, episodeNum int) error {
+	if s.downloadTVEpisode != nil {
+		return s.downloadTVEpisode(media, seasonNum, episodeNum)
+	}
+	return nil
+}
+
+func (s stubMovieDownloader) DownloadTVEpisodeRange(media *models.Anime, seasonNum, startEp, endEp int) error {
+	if s.downloadTVEpisodeRange != nil {
+		return s.downloadTVEpisodeRange(media, seasonNum, startEp, endEp)
+	}
+	return nil
+}
+
+func (s stubMovieDownloader) DownloadAllSeasons(media *models.Anime) error {
+	if s.downloadAllSeasons != nil {
+		return s.downloadAllSeasons(media)
+	}
+	return nil
+}
+
+type stubMediaCatalog struct {
+	results  []*scraper.FlixHQMedia
+	seasons  []scraper.FlixHQSeason
+	episodes []scraper.FlixHQEpisode
+	err      error
+}
+
+func (s stubMediaCatalog) SearchMoviesAndTV(query string) ([]*scraper.FlixHQMedia, error) {
+	return s.results, s.err
+}
+
+func (s stubMediaCatalog) GetTVSeasons(mediaID string) ([]scraper.FlixHQSeason, error) {
+	return s.seasons, s.err
+}
+
+func (s stubMediaCatalog) GetTVEpisodes(seasonID string) ([]scraper.FlixHQEpisode, error) {
+	return s.episodes, s.err
+}
+
+func installNoopMetadata(t *testing.T) {
+	t.Helper()
+
+	enrichAnimeMetadata = func(context.Context, *models.Anime) ([]metadata.SeasonMapping, error) {
+		return nil, nil
+	}
+	enrichMovieMedia = func(*models.Anime) error {
+		return nil
+	}
+}
+
+func restoreWorkflowState(t *testing.T) {
+	t.Helper()
+
+	originalGlobalRequest := util.GlobalDownloadRequest
+	originalSearch := searchAnimeWithRetry
+	originalEnhancedEpisodes := getAnimeEpisodesEnhanced
+	originalLegacyEpisodes := getAnimeEpisodesLegacy
+	originalSmartRange := downloadAllAnimeSmartRange
+	originalEnhancedRange := downloadEpisodeRangeEnhanced
+	originalBatchDownload := handleBatchDownload
+	originalBatchDownloadRange := handleBatchDownloadRange
+	originalMovieWorkflow := handleMovieDownloadWorkflow
+	originalAnimeEnrichment := enrichAnimeMetadata
+	originalMovieEnrichment := enrichMovieMedia
+	originalEpisodeDownloader := newEpisodeDownloaderWithAnime
+	originalNineAnimeDownloader := newNineAnimeDownloader
+	originalMediaManager := newMediaManager
+	originalMovieDownloader := newMovieDownloaderWithConfig
+
+	t.Cleanup(func() {
+		util.GlobalDownloadRequest = originalGlobalRequest
+		searchAnimeWithRetry = originalSearch
+		getAnimeEpisodesEnhanced = originalEnhancedEpisodes
+		getAnimeEpisodesLegacy = originalLegacyEpisodes
+		downloadAllAnimeSmartRange = originalSmartRange
+		downloadEpisodeRangeEnhanced = originalEnhancedRange
+		handleBatchDownload = originalBatchDownload
+		handleBatchDownloadRange = originalBatchDownloadRange
+		handleMovieDownloadWorkflow = originalMovieWorkflow
+		enrichAnimeMetadata = originalAnimeEnrichment
+		enrichMovieMedia = originalMovieEnrichment
+		newEpisodeDownloaderWithAnime = originalEpisodeDownloader
+		newNineAnimeDownloader = originalNineAnimeDownloader
+		newMediaManager = originalMediaManager
+		newMovieDownloaderWithConfig = originalMovieDownloader
+	})
+}

--- a/internal/download/workflow_test.go
+++ b/internal/download/workflow_test.go
@@ -81,7 +81,7 @@ func TestHandleDownloadRequestAllTreatsUserQuitAsSuccess(t *testing.T) {
 	anime := &models.Anime{Name: "Bocchi", URL: "anime-id", Source: "AllAnime", MediaType: models.MediaTypeAnime}
 	episodes := []models.Episode{{Number: "1", Num: 1, URL: "episode-1"}}
 
-	searchAnimeWithRetry = func(name string) (*models.Anime, error) {
+	searchAnimeWithRetry = func(_ string) (*models.Anime, error) {
 		return anime, nil
 	}
 	getAnimeEpisodesEnhanced = func(gotAnime *models.Anime) ([]models.Episode, error) {
@@ -119,7 +119,7 @@ func TestHandleDownloadRequestRangeFallsBackToLegacyDownloader(t *testing.T) {
 	anime := &models.Anime{Name: "Dungeon Meshi", URL: "anime-url", Source: "AllAnime", MediaType: models.MediaTypeAnime}
 	enhancedErr := errors.New("enhanced unavailable")
 
-	searchAnimeWithRetry = func(name string) (*models.Anime, error) {
+	searchAnimeWithRetry = func(_ string) (*models.Anime, error) {
 		return anime, nil
 	}
 	getAnimeEpisodesEnhanced = func(gotAnime *models.Anime) ([]models.Episode, error) {
@@ -165,7 +165,7 @@ func TestHandleDownloadRequestRoutesNineAnimeRange(t *testing.T) {
 
 	anime := &models.Anime{Name: "Solo Leveling", URL: "solo-leveling-id", Source: "9Anime", MediaType: models.MediaTypeAnime}
 
-	searchAnimeWithRetry = func(name string) (*models.Anime, error) {
+	searchAnimeWithRetry = func(_ string) (*models.Anime, error) {
 		return anime, nil
 	}
 
@@ -209,7 +209,7 @@ func TestHandleDownloadRequestRedirectsMovieContent(t *testing.T) {
 	restoreWorkflowState(t)
 	installNoopMetadata(t)
 
-	searchAnimeWithRetry = func(name string) (*models.Anime, error) {
+	searchAnimeWithRetry = func(_ string) (*models.Anime, error) {
 		return &models.Anime{
 			Name:      "Inception",
 			URL:       "https://flixhq.to/movie/watch-inception-123",
@@ -305,7 +305,7 @@ func TestHandleMovieDownloadRequestDownloadsTVEpisodeWithoutSelectionUI(t *testi
 
 	var gotMedia *models.Anime
 	var gotSeason, gotEpisode int
-	newMovieDownloaderWithConfig = func(config downloader.MovieDownloadConfig) movieDownloader {
+	newMovieDownloaderWithConfig = func(_ downloader.MovieDownloadConfig) movieDownloader {
 		return stubMovieDownloader{
 			downloadTVEpisode: func(media *models.Anime, seasonNum, episodeNum int) error {
 				gotMedia, gotSeason, gotEpisode = media, seasonNum, episodeNum
@@ -427,15 +427,15 @@ type stubMediaCatalog struct {
 	err      error
 }
 
-func (s stubMediaCatalog) SearchMoviesAndTV(query string) ([]*scraper.FlixHQMedia, error) {
+func (s stubMediaCatalog) SearchMoviesAndTV(_ string) ([]*scraper.FlixHQMedia, error) {
 	return s.results, s.err
 }
 
-func (s stubMediaCatalog) GetTVSeasons(mediaID string) ([]scraper.FlixHQSeason, error) {
+func (s stubMediaCatalog) GetTVSeasons(_ string) ([]scraper.FlixHQSeason, error) {
 	return s.seasons, s.err
 }
 
-func (s stubMediaCatalog) GetTVEpisodes(seasonID string) ([]scraper.FlixHQEpisode, error) {
+func (s stubMediaCatalog) GetTVEpisodes(_ string) ([]scraper.FlixHQEpisode, error) {
 	return s.episodes, s.err
 }
 

--- a/internal/handlers/download.go
+++ b/internal/handlers/download.go
@@ -7,6 +7,11 @@ import (
 	"github.com/alvarorichard/Goanime/internal/util"
 )
 
+var (
+	runAnimeDownload = download.HandleDownloadRequest
+	runMovieDownload = download.HandleMovieDownloadRequest
+)
+
 // HandleDownloadRequest processes download requests
 func HandleDownloadRequest() error {
 	// Initialize logger for download process
@@ -16,7 +21,7 @@ func HandleDownloadRequest() error {
 		return fmt.Errorf("download request is nil")
 	}
 
-	if err := download.HandleDownloadRequest(util.GlobalDownloadRequest); err != nil {
+	if err := runAnimeDownload(util.GlobalDownloadRequest); err != nil {
 		return fmt.Errorf("download failed: %w", err)
 	}
 	return nil
@@ -31,7 +36,7 @@ func HandleMovieDownloadRequest() error {
 		return fmt.Errorf("movie download request is nil")
 	}
 
-	if err := download.HandleMovieDownloadRequest(util.GlobalDownloadRequest); err != nil {
+	if err := runMovieDownload(util.GlobalDownloadRequest); err != nil {
 		return fmt.Errorf("movie download failed: %w", err)
 	}
 	return nil

--- a/internal/handlers/download_upscale_update_test.go
+++ b/internal/handlers/download_upscale_update_test.go
@@ -35,7 +35,7 @@ func TestHandleDownloadRequestRejectsNilRequest(t *testing.T) {
 
 	var called bool
 	util.GlobalDownloadRequest = nil
-	runAnimeDownload = func(req *util.DownloadRequest) error {
+	runAnimeDownload = func(_ *util.DownloadRequest) error {
 		called = true
 		return nil
 	}
@@ -54,7 +54,7 @@ func TestHandleDownloadRequestWrapsRunnerError(t *testing.T) {
 
 	sentinel := errors.New("network blocked")
 	util.GlobalDownloadRequest = &util.DownloadRequest{AnimeName: "frieren", EpisodeNum: 1}
-	runAnimeDownload = func(req *util.DownloadRequest) error {
+	runAnimeDownload = func(_ *util.DownloadRequest) error {
 		return sentinel
 	}
 
@@ -151,7 +151,7 @@ func TestHandleUpscaleRequestStopsWhenFFmpegValidationFails(t *testing.T) {
 	validateFFmpeg = func() (string, error) {
 		return "", sentinel
 	}
-	upscaleImageFile = func(inputPath, outputPath string, opts upscaler.Anime4KOptions) error {
+	upscaleImageFile = func(_, _ string, _ upscaler.Anime4KOptions) error {
 		t.Fatal("upscaleImageFile must not run when FFmpeg validation fails")
 		return nil
 	}

--- a/internal/handlers/download_upscale_update_test.go
+++ b/internal/handlers/download_upscale_update_test.go
@@ -1,0 +1,210 @@
+package handlers
+
+import (
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/alvarorichard/Goanime/internal/upscaler"
+	"github.com/alvarorichard/Goanime/internal/util"
+)
+
+func TestHandleDownloadRequestDelegatesGlobalRequest(t *testing.T) {
+	restoreDownloadHandlerState(t)
+
+	wantReq := &util.DownloadRequest{AnimeName: "frieren", EpisodeNum: 7}
+	util.GlobalDownloadRequest = wantReq
+
+	var gotReq *util.DownloadRequest
+	runAnimeDownload = func(req *util.DownloadRequest) error {
+		gotReq = req
+		return nil
+	}
+
+	if err := HandleDownloadRequest(); err != nil {
+		t.Fatalf("HandleDownloadRequest() error = %v", err)
+	}
+	if gotReq != wantReq {
+		t.Fatalf("download runner received %#v, want original request %#v", gotReq, wantReq)
+	}
+}
+
+func TestHandleDownloadRequestRejectsNilRequest(t *testing.T) {
+	restoreDownloadHandlerState(t)
+
+	var called bool
+	util.GlobalDownloadRequest = nil
+	runAnimeDownload = func(req *util.DownloadRequest) error {
+		called = true
+		return nil
+	}
+
+	err := HandleDownloadRequest()
+	if err == nil || !strings.Contains(err.Error(), "download request is nil") {
+		t.Fatalf("HandleDownloadRequest() error = %v, want nil request error", err)
+	}
+	if called {
+		t.Fatal("download runner must not be called when global request is nil")
+	}
+}
+
+func TestHandleDownloadRequestWrapsRunnerError(t *testing.T) {
+	restoreDownloadHandlerState(t)
+
+	sentinel := errors.New("network blocked")
+	util.GlobalDownloadRequest = &util.DownloadRequest{AnimeName: "frieren", EpisodeNum: 1}
+	runAnimeDownload = func(req *util.DownloadRequest) error {
+		return sentinel
+	}
+
+	err := HandleDownloadRequest()
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("HandleDownloadRequest() error = %v, want wrapped sentinel", err)
+	}
+	if !strings.Contains(err.Error(), "download failed") {
+		t.Fatalf("HandleDownloadRequest() error = %v, want context", err)
+	}
+}
+
+func TestHandleMovieDownloadRequestDelegatesGlobalRequest(t *testing.T) {
+	restoreDownloadHandlerState(t)
+
+	wantReq := &util.DownloadRequest{AnimeName: "inception", IsMovie: true, Quality: "1080"}
+	util.GlobalDownloadRequest = wantReq
+
+	var gotReq *util.DownloadRequest
+	runMovieDownload = func(req *util.DownloadRequest) error {
+		gotReq = req
+		return nil
+	}
+
+	if err := HandleMovieDownloadRequest(); err != nil {
+		t.Fatalf("HandleMovieDownloadRequest() error = %v", err)
+	}
+	if gotReq != wantReq {
+		t.Fatalf("movie download runner received %#v, want original request %#v", gotReq, wantReq)
+	}
+}
+
+func TestHandleUpdateRequestDelegatesAndWrapsError(t *testing.T) {
+	original := checkAndPromptUpdate
+	t.Cleanup(func() { checkAndPromptUpdate = original })
+
+	sentinel := errors.New("updater offline")
+	checkAndPromptUpdate = func() error { return sentinel }
+
+	err := HandleUpdateRequest()
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("HandleUpdateRequest() error = %v, want wrapped sentinel", err)
+	}
+	if !strings.Contains(err.Error(), "update failed") {
+		t.Fatalf("HandleUpdateRequest() error = %v, want context", err)
+	}
+}
+
+func TestHandleUpscaleRequestImageDefaultsOutputAndOptions(t *testing.T) {
+	restoreUpscaleHandlerState(t)
+
+	inputPath := filepath.Join(t.TempDir(), "frame.PNG")
+	util.GlobalUpscaleRequest = &util.UpscaleRequest{
+		InputPath:        inputPath,
+		ScaleFactor:      3,
+		Passes:           5,
+		StrengthColor:    0.25,
+		StrengthGradient: 0.75,
+	}
+
+	validateFFmpeg = func() (string, error) {
+		return "ffmpeg test", nil
+	}
+
+	var gotInput, gotOutput string
+	var gotOpts upscaler.Anime4KOptions
+	upscaleImageFile = func(inputPath, outputPath string, opts upscaler.Anime4KOptions) error {
+		gotInput = inputPath
+		gotOutput = outputPath
+		gotOpts = opts
+		return nil
+	}
+
+	if err := HandleUpscaleRequest(); err != nil {
+		t.Fatalf("HandleUpscaleRequest() error = %v", err)
+	}
+	if gotInput != inputPath {
+		t.Fatalf("upscale input = %q, want %q", gotInput, inputPath)
+	}
+	wantOutput := strings.TrimSuffix(inputPath, filepath.Ext(inputPath)) + "_upscaled" + filepath.Ext(inputPath)
+	if gotOutput != wantOutput {
+		t.Fatalf("upscale output = %q, want %q", gotOutput, wantOutput)
+	}
+	if gotOpts.ScaleFactor != 3 || gotOpts.Passes != 5 || gotOpts.StrengthColor != 0.25 || gotOpts.StrengthGradient != 0.75 {
+		t.Fatalf("upscale options = %+v, want request values propagated", gotOpts)
+	}
+}
+
+func TestHandleUpscaleRequestStopsWhenFFmpegValidationFails(t *testing.T) {
+	restoreUpscaleHandlerState(t)
+
+	sentinel := errors.New("ffmpeg missing")
+	util.GlobalUpscaleRequest = &util.UpscaleRequest{InputPath: "frame.png"}
+	validateFFmpeg = func() (string, error) {
+		return "", sentinel
+	}
+	upscaleImageFile = func(inputPath, outputPath string, opts upscaler.Anime4KOptions) error {
+		t.Fatal("upscaleImageFile must not run when FFmpeg validation fails")
+		return nil
+	}
+
+	err := HandleUpscaleRequest()
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("HandleUpscaleRequest() error = %v, want wrapped sentinel", err)
+	}
+	if !strings.Contains(err.Error(), "FFmpeg validation failed") {
+		t.Fatalf("HandleUpscaleRequest() error = %v, want validation context", err)
+	}
+}
+
+func TestIsImageExtension(t *testing.T) {
+	tests := []struct {
+		ext  string
+		want bool
+	}{
+		{ext: ".png", want: true},
+		{ext: ".webp", want: true},
+		{ext: ".mp4", want: false},
+		{ext: "", want: false},
+	}
+
+	for _, tt := range tests {
+		if got := isImageExtension(tt.ext); got != tt.want {
+			t.Fatalf("isImageExtension(%q) = %v, want %v", tt.ext, got, tt.want)
+		}
+	}
+}
+
+func restoreDownloadHandlerState(t *testing.T) {
+	t.Helper()
+
+	originalRequest := util.GlobalDownloadRequest
+	originalAnimeRunner := runAnimeDownload
+	originalMovieRunner := runMovieDownload
+	t.Cleanup(func() {
+		util.GlobalDownloadRequest = originalRequest
+		runAnimeDownload = originalAnimeRunner
+		runMovieDownload = originalMovieRunner
+	})
+}
+
+func restoreUpscaleHandlerState(t *testing.T) {
+	t.Helper()
+
+	originalRequest := util.GlobalUpscaleRequest
+	originalValidate := validateFFmpeg
+	originalUpscaleImage := upscaleImageFile
+	t.Cleanup(func() {
+		util.GlobalUpscaleRequest = originalRequest
+		validateFFmpeg = originalValidate
+		upscaleImageFile = originalUpscaleImage
+	})
+}

--- a/internal/handlers/download_upscale_update_test.go
+++ b/internal/handlers/download_upscale_update_test.go
@@ -1,5 +1,8 @@
 package handlers
 
+// Tests in this file mutate package-level vars used as DI seams.
+// Do not add t.Parallel(); these tests must run sequentially.
+
 import (
 	"errors"
 	"path/filepath"

--- a/internal/handlers/playback.go
+++ b/internal/handlers/playback.go
@@ -15,23 +15,43 @@ import (
 	"github.com/alvarorichard/Goanime/internal/version"
 )
 
+type playbackModeDiscordManager interface {
+	Initialize() error
+	Shutdown()
+	IsEnabled() bool
+}
+
+var (
+	playbackModeInitLogger           = util.InitLogger
+	playbackModePreWarmConnections   = util.PreWarmConnections
+	playbackModeHandleTrackingNotice = tracking.HandleTrackingNotice
+	playbackModeNewDiscordManager    = func() playbackModeDiscordManager {
+		return discord.NewManager()
+	}
+	playbackModeSearchAnimeWithRetry = appflow.SearchAnimeWithRetry
+	playbackModeFetchAnimeDetails    = appflow.FetchAnimeDetails
+	playbackModeGetAnimeEpisodes     = appflow.GetAnimeEpisodes
+	playbackModeHandleSeries         = playback.HandleSeries
+	playbackModeHandleMovie          = playback.HandleMovie
+)
+
 // HandlePlaybackMode processes normal anime playback
 func HandlePlaybackMode(animeName string) {
 	timer := util.StartTimer("PlaybackMode:Total")
 	defer timer.Stop()
 
 	// Initialize the beautiful logger
-	util.InitLogger()
+	playbackModeInitLogger()
 
 	// Pre-warm connections are now started in main() so they run while the
 	// user is still typing the anime name. This call is a noop (sync.Once).
-	util.PreWarmConnections()
+	playbackModePreWarmConnections()
 
-	tracking.HandleTrackingNotice()
+	playbackModeHandleTrackingNotice()
 	util.Debugf("[PERF] starting Goanime v%s", version.Version)
 
 	// Discord init runs in background - doesn't block startup
-	discordManager := discord.NewManager()
+	discordManager := playbackModeNewDiscordManager()
 	_ = discordManager.Initialize() // Non-blocking, runs async
 	defer discordManager.Shutdown()
 
@@ -40,7 +60,7 @@ func HandlePlaybackMode(animeName string) {
 	for {
 		// Use enhanced search with retry logic
 		searchTimer := util.StartTimer("SearchAnime:WithRetry")
-		anime, err := appflow.SearchAnimeWithRetry(currentAnimeName)
+		anime, err := playbackModeSearchAnimeWithRetry(currentAnimeName)
 		searchTimer.Stop()
 
 		if err != nil {
@@ -68,11 +88,11 @@ func HandlePlaybackMode(animeName string) {
 			parallelTimer := util.StartTimer("FetchDetails+Episodes:Sequential")
 
 			detailsTimer := util.StartTimer("FetchAnimeDetails")
-			appflow.FetchAnimeDetails(anime)
+			playbackModeFetchAnimeDetails(anime)
 			detailsTimer.Stop()
 
 			episodesTimer := util.StartTimer("GetAnimeEpisodes")
-			episodes, epErr = appflow.GetAnimeEpisodes(anime)
+			episodes, epErr = playbackModeGetAnimeEpisodes(anime)
 			if epErr != nil && !errors.Is(epErr, api.ErrBackToSearch) {
 				util.Errorf("Failed to get episodes: %v", epErr)
 			}
@@ -88,13 +108,13 @@ func HandlePlaybackMode(animeName string) {
 			go func() {
 				defer wg.Done()
 				detailsTimer := util.StartTimer("FetchAnimeDetails")
-				appflow.FetchAnimeDetails(anime)
+				playbackModeFetchAnimeDetails(anime)
 				detailsTimer.Stop()
 			}()
 			go func() {
 				defer wg.Done()
 				episodesTimer := util.StartTimer("GetAnimeEpisodes")
-				episodes, epErr = appflow.GetAnimeEpisodes(anime)
+				episodes, epErr = playbackModeGetAnimeEpisodes(anime)
 				if epErr != nil && !errors.Is(epErr, api.ErrBackToSearch) {
 					util.Errorf("Failed to get episodes: %v", epErr)
 				}
@@ -132,9 +152,9 @@ func HandlePlaybackMode(animeName string) {
 
 		playbackTimer := util.StartTimer("Playback:Handle")
 		if series {
-			playbackErr = playback.HandleSeries(anime, episodes, totalEpisodes, discordManager.IsEnabled())
+			playbackErr = playbackModeHandleSeries(anime, episodes, totalEpisodes, discordManager.IsEnabled())
 		} else {
-			playbackErr = playback.HandleMovie(anime, episodes, discordManager.IsEnabled())
+			playbackErr = playbackModeHandleMovie(anime, episodes, discordManager.IsEnabled())
 		}
 		playbackTimer.Stop()
 

--- a/internal/handlers/playback_test.go
+++ b/internal/handlers/playback_test.go
@@ -54,16 +54,16 @@ func installPlaybackModeTestHooks(t *testing.T) *stubPlaybackModeDiscordManager 
 		t.Errorf("unexpected search for %q", name)
 		return nil, unexpectedCall
 	}
-	playbackModeFetchAnimeDetails = func(anime *models.Anime) {}
+	playbackModeFetchAnimeDetails = func(_ *models.Anime) {}
 	playbackModeGetAnimeEpisodes = func(anime *models.Anime) ([]models.Episode, error) {
 		t.Errorf("unexpected episode fetch for %#v", anime)
 		return nil, unexpectedCall
 	}
-	playbackModeHandleSeries = func(anime *models.Anime, episodes []models.Episode, totalEpisodes int, discordEnabled bool) error {
+	playbackModeHandleSeries = func(anime *models.Anime, _ []models.Episode, _ int, _ bool) error {
 		t.Errorf("unexpected series playback for %#v", anime)
 		return nil
 	}
-	playbackModeHandleMovie = func(anime *models.Anime, episodes []models.Episode, discordEnabled bool) error {
+	playbackModeHandleMovie = func(anime *models.Anime, _ []models.Episode, _ bool) error {
 		t.Errorf("unexpected movie playback for %#v", anime)
 		return nil
 	}
@@ -121,7 +121,7 @@ func TestHandlePlaybackModeSeriesAnimeUsesSeriesHandler(t *testing.T) {
 		gotDiscordEnabled = discordEnabled
 		return nil
 	}
-	playbackModeHandleMovie = func(anime *models.Anime, episodes []models.Episode, discordEnabled bool) error {
+	playbackModeHandleMovie = func(_ *models.Anime, _ []models.Episode, _ bool) error {
 		t.Errorf("movie playback called for series anime")
 		return nil
 	}
@@ -190,7 +190,7 @@ func TestHandlePlaybackModeMovieOrSingleEpisodeUsesMovieHandler(t *testing.T) {
 
 			movieCalls := 0
 			var gotEpisodes []models.Episode
-			playbackModeHandleMovie = func(got *models.Anime, eps []models.Episode, discordEnabled bool) error {
+			playbackModeHandleMovie = func(got *models.Anime, eps []models.Episode, _ bool) error {
 				movieCalls++
 				if got != tt.anime {
 					t.Errorf("movie anime = %#v, want %#v", got, tt.anime)
@@ -198,7 +198,7 @@ func TestHandlePlaybackModeMovieOrSingleEpisodeUsesMovieHandler(t *testing.T) {
 				gotEpisodes = append([]models.Episode(nil), eps...)
 				return nil
 			}
-			playbackModeHandleSeries = func(anime *models.Anime, episodes []models.Episode, totalEpisodes int, discordEnabled bool) error {
+			playbackModeHandleSeries = func(_ *models.Anime, _ []models.Episode, _ int, _ bool) error {
 				t.Errorf("series playback called for %s", tt.name)
 				return nil
 			}
@@ -260,7 +260,7 @@ func TestHandlePlaybackModeBackToSearchContinuesWithFreshSearch(t *testing.T) {
 	}
 
 	seriesCalls := 0
-	playbackModeHandleSeries = func(anime *models.Anime, episodes []models.Episode, totalEpisodes int, discordEnabled bool) error {
+	playbackModeHandleSeries = func(anime *models.Anime, _ []models.Episode, totalEpisodes int, _ bool) error {
 		seriesCalls++
 		if anime != secondAnime {
 			t.Errorf("series anime = %#v, want %#v", anime, secondAnime)
@@ -270,7 +270,7 @@ func TestHandlePlaybackModeBackToSearchContinuesWithFreshSearch(t *testing.T) {
 		}
 		return nil
 	}
-	playbackModeHandleMovie = func(anime *models.Anime, episodes []models.Episode, discordEnabled bool) error {
+	playbackModeHandleMovie = func(_ *models.Anime, _ []models.Episode, _ bool) error {
 		t.Errorf("movie playback called after back-to-search")
 		return nil
 	}

--- a/internal/handlers/playback_test.go
+++ b/internal/handlers/playback_test.go
@@ -1,0 +1,290 @@
+package handlers
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/alvarorichard/Goanime/internal/api"
+	"github.com/alvarorichard/Goanime/internal/models"
+)
+
+type stubPlaybackModeDiscordManager struct {
+	enabled         bool
+	initializeCalls int
+	shutdownCalls   int
+}
+
+func (m *stubPlaybackModeDiscordManager) Initialize() error {
+	m.initializeCalls++
+	return nil
+}
+
+func (m *stubPlaybackModeDiscordManager) Shutdown() {
+	m.shutdownCalls++
+}
+
+func (m *stubPlaybackModeDiscordManager) IsEnabled() bool {
+	return m.enabled
+}
+
+func installPlaybackModeTestHooks(t *testing.T) *stubPlaybackModeDiscordManager {
+	t.Helper()
+
+	oldInitLogger := playbackModeInitLogger
+	oldPreWarmConnections := playbackModePreWarmConnections
+	oldHandleTrackingNotice := playbackModeHandleTrackingNotice
+	oldNewDiscordManager := playbackModeNewDiscordManager
+	oldSearchAnimeWithRetry := playbackModeSearchAnimeWithRetry
+	oldFetchAnimeDetails := playbackModeFetchAnimeDetails
+	oldGetAnimeEpisodes := playbackModeGetAnimeEpisodes
+	oldHandleSeries := playbackModeHandleSeries
+	oldHandleMovie := playbackModeHandleMovie
+
+	manager := &stubPlaybackModeDiscordManager{enabled: true}
+	unexpectedCall := errors.New("unexpected playback mode test hook call")
+
+	playbackModeInitLogger = func() {}
+	playbackModePreWarmConnections = func() {}
+	playbackModeHandleTrackingNotice = func() {}
+	playbackModeNewDiscordManager = func() playbackModeDiscordManager {
+		return manager
+	}
+	playbackModeSearchAnimeWithRetry = func(name string) (*models.Anime, error) {
+		t.Errorf("unexpected search for %q", name)
+		return nil, unexpectedCall
+	}
+	playbackModeFetchAnimeDetails = func(anime *models.Anime) {}
+	playbackModeGetAnimeEpisodes = func(anime *models.Anime) ([]models.Episode, error) {
+		t.Errorf("unexpected episode fetch for %#v", anime)
+		return nil, unexpectedCall
+	}
+	playbackModeHandleSeries = func(anime *models.Anime, episodes []models.Episode, totalEpisodes int, discordEnabled bool) error {
+		t.Errorf("unexpected series playback for %#v", anime)
+		return nil
+	}
+	playbackModeHandleMovie = func(anime *models.Anime, episodes []models.Episode, discordEnabled bool) error {
+		t.Errorf("unexpected movie playback for %#v", anime)
+		return nil
+	}
+
+	t.Cleanup(func() {
+		playbackModeInitLogger = oldInitLogger
+		playbackModePreWarmConnections = oldPreWarmConnections
+		playbackModeHandleTrackingNotice = oldHandleTrackingNotice
+		playbackModeNewDiscordManager = oldNewDiscordManager
+		playbackModeSearchAnimeWithRetry = oldSearchAnimeWithRetry
+		playbackModeFetchAnimeDetails = oldFetchAnimeDetails
+		playbackModeGetAnimeEpisodes = oldGetAnimeEpisodes
+		playbackModeHandleSeries = oldHandleSeries
+		playbackModeHandleMovie = oldHandleMovie
+	})
+
+	return manager
+}
+
+func TestHandlePlaybackModeSeriesAnimeUsesSeriesHandler(t *testing.T) {
+	manager := installPlaybackModeTestHooks(t)
+	anime := &models.Anime{Name: "Series Anime", Source: "AllAnime", MediaType: models.MediaTypeAnime}
+	episodes := []models.Episode{
+		{Number: "1", URL: "https://example.test/1"},
+		{Number: "2", URL: "https://example.test/2"},
+		{Number: "3", URL: "https://example.test/3"},
+	}
+
+	searchCalls := 0
+	playbackModeSearchAnimeWithRetry = func(name string) (*models.Anime, error) {
+		searchCalls++
+		if name != "series query" {
+			t.Errorf("search name = %q, want %q", name, "series query")
+		}
+		return anime, nil
+	}
+	playbackModeGetAnimeEpisodes = func(got *models.Anime) ([]models.Episode, error) {
+		if got != anime {
+			t.Errorf("episode fetch anime = %#v, want %#v", got, anime)
+		}
+		return episodes, nil
+	}
+
+	seriesCalls := 0
+	var gotEpisodes []models.Episode
+	var gotTotal int
+	var gotDiscordEnabled bool
+	playbackModeHandleSeries = func(got *models.Anime, eps []models.Episode, totalEpisodes int, discordEnabled bool) error {
+		seriesCalls++
+		if got != anime {
+			t.Errorf("series anime = %#v, want %#v", got, anime)
+		}
+		gotEpisodes = append([]models.Episode(nil), eps...)
+		gotTotal = totalEpisodes
+		gotDiscordEnabled = discordEnabled
+		return nil
+	}
+	playbackModeHandleMovie = func(anime *models.Anime, episodes []models.Episode, discordEnabled bool) error {
+		t.Errorf("movie playback called for series anime")
+		return nil
+	}
+
+	HandlePlaybackMode("series query")
+
+	if searchCalls != 1 {
+		t.Fatalf("search calls = %d, want 1", searchCalls)
+	}
+	if seriesCalls != 1 {
+		t.Fatalf("series playback calls = %d, want 1", seriesCalls)
+	}
+	if gotTotal != len(episodes) {
+		t.Errorf("series total episodes = %d, want %d", gotTotal, len(episodes))
+	}
+	if !reflect.DeepEqual(gotEpisodes, episodes) {
+		t.Errorf("series episodes = %#v, want %#v", gotEpisodes, episodes)
+	}
+	if !gotDiscordEnabled {
+		t.Errorf("discord enabled = false, want true")
+	}
+	if manager.initializeCalls != 1 || manager.shutdownCalls != 1 {
+		t.Errorf("discord manager calls = init:%d shutdown:%d, want 1 each", manager.initializeCalls, manager.shutdownCalls)
+	}
+}
+
+func TestHandlePlaybackModeMovieOrSingleEpisodeUsesMovieHandler(t *testing.T) {
+	tests := []struct {
+		name     string
+		anime    *models.Anime
+		episodes []models.Episode
+	}{
+		{
+			name:  "movie media type",
+			anime: &models.Anime{Name: "Standalone Movie", Source: "FlixHQ", MediaType: models.MediaTypeMovie},
+			episodes: []models.Episode{
+				{Number: "1", URL: "https://example.test/movie"},
+				{Number: "2", URL: "https://example.test/extra"},
+			},
+		},
+		{
+			name:  "single anime episode",
+			anime: &models.Anime{Name: "OVA", Source: "AllAnime", MediaType: models.MediaTypeAnime},
+			episodes: []models.Episode{
+				{Number: "1", URL: "https://example.test/ova"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			installPlaybackModeTestHooks(t)
+
+			playbackModeSearchAnimeWithRetry = func(name string) (*models.Anime, error) {
+				if name != "movie query" {
+					t.Errorf("search name = %q, want %q", name, "movie query")
+				}
+				return tt.anime, nil
+			}
+			playbackModeGetAnimeEpisodes = func(got *models.Anime) ([]models.Episode, error) {
+				if got != tt.anime {
+					t.Errorf("episode fetch anime = %#v, want %#v", got, tt.anime)
+				}
+				return tt.episodes, nil
+			}
+
+			movieCalls := 0
+			var gotEpisodes []models.Episode
+			playbackModeHandleMovie = func(got *models.Anime, eps []models.Episode, discordEnabled bool) error {
+				movieCalls++
+				if got != tt.anime {
+					t.Errorf("movie anime = %#v, want %#v", got, tt.anime)
+				}
+				gotEpisodes = append([]models.Episode(nil), eps...)
+				return nil
+			}
+			playbackModeHandleSeries = func(anime *models.Anime, episodes []models.Episode, totalEpisodes int, discordEnabled bool) error {
+				t.Errorf("series playback called for %s", tt.name)
+				return nil
+			}
+
+			HandlePlaybackMode("movie query")
+
+			if movieCalls != 1 {
+				t.Fatalf("movie playback calls = %d, want 1", movieCalls)
+			}
+			if !reflect.DeepEqual(gotEpisodes, tt.episodes) {
+				t.Errorf("movie episodes = %#v, want %#v", gotEpisodes, tt.episodes)
+			}
+		})
+	}
+}
+
+func TestHandlePlaybackModeBackToSearchContinuesWithFreshSearch(t *testing.T) {
+	installPlaybackModeTestHooks(t)
+
+	firstAnime := &models.Anime{Name: "Needs Season Selection", Source: "FlixHQ", MediaType: models.MediaTypeTV}
+	secondAnime := &models.Anime{Name: "Fresh Result", Source: "AllAnime", MediaType: models.MediaTypeAnime}
+	secondEpisodes := []models.Episode{
+		{Number: "1", URL: "https://example.test/fresh-1"},
+		{Number: "2", URL: "https://example.test/fresh-2"},
+	}
+
+	searchNames := []string{}
+	playbackModeSearchAnimeWithRetry = func(name string) (*models.Anime, error) {
+		searchNames = append(searchNames, name)
+		switch len(searchNames) {
+		case 1:
+			return firstAnime, nil
+		case 2:
+			return secondAnime, nil
+		default:
+			t.Errorf("unexpected extra search for %q", name)
+			return nil, errors.New("unexpected extra search")
+		}
+	}
+
+	episodeFetchCalls := 0
+	playbackModeGetAnimeEpisodes = func(anime *models.Anime) ([]models.Episode, error) {
+		episodeFetchCalls++
+		switch episodeFetchCalls {
+		case 1:
+			if anime != firstAnime {
+				t.Errorf("first episode fetch anime = %#v, want %#v", anime, firstAnime)
+			}
+			return nil, api.ErrBackToSearch
+		case 2:
+			if anime != secondAnime {
+				t.Errorf("second episode fetch anime = %#v, want %#v", anime, secondAnime)
+			}
+			return secondEpisodes, nil
+		default:
+			t.Errorf("unexpected extra episode fetch for %#v", anime)
+			return nil, errors.New("unexpected extra episode fetch")
+		}
+	}
+
+	seriesCalls := 0
+	playbackModeHandleSeries = func(anime *models.Anime, episodes []models.Episode, totalEpisodes int, discordEnabled bool) error {
+		seriesCalls++
+		if anime != secondAnime {
+			t.Errorf("series anime = %#v, want %#v", anime, secondAnime)
+		}
+		if totalEpisodes != len(secondEpisodes) {
+			t.Errorf("series total episodes = %d, want %d", totalEpisodes, len(secondEpisodes))
+		}
+		return nil
+	}
+	playbackModeHandleMovie = func(anime *models.Anime, episodes []models.Episode, discordEnabled bool) error {
+		t.Errorf("movie playback called after back-to-search")
+		return nil
+	}
+
+	HandlePlaybackMode("initial query")
+
+	wantSearchNames := []string{"initial query", ""}
+	if !reflect.DeepEqual(searchNames, wantSearchNames) {
+		t.Fatalf("search names = %#v, want %#v", searchNames, wantSearchNames)
+	}
+	if episodeFetchCalls != 2 {
+		t.Fatalf("episode fetch calls = %d, want 2", episodeFetchCalls)
+	}
+	if seriesCalls != 1 {
+		t.Fatalf("series playback calls = %d, want 1", seriesCalls)
+	}
+}

--- a/internal/handlers/playback_test.go
+++ b/internal/handlers/playback_test.go
@@ -1,5 +1,8 @@
 package handlers
 
+// Tests in this file mutate package-level vars used as DI seams.
+// Do not add t.Parallel(); these tests must run sequentially.
+
 import (
 	"errors"
 	"reflect"

--- a/internal/handlers/update.go
+++ b/internal/handlers/update.go
@@ -7,12 +7,14 @@ import (
 	"github.com/alvarorichard/Goanime/internal/util"
 )
 
+var checkAndPromptUpdate = updater.CheckAndPromptUpdate
+
 // HandleUpdateRequest processes update requests
 func HandleUpdateRequest() error {
 	// Initialize logger for update process
 	util.InitLogger()
 	util.Info("Checking for updates...")
-	if updateErr := updater.CheckAndPromptUpdate(); updateErr != nil {
+	if updateErr := checkAndPromptUpdate(); updateErr != nil {
 		return fmt.Errorf("update failed: %w", updateErr)
 	}
 	return nil

--- a/internal/handlers/upscale.go
+++ b/internal/handlers/upscale.go
@@ -11,6 +11,11 @@ import (
 	"github.com/alvarorichard/Goanime/internal/util"
 )
 
+var (
+	validateFFmpeg   = upscaler.ValidateFFmpeg
+	upscaleImageFile = upscaler.UpscaleImageFile
+)
+
 // HandleUpscaleRequest processes upscale requests
 func HandleUpscaleRequest() error {
 	// Initialize logger for upscale process
@@ -23,7 +28,7 @@ func HandleUpscaleRequest() error {
 	req := util.GlobalUpscaleRequest
 
 	// Validate FFmpeg is available
-	ffmpegVersion, err := upscaler.ValidateFFmpeg()
+	ffmpegVersion, err := validateFFmpeg()
 	if err != nil {
 		return fmt.Errorf("FFmpeg validation failed: %w", err)
 	}
@@ -73,7 +78,7 @@ func handleImageUpscale(inputPath, outputPath string, opts upscaler.Anime4KOptio
 
 	startTime := time.Now()
 
-	if err := upscaler.UpscaleImageFile(inputPath, outputPath, opts); err != nil {
+	if err := upscaleImageFile(inputPath, outputPath, opts); err != nil {
 		return fmt.Errorf("image upscale failed: %w", err)
 	}
 

--- a/internal/playback/common_test.go
+++ b/internal/playback/common_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/alvarorichard/Goanime/internal/models"
 	"github.com/stretchr/testify/assert"
+	"golang.org/x/term"
 )
 
 // TestSelectEpisodeWithFuzzy_EmptyList verifies that passing an empty episode
@@ -23,8 +24,8 @@ func TestFindEpisodeByNumber_NotFound(t *testing.T) {
 	// This test falls back to SelectEpisodeWithFuzzy which opens an interactive
 	// fuzzy finder (tcell-based TUI). On CI there is no TTY, so the fuzzy finder
 	// either panics (Windows) or hangs indefinitely waiting for terminal input.
-	if os.Getenv("CI") != "" {
-		t.Skip("Skipping interactive fuzzy-finder test in CI (no TTY available)")
+	if os.Getenv("CI") != "" || !term.IsTerminal(int(os.Stdin.Fd())) {
+		t.Skip("Skipping interactive fuzzy-finder test without a real TTY")
 	}
 
 	episodes := []models.Episode{

--- a/internal/tracking/local_nocgo_test.go
+++ b/internal/tracking/local_nocgo_test.go
@@ -1,0 +1,40 @@
+//go:build !cgo
+
+package tracking
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestNoCGOLocalTrackerContract(t *testing.T) {
+	t.Parallel()
+
+	if IsCgoEnabled {
+		t.Fatal("IsCgoEnabled must be false in a no-CGO build")
+	}
+
+	dbPath := filepath.Join(t.TempDir(), "progress.db")
+	tracker := NewLocalTracker(dbPath)
+	if tracker != nil {
+		t.Fatalf("NewLocalTracker(%q) = %#v, want nil when CGO is disabled", dbPath, tracker)
+	}
+
+	if _, err := os.Stat(dbPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("no-CGO tracker must not create a SQLite database, stat err = %v", err)
+	}
+
+	if err := tracker.UpdateProgress(Anime{AllanimeID: "anime:ep1", Duration: 1}); !errors.Is(err, ErrTrackerNotInited) {
+		t.Fatalf("UpdateProgress on no-CGO tracker error = %v, want ErrTrackerNotInited", err)
+	}
+
+	if got, err := tracker.GetAnime(1, "anime:ep1"); got != nil || !errors.Is(err, ErrTrackerNotInited) {
+		t.Fatalf("GetAnime on no-CGO tracker = (%#v, %v), want (nil, ErrTrackerNotInited)", got, err)
+	}
+
+	if got, err := tracker.GetAllAnime(); got != nil || !errors.Is(err, ErrTrackerNotInited) {
+		t.Fatalf("GetAllAnime on no-CGO tracker = (%#v, %v), want (nil, ErrTrackerNotInited)", got, err)
+	}
+}

--- a/internal/upscaler/video.go
+++ b/internal/upscaler/video.go
@@ -22,6 +22,13 @@ import (
 	"github.com/alvarorichard/Goanime/internal/util"
 )
 
+var (
+	lookPath = exec.LookPath
+	statPath = os.Stat
+	getEnv   = os.Getenv
+	goos     = runtime.GOOS
+)
+
 // VideoUpscaleConfig holds configuration for video upscaling
 type VideoUpscaleConfig struct {
 	InputPath      string
@@ -41,20 +48,7 @@ type VideoUpscaleConfig struct {
 
 // DefaultVideoConfig returns default video upscaling configuration
 func DefaultVideoConfig() VideoUpscaleConfig {
-	ffmpegPath := "ffmpeg"
-	ffprobePath := "ffprobe"
-
-	// Try to find FFmpeg in common locations
-	if runtime.GOOS == "darwin" {
-		// Check Homebrew locations
-		if _, err := os.Stat("/opt/homebrew/bin/ffmpeg"); err == nil {
-			ffmpegPath = "/opt/homebrew/bin/ffmpeg"
-			ffprobePath = "/opt/homebrew/bin/ffprobe"
-		} else if _, err := os.Stat("/usr/local/bin/ffmpeg"); err == nil {
-			ffmpegPath = "/usr/local/bin/ffmpeg"
-			ffprobePath = "/usr/local/bin/ffprobe"
-		}
-	}
+	ffmpegPath, ffprobePath := resolveFFmpegTools()
 
 	return VideoUpscaleConfig{
 		Anime4KOptions: DefaultOptions(),
@@ -69,6 +63,49 @@ func DefaultVideoConfig() VideoUpscaleConfig {
 		AudioBitrate:   "192k",
 		FrameRate:      0,
 	}
+}
+
+func resolveFFmpegTools() (string, string) {
+	ffmpegPath := "ffmpeg"
+	ffprobePath := "ffprobe"
+
+	// Prefer PATH first so local shims and user-selected toolchains win.
+	if path, err := lookPath("ffmpeg"); err == nil {
+		ffmpegPath = path
+	}
+	if path, err := lookPath("ffprobe"); err == nil {
+		ffprobePath = path
+	}
+
+	// Deterministic E2E runs must not silently pick host-level Homebrew tools
+	// outside the test PATH.
+	if getEnv("GOANIME_E2E") != "" {
+		return ffmpegPath, ffprobePath
+	}
+
+	if goos != "darwin" {
+		return ffmpegPath, ffprobePath
+	}
+
+	// Fallback for macOS users whose FFmpeg is installed in common Homebrew
+	// paths but not exported in PATH.
+	for _, base := range []string{"/opt/homebrew/bin", "/usr/local/bin"} {
+		ffmpegCandidate := filepath.Join(base, "ffmpeg")
+		ffprobeCandidate := filepath.Join(base, "ffprobe")
+
+		if ffmpegPath == "ffmpeg" {
+			if _, err := statPath(ffmpegCandidate); err == nil {
+				ffmpegPath = ffmpegCandidate
+			}
+		}
+		if ffprobePath == "ffprobe" {
+			if _, err := statPath(ffprobeCandidate); err == nil {
+				ffprobePath = ffprobeCandidate
+			}
+		}
+	}
+
+	return ffmpegPath, ffprobePath
 }
 
 // VideoUpscaler handles video upscaling operations

--- a/internal/upscaler/video_paths_test.go
+++ b/internal/upscaler/video_paths_test.go
@@ -1,5 +1,8 @@
 package upscaler
 
+// Tests in this file mutate package-level vars used as DI seams.
+// Do not add t.Parallel(); these tests must run sequentially.
+
 import (
 	"errors"
 	"io/fs"

--- a/internal/upscaler/video_paths_test.go
+++ b/internal/upscaler/video_paths_test.go
@@ -61,7 +61,7 @@ func TestResolveFFmpegToolsSkipsMacFallbackInE2E(t *testing.T) {
 		}
 		return ""
 	}
-	lookPath = func(file string) (string, error) {
+	lookPath = func(_ string) (string, error) {
 		return "", errors.New("missing from PATH")
 	}
 	statPath = func(path string) (fs.FileInfo, error) {

--- a/internal/upscaler/video_paths_test.go
+++ b/internal/upscaler/video_paths_test.go
@@ -1,0 +1,75 @@
+package upscaler
+
+import (
+	"errors"
+	"io/fs"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestResolveFFmpegToolsPrefersPathLookups(t *testing.T) {
+	originalLookPath := lookPath
+	originalStatPath := statPath
+	originalGetEnv := getEnv
+	originalGOOS := goos
+	t.Cleanup(func() {
+		lookPath = originalLookPath
+		statPath = originalStatPath
+		getEnv = originalGetEnv
+		goos = originalGOOS
+	})
+
+	goos = "darwin"
+	getEnv = func(string) string { return "" }
+	lookPath = func(file string) (string, error) {
+		switch file {
+		case "ffmpeg":
+			return "/tmp/shims/ffmpeg", nil
+		case "ffprobe":
+			return "/tmp/shims/ffprobe", nil
+		default:
+			return "", errors.New("unexpected tool")
+		}
+	}
+	statPath = func(path string) (fs.FileInfo, error) {
+		t.Fatalf("stat fallback should not run when PATH already resolves %s", path)
+		return nil, errors.New("unreachable")
+	}
+
+	ffmpegPath, ffprobePath := resolveFFmpegTools()
+	assert.Equal(t, "/tmp/shims/ffmpeg", ffmpegPath)
+	assert.Equal(t, "/tmp/shims/ffprobe", ffprobePath)
+}
+
+func TestResolveFFmpegToolsSkipsMacFallbackInE2E(t *testing.T) {
+	originalLookPath := lookPath
+	originalStatPath := statPath
+	originalGetEnv := getEnv
+	originalGOOS := goos
+	t.Cleanup(func() {
+		lookPath = originalLookPath
+		statPath = originalStatPath
+		getEnv = originalGetEnv
+		goos = originalGOOS
+	})
+
+	goos = "darwin"
+	getEnv = func(key string) string {
+		if key == "GOANIME_E2E" {
+			return "1"
+		}
+		return ""
+	}
+	lookPath = func(file string) (string, error) {
+		return "", errors.New("missing from PATH")
+	}
+	statPath = func(path string) (fs.FileInfo, error) {
+		t.Fatalf("macOS fallback should be disabled in GOANIME_E2E, got stat on %s", path)
+		return nil, errors.New("unreachable")
+	}
+
+	ffmpegPath, ffprobePath := resolveFFmpegTools()
+	assert.Equal(t, "ffmpeg", ffmpegPath)
+	assert.Equal(t, "ffprobe", ffprobePath)
+}

--- a/test/e2e/cli_smoke_test.go
+++ b/test/e2e/cli_smoke_test.go
@@ -86,10 +86,12 @@ func runGoAnime(t *testing.T, args ...string) (int, string) {
 func runGoAnimeWithEnv(t *testing.T, env []string, args ...string) (int, string) {
 	t.Helper()
 
+	binary := goanimeBinary(t)
+
 	ctx, cancel := context.WithTimeout(context.Background(), e2eCommandTimeout)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, goanimeBinary(t), args...)
+	cmd := exec.CommandContext(ctx, binary, args...)
 	cmd.Dir = repoRoot(t)
 	cmd.Env = env
 

--- a/test/e2e/cli_smoke_test.go
+++ b/test/e2e/cli_smoke_test.go
@@ -4,6 +4,7 @@ package e2e_test
 
 import (
 	"bytes"
+	"context"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -20,6 +21,8 @@ var (
 	binaryError error
 	buildDir    string
 )
+
+const e2eCommandTimeout = 30 * time.Second
 
 func TestMain(m *testing.M) {
 	code := m.Run()
@@ -77,15 +80,27 @@ func repoRoot(t *testing.T) string {
 func runGoAnime(t *testing.T, args ...string) (int, string) {
 	t.Helper()
 
-	cmd := exec.Command(goanimeBinary(t), args...)
+	return runGoAnimeWithEnv(t, isolatedEnv(t), args...)
+}
+
+func runGoAnimeWithEnv(t *testing.T, env []string, args ...string) (int, string) {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), e2eCommandTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, goanimeBinary(t), args...)
 	cmd.Dir = repoRoot(t)
-	cmd.Env = isolatedEnv(t)
+	cmd.Env = env
 
 	var output bytes.Buffer
 	cmd.Stdout = &output
 	cmd.Stderr = &output
 
 	err := cmd.Run()
+	if ctx.Err() == context.DeadlineExceeded {
+		t.Fatalf("goanime %q timed out; likely a regression in early validation\noutput:\n%s", strings.Join(args, " "), output.String())
+	}
 	if err == nil {
 		return 0, output.String()
 	}
@@ -202,6 +217,8 @@ func TestCLIRejectsInvalidDownloadArguments(t *testing.T) {
 }
 
 func TestCLIRejectsInvalidUpscaleArguments(t *testing.T) {
+	missingInput := filepath.Join(t.TempDir(), "definitely-missing.png")
+
 	tests := []struct {
 		name string
 		args []string
@@ -214,7 +231,7 @@ func TestCLIRejectsInvalidUpscaleArguments(t *testing.T) {
 		},
 		{
 			name: "upscale input must exist",
-			args: []string{"--upscale", filepath.Join("testdata", "missing.png")},
+			args: []string{"--upscale", missingInput},
 			want: "input file not found",
 		},
 	}

--- a/test/e2e/cli_smoke_test.go
+++ b/test/e2e/cli_smoke_test.go
@@ -1,0 +1,250 @@
+//go:build e2e
+
+package e2e_test
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+var (
+	buildOnce   sync.Once
+	binaryPath  string
+	binaryError error
+	buildDir    string
+)
+
+func TestMain(m *testing.M) {
+	code := m.Run()
+	if buildDir != "" {
+		_ = os.RemoveAll(buildDir)
+	}
+	os.Exit(code)
+}
+
+func goanimeBinary(t *testing.T) string {
+	t.Helper()
+
+	buildOnce.Do(func() {
+		var err error
+		buildDir, err = os.MkdirTemp("", "goanime-e2e-*")
+		if err != nil {
+			binaryError = err
+			return
+		}
+
+		name := "goanime-e2e"
+		if runtime.GOOS == "windows" {
+			name += ".exe"
+		}
+		binaryPath = filepath.Join(buildDir, name)
+
+		cmd := exec.Command("go", "build", "-trimpath", "-o", binaryPath, "./cmd/goanime")
+		cmd.Dir = repoRoot(t)
+		cmd.Env = append(os.Environ(), "CGO_ENABLED=0")
+
+		var output bytes.Buffer
+		cmd.Stdout = &output
+		cmd.Stderr = &output
+		if err := cmd.Run(); err != nil {
+			binaryError = &commandError{err: err, output: output.String()}
+		}
+	})
+
+	if binaryError != nil {
+		t.Fatalf("failed to build goanime binary: %v", binaryError)
+	}
+	return binaryPath
+}
+
+func repoRoot(t *testing.T) string {
+	t.Helper()
+
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return filepath.Clean(filepath.Join(wd, "..", ".."))
+}
+
+func runGoAnime(t *testing.T, args ...string) (int, string) {
+	t.Helper()
+
+	cmd := exec.Command(goanimeBinary(t), args...)
+	cmd.Dir = repoRoot(t)
+	cmd.Env = isolatedEnv(t)
+
+	var output bytes.Buffer
+	cmd.Stdout = &output
+	cmd.Stderr = &output
+
+	err := cmd.Run()
+	if err == nil {
+		return 0, output.String()
+	}
+	if exitErr, ok := err.(*exec.ExitError); ok {
+		return exitErr.ExitCode(), output.String()
+	}
+	t.Fatalf("failed to run goanime %q: %v\n%s", strings.Join(args, " "), err, output.String())
+	return -1, ""
+}
+
+func isolatedEnv(t *testing.T) []string {
+	t.Helper()
+
+	home := t.TempDir()
+	env := append(os.Environ(),
+		"GOANIME_E2E=1",
+		"HOME="+home,
+		"USERPROFILE="+home,
+	)
+	return env
+}
+
+func assertExitCode(t *testing.T, got, want int, output string) {
+	t.Helper()
+
+	if got != want {
+		t.Fatalf("exit code = %d, want %d\noutput:\n%s", got, want, output)
+	}
+}
+
+func assertOutputContains(t *testing.T, output string, want ...string) {
+	t.Helper()
+
+	for _, fragment := range want {
+		if !strings.Contains(output, fragment) {
+			t.Fatalf("output does not contain %q\noutput:\n%s", fragment, output)
+		}
+	}
+}
+
+func TestCLIHelpAndVersionSmoke(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want []string
+	}{
+		{
+			name: "help",
+			args: []string{"--help"},
+			want: []string{"GoAnime", "Usage:", "--update", "--upscale"},
+		},
+		{
+			name: "short help",
+			args: []string{"-h"},
+			want: []string{"GoAnime", "Options:", "Examples:"},
+		},
+		{
+			name: "version",
+			args: []string{"--version"},
+			want: []string{"GoAnime v", "tracking"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			code, output := runGoAnime(t, tt.args...)
+			assertExitCode(t, code, 0, output)
+			assertOutputContains(t, output, tt.want...)
+		})
+	}
+}
+
+func TestCLIRejectsInvalidPlaybackName(t *testing.T) {
+	code, output := runGoAnime(t, "abc")
+
+	if code == 0 {
+		t.Fatalf("expected non-zero exit for short playback query\noutput:\n%s", output)
+	}
+	assertOutputContains(t, output, "anime name must have at least 4 characters")
+}
+
+func TestCLIRejectsInvalidDownloadArguments(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{
+			name: "download requires arguments",
+			args: []string{"-d"},
+			want: "download mode requires anime name and episode number/range",
+		},
+		{
+			name: "download range must be ordered",
+			args: []string{"-d", "-r", "naruto", "5-1"},
+			want: "start episode (5) cannot be greater than end episode (1)",
+		},
+		{
+			name: "movie tv download requires season and episode",
+			args: []string{"-dm", "--type", "tv", "dexter"},
+			want: "TV episode download requires show name, season number, and episode number",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			code, output := runGoAnime(t, tt.args...)
+			if code == 0 {
+				t.Fatalf("expected non-zero exit\noutput:\n%s", output)
+			}
+			assertOutputContains(t, output, tt.want)
+		})
+	}
+}
+
+func TestCLIRejectsInvalidUpscaleArguments(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{
+			name: "upscale requires input",
+			args: []string{"--upscale"},
+			want: "upscale mode requires an input file path",
+		},
+		{
+			name: "upscale input must exist",
+			args: []string{"--upscale", filepath.Join("testdata", "missing.png")},
+			want: "input file not found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			code, output := runGoAnime(t, tt.args...)
+			if code == 0 {
+				t.Fatalf("expected non-zero exit\noutput:\n%s", output)
+			}
+			assertOutputContains(t, output, tt.want)
+		})
+	}
+}
+
+func TestCLISmokeCompletesQuickly(t *testing.T) {
+	start := time.Now()
+	code, output := runGoAnime(t, "--version")
+	assertExitCode(t, code, 0, output)
+
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Fatalf("--version took %s, expected a fast no-network smoke path", elapsed)
+	}
+}
+
+type commandError struct {
+	err    error
+	output string
+}
+
+func (e *commandError) Error() string {
+	return e.err.Error() + "\n" + e.output
+}

--- a/test/e2e/command_workflow_e2e_test.go
+++ b/test/e2e/command_workflow_e2e_test.go
@@ -1,0 +1,232 @@
+//go:build e2e
+
+package e2e_test
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/alvarorichard/Goanime/internal/util"
+)
+
+func TestCommandWorkflowsEndToEndWithoutSideEffects(t *testing.T) {
+	t.Run("direct playback search route", func(t *testing.T) {
+		name, err := parseCommand(t, "Attack", "on", "Titan")
+		if err != nil {
+			t.Fatalf("FlagParser returned error: %v", err)
+		}
+		if name != "attack-on-titan" {
+			t.Fatalf("parsed name = %q, want %q", name, "attack-on-titan")
+		}
+		if util.GlobalQuality != "best" {
+			t.Fatalf("GlobalQuality = %q, want best", util.GlobalQuality)
+		}
+	})
+
+	t.Run("update route", func(t *testing.T) {
+		_, err := parseCommand(t, "--update")
+		if !errors.Is(err, util.ErrUpdateRequested) {
+			t.Fatalf("error = %v, want ErrUpdateRequested", err)
+		}
+	})
+
+	t.Run("anime single episode download route", func(t *testing.T) {
+		outDir := t.TempDir()
+		name, err := parseCommand(t,
+			"-d",
+			"--source", "allanime",
+			"--quality", "720p",
+			"-o", outDir,
+			"One", "Piece", "12",
+		)
+		if !errors.Is(err, util.ErrDownloadRequested) {
+			t.Fatalf("error = %v, want ErrDownloadRequested", err)
+		}
+		if name != "one-piece" {
+			t.Fatalf("parsed name = %q, want one-piece", name)
+		}
+		req := mustDownloadRequest(t)
+		if req.AnimeName != "One Piece" || req.EpisodeNum != 12 || req.IsRange || req.IsAll {
+			t.Fatalf("unexpected download request: %+v", req)
+		}
+		if req.Source != "allanime" || req.Quality != "720p" || req.OutputDir != outDir {
+			t.Fatalf("download options not preserved: %+v", req)
+		}
+	})
+
+	t.Run("anime smart range download route", func(t *testing.T) {
+		_, err := parseCommand(t,
+			"-d",
+			"-r",
+			"--source", "allanime",
+			"--quality", "best",
+			"--allanime-smart",
+			"Vinland", "Saga", "1-4",
+		)
+		if !errors.Is(err, util.ErrDownloadRequested) {
+			t.Fatalf("error = %v, want ErrDownloadRequested", err)
+		}
+		req := mustDownloadRequest(t)
+		if req.AnimeName != "Vinland Saga" || !req.IsRange || req.StartEpisode != 1 || req.EndEpisode != 4 {
+			t.Fatalf("unexpected range request: %+v", req)
+		}
+		if !req.AllAnimeSmart {
+			t.Fatal("AllAnimeSmart was not enabled")
+		}
+	})
+
+	t.Run("anime download all route", func(t *testing.T) {
+		_, err := parseCommand(t, "-d", "-a", "One", "Piece")
+		if !errors.Is(err, util.ErrDownloadRequested) {
+			t.Fatalf("error = %v, want ErrDownloadRequested", err)
+		}
+		req := mustDownloadRequest(t)
+		if req.AnimeName != "One Piece" || !req.IsAll {
+			t.Fatalf("unexpected download-all request: %+v", req)
+		}
+	})
+
+	t.Run("movie download route", func(t *testing.T) {
+		_, err := parseCommand(t,
+			"-dm",
+			"--quality", "1080p",
+			"--subs", "portuguese",
+			"Spider", "Man",
+		)
+		if !errors.Is(err, util.ErrMovieDownloadRequested) {
+			t.Fatalf("error = %v, want ErrMovieDownloadRequested", err)
+		}
+		req := mustDownloadRequest(t)
+		if req.AnimeName != "Spider Man" || !req.IsMovie || req.IsTV || req.Quality != "1080p" || req.SubsLanguage != "portuguese" {
+			t.Fatalf("unexpected movie request: %+v", req)
+		}
+	})
+
+	t.Run("tv single episode download route", func(t *testing.T) {
+		_, err := parseCommand(t, "-dm", "--type", "tv", "Breaking", "Bad", "1", "2")
+		if !errors.Is(err, util.ErrMovieDownloadRequested) {
+			t.Fatalf("error = %v, want ErrMovieDownloadRequested", err)
+		}
+		req := mustDownloadRequest(t)
+		if req.AnimeName != "Breaking Bad" || !req.IsTV || req.SeasonNum != 1 || req.EpisodeNum != 2 || req.IsRange {
+			t.Fatalf("unexpected tv request: %+v", req)
+		}
+	})
+
+	t.Run("tv range download route", func(t *testing.T) {
+		_, err := parseCommand(t, "-dm", "-r", "Breaking", "Bad", "2", "1-3")
+		if !errors.Is(err, util.ErrMovieDownloadRequested) {
+			t.Fatalf("error = %v, want ErrMovieDownloadRequested", err)
+		}
+		req := mustDownloadRequest(t)
+		if req.AnimeName != "Breaking Bad" || !req.IsTV || !req.IsRange || req.SeasonNum != 2 || req.StartEpisode != 1 || req.EndEpisode != 3 {
+			t.Fatalf("unexpected tv range request: %+v", req)
+		}
+	})
+
+	t.Run("tv download all route", func(t *testing.T) {
+		_, err := parseCommand(t, "-dm", "-a", "Breaking", "Bad")
+		if !errors.Is(err, util.ErrMovieDownloadRequested) {
+			t.Fatalf("error = %v, want ErrMovieDownloadRequested", err)
+		}
+		req := mustDownloadRequest(t)
+		if req.AnimeName != "Breaking Bad" || !req.IsTV || !req.IsAll {
+			t.Fatalf("unexpected tv download-all request: %+v", req)
+		}
+	})
+
+	t.Run("playback media preferences route", func(t *testing.T) {
+		name, err := parseCommand(t,
+			"--type", "movie",
+			"--subs", "portuguese",
+			"--audio", "pt-BR,english",
+			"--no-subs",
+			"Matrix",
+		)
+		if err != nil {
+			t.Fatalf("FlagParser returned error: %v", err)
+		}
+		if name != "matrix" {
+			t.Fatalf("parsed name = %q, want matrix", name)
+		}
+		if util.GlobalMediaType != "movie" || util.GlobalSubsLanguage != "portuguese" || util.GlobalAudioLanguage != "pt-BR,english" || !util.GlobalNoSubs {
+			t.Fatalf("media preferences not preserved: type=%q subs=%q audio=%q noSubs=%v",
+				util.GlobalMediaType, util.GlobalSubsLanguage, util.GlobalAudioLanguage, util.GlobalNoSubs)
+		}
+	})
+
+	t.Run("image upscale route", func(t *testing.T) {
+		tmp := t.TempDir()
+		input := filepath.Join(tmp, "frame.png")
+		output := filepath.Join(tmp, "frame-upscaled.png")
+		if err := os.WriteFile(input, []byte("placeholder"), 0o600); err != nil {
+			t.Fatalf("failed to create input file: %v", err)
+		}
+
+		name, err := parseCommand(t,
+			"--upscale",
+			"--upscale-output", output,
+			"--upscale-scale", "4",
+			"--upscale-passes", "3",
+			"--upscale-fast",
+			"--upscale-workers", "2",
+			input,
+		)
+		if !errors.Is(err, util.ErrUpscaleRequested) {
+			t.Fatalf("error = %v, want ErrUpscaleRequested", err)
+		}
+		if name != input {
+			t.Fatalf("parsed input = %q, want %q", name, input)
+		}
+		req := util.GlobalUpscaleRequest
+		if req == nil {
+			t.Fatal("GlobalUpscaleRequest is nil")
+		}
+		if req.InputPath != input || req.OutputPath != output || req.ScaleFactor != 4 || req.Passes != 3 || !req.FastMode || req.Workers != 2 {
+			t.Fatalf("unexpected upscale request: %+v", req)
+		}
+	})
+}
+
+func parseCommand(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+
+	oldArgs := os.Args
+	resetUtilGlobals()
+	os.Args = append([]string{"goanime"}, args...)
+
+	t.Cleanup(func() {
+		os.Args = oldArgs
+		resetUtilGlobals()
+	})
+
+	return util.FlagParser()
+}
+
+func mustDownloadRequest(t *testing.T) *util.DownloadRequest {
+	t.Helper()
+
+	if util.GlobalDownloadRequest == nil {
+		t.Fatal("GlobalDownloadRequest is nil")
+	}
+	return util.GlobalDownloadRequest
+}
+
+func resetUtilGlobals() {
+	util.IsDebug = false
+	util.PerfEnabled = false
+	util.GlobalSource = ""
+	util.GlobalQuality = ""
+	util.GlobalMediaType = ""
+	util.GlobalSubsLanguage = ""
+	util.GlobalAudioLanguage = ""
+	util.GlobalSubtitles = nil
+	util.GlobalNoSubs = false
+	util.GlobalReferer = ""
+	util.GlobalOutputDir = ""
+	util.GlobalAnimeSource = ""
+	util.GlobalDownloadRequest = nil
+	util.GlobalUpscaleRequest = nil
+}

--- a/test/e2e/dependency_shims_e2e_test.go
+++ b/test/e2e/dependency_shims_e2e_test.go
@@ -1,0 +1,154 @@
+//go:build e2e
+
+package e2e_test
+
+import (
+	"bytes"
+	"image"
+	"image/color"
+	"image/png"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestCLIUpscaleReportsMissingFFmpegWithIsolatedPath(t *testing.T) {
+	tmp := t.TempDir()
+	input := filepath.Join(tmp, "frame.png")
+	writeTestPNG(t, input)
+
+	env := isolatedEnvWithPath(t, t.TempDir())
+	code, output := runGoAnimeWithEnv(t, env, "--upscale", input)
+
+	if code == 0 {
+		t.Fatalf("expected non-zero exit when ffmpeg is missing\noutput:\n%s", output)
+	}
+	assertOutputContains(t, output, "FFmpeg validation failed", "FFmpeg not found")
+}
+
+func TestCLIUpscaleUsesFFmpegShimFromIsolatedPath(t *testing.T) {
+	tmp := t.TempDir()
+	input := filepath.Join(tmp, "frame.png")
+	outputPath := filepath.Join(tmp, "frame-upscaled.png")
+	writeTestPNG(t, input)
+
+	shimDir := t.TempDir()
+	markerPath := filepath.Join(tmp, "ffmpeg-invocations.txt")
+	writeFFmpegShim(t, shimDir, markerPath)
+
+	env := isolatedEnvWithPath(t, shimDir)
+	code, output := runGoAnimeWithEnv(t, env,
+		"--upscale",
+		"--upscale-output", outputPath,
+		"--upscale-passes", "1",
+		"--upscale-fast",
+		input,
+	)
+	assertExitCode(t, code, 0, output)
+
+	marker, err := os.ReadFile(markerPath)
+	if err != nil {
+		t.Fatalf("expected ffmpeg shim to be invoked: %v\noutput:\n%s", err, output)
+	}
+	if !strings.Contains(string(marker), "-version") {
+		t.Fatalf("ffmpeg shim invocations = %q, want -version", string(marker))
+	}
+	if _, err := os.Stat(outputPath); err != nil {
+		t.Fatalf("expected upscaled output at %s: %v\noutput:\n%s", outputPath, err, output)
+	}
+}
+
+func runGoAnimeWithEnv(t *testing.T, env []string, args ...string) (int, string) {
+	t.Helper()
+
+	cmd := exec.Command(goanimeBinary(t), args...)
+	cmd.Dir = repoRoot(t)
+	cmd.Env = env
+
+	var output bytes.Buffer
+	cmd.Stdout = &output
+	cmd.Stderr = &output
+
+	err := cmd.Run()
+	if err == nil {
+		return 0, output.String()
+	}
+	if exitErr, ok := err.(*exec.ExitError); ok {
+		return exitErr.ExitCode(), output.String()
+	}
+	t.Fatalf("failed to run goanime %q: %v\n%s", strings.Join(args, " "), err, output.String())
+	return -1, ""
+}
+
+func isolatedEnvWithPath(t *testing.T, path string) []string {
+	t.Helper()
+
+	env := isolatedEnv(t)
+	env = replaceEnv(env, "PATH", path)
+	env = replaceEnv(env, "Path", path)
+	return env
+}
+
+func replaceEnv(env []string, key, value string) []string {
+	prefix := key + "="
+	replaced := false
+	for i, entry := range env {
+		if strings.HasPrefix(entry, prefix) {
+			env[i] = prefix + value
+			replaced = true
+		}
+	}
+	if !replaced {
+		env = append(env, prefix+value)
+	}
+	return env
+}
+
+func writeTestPNG(t *testing.T, path string) {
+	t.Helper()
+
+	img := image.NewRGBA(image.Rect(0, 0, 2, 2))
+	img.Set(0, 0, color.RGBA{R: 0x20, G: 0x40, B: 0x80, A: 0xff})
+	img.Set(1, 0, color.RGBA{R: 0xf0, G: 0xc0, B: 0x40, A: 0xff})
+	img.Set(0, 1, color.RGBA{R: 0x30, G: 0x90, B: 0x60, A: 0xff})
+	img.Set(1, 1, color.RGBA{R: 0xe0, G: 0x40, B: 0x50, A: 0xff})
+
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("failed to create test image: %v", err)
+	}
+	defer func() {
+		if err := f.Close(); err != nil {
+			t.Fatalf("failed to close test image: %v", err)
+		}
+	}()
+	if err := png.Encode(f, img); err != nil {
+		t.Fatalf("failed to encode test image: %v", err)
+	}
+}
+
+func writeFFmpegShim(t *testing.T, dir, markerPath string) {
+	t.Helper()
+
+	if runtime.GOOS == "windows" {
+		script := "@echo off\r\n" +
+			"echo %*>>\"" + markerPath + "\"\r\n" +
+			"echo ffmpeg version e2e-shim\r\n" +
+			"exit /b 0\r\n"
+		if err := os.WriteFile(filepath.Join(dir, "ffmpeg.bat"), []byte(script), 0o700); err != nil {
+			t.Fatalf("failed to write ffmpeg shim: %v", err)
+		}
+		return
+	}
+
+	script := "#!/bin/sh\n" +
+		"printf '%s\\n' \"$*\" >> '" + markerPath + "'\n" +
+		"printf '%s\\n' 'ffmpeg version e2e-shim'\n" +
+		"exit 0\n"
+	if err := os.WriteFile(filepath.Join(dir, "ffmpeg"), []byte(script), 0o700); err != nil {
+		t.Fatalf("failed to write ffmpeg shim: %v", err)
+	}
+}

--- a/test/e2e/dependency_shims_e2e_test.go
+++ b/test/e2e/dependency_shims_e2e_test.go
@@ -3,12 +3,10 @@
 package e2e_test
 
 import (
-	"bytes"
 	"image"
 	"image/color"
 	"image/png"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -61,28 +59,6 @@ func TestCLIUpscaleUsesFFmpegShimFromIsolatedPath(t *testing.T) {
 	}
 }
 
-func runGoAnimeWithEnv(t *testing.T, env []string, args ...string) (int, string) {
-	t.Helper()
-
-	cmd := exec.Command(goanimeBinary(t), args...)
-	cmd.Dir = repoRoot(t)
-	cmd.Env = env
-
-	var output bytes.Buffer
-	cmd.Stdout = &output
-	cmd.Stderr = &output
-
-	err := cmd.Run()
-	if err == nil {
-		return 0, output.String()
-	}
-	if exitErr, ok := err.(*exec.ExitError); ok {
-		return exitErr.ExitCode(), output.String()
-	}
-	t.Fatalf("failed to run goanime %q: %v\n%s", strings.Join(args, " "), err, output.String())
-	return -1, ""
-}
-
 func isolatedEnvWithPath(t *testing.T, path string) []string {
 	t.Helper()
 
@@ -99,6 +75,7 @@ func replaceEnv(env []string, key, value string) []string {
 		if strings.HasPrefix(entry, prefix) {
 			env[i] = prefix + value
 			replaced = true
+			break
 		}
 	}
 	if !replaced {


### PR DESCRIPTION
## Summary

Adds a deterministic QA/versioning gate for GoAnime so release-critical flows are covered without relying on external providers, mpv, ffmpeg, Discord, or interactive terminals.

## What changed

- Added opt-in E2E tests for CLI help/version, command routing, invalid argument handling, download/upscale parsing, and ffmpeg dependency shims.
- Added offline handler and workflow tests for playback, anime downloads, movie/TV downloads, update handling, image upscale, and no-CGO tracking behavior.
- Added small package-level test seams that keep production defaults unchanged while allowing deterministic fakes in tests.
- Added the deterministic E2E suite to CI and release workflows.
- Documented the QA E2E versioning gate, PM/QA acceptance criteria, live-source classification rules, and release evidence requirements.

## Why

The current PR coverage report showed low patch coverage on composed runtime flows, especially download workflow orchestration. These tests move the release gate from argument parsing only to proving that important commands reach the right subsystems under controlled, repeatable conditions.

## Validation

Executed locally on Windows with Go 1.26.2 and `CGO_ENABLED=0`:

- `go test ./internal/handlers ./internal/download ./internal/tracking -count=1`
- `go test -tags e2e ./test/e2e -count=1`
- `go test -count=1 ./...`
- `go fmt ./...`
- `go mod verify`
- `go vet ./...`
- `go test -tags e2e -count=1 -v ./test/e2e`
- `go build -v ./cmd/goanime`
- `govulncheck ./...`
- `gosec ./...`
- `staticcheck ./...`
- `golangci-lint run --timeout=15m`

Note: local `go test -race` could not run on this Windows environment because `runtime/cgo` requires `gcc`; the GitHub Linux CI/release workflow still runs the race suite.

## Codacy and Codecov

- The latest public Codacy comment on PR #151 reports `0 new issues`.
- Codecov for PR #151 reported the branch was behind `dev`; this branch is created from the latest `origin/dev` commit before applying the QA coverage changes.
