### PR TITLE
test(api): cover source resolution and orchestration

### DIFF
--- a/internal/api/allanime_enhanced.go
+++ b/internal/api/allanime_enhanced.go
@@ -3,7 +3,6 @@ package api
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/alvarorichard/Goanime/internal/models"
 	"github.com/alvarorichard/Goanime/internal/scraper"
@@ -12,73 +11,41 @@ import (
 
 // GetEpisodeStreamURLEnhanced gets streaming URL with AllAnime navigation support
 func GetEpisodeStreamURLEnhanced(episode *models.Episode, anime *models.Anime, quality string) (string, error) {
-	// Determine source type and use appropriate method
-	sourceName := "Unknown"
-	scraperType := scraper.AllAnimeType // Default
-
-	// Enhanced source detection like in enhanced.go
-	if anime.Source != "" {
-		sourceName = anime.Source
-		if strings.Contains(anime.Source, "AllAnime") {
-			scraperType = scraper.AllAnimeType
-		} else if strings.Contains(anime.Source, "AnimeFire") {
-			scraperType = scraper.AnimefireType
-		}
-	} else if strings.Contains(anime.Name, "[AllAnime]") {
-		// Priority 1: Name tag detection
-		scraperType = scraper.AllAnimeType
-		sourceName = "AllAnime"
-	} else if strings.Contains(anime.Name, "[AnimeFire]") {
-		// Priority 2: AnimeFire tag detection
-		scraperType = scraper.AnimefireType
-		sourceName = "Animefire.io"
-	} else if len(anime.URL) < 30 && strings.ContainsAny(anime.URL, "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789") && !strings.Contains(anime.URL, "http") {
-		// Priority 3: URL analysis for AllAnime (short IDs)
-		scraperType = scraper.AllAnimeType
-		sourceName = "AllAnime"
-	} else if strings.Contains(anime.URL, "animefire") {
-		// Priority 4: URL analysis for AnimeFire
-		scraperType = scraper.AnimefireType
-		sourceName = "Animefire.io"
-	} else if strings.Contains(anime.URL, "allanime") {
-		// Priority 5: AllAnime full URLs
-		scraperType = scraper.AllAnimeType
-		sourceName = "AllAnime"
+	resolved, err := ResolveSource(anime)
+	if err != nil {
+		return "", err
 	}
 
 	util.Debug("Enhanced episode URL fetch",
-		"source", sourceName,
+		"source", resolved.Name,
 		"episode", episode.Number,
 		"quality", quality)
 
-	// Use AllAnime enhanced navigation if applicable
-	if scraperType == scraper.AllAnimeType {
-		url, metadata, err := GetAllAnimeEpisodeURLDirect(anime, episode.Number, quality)
-		if err != nil {
-			return "", fmt.Errorf("failed to get AllAnime episode URL: %w", err)
-		}
-
-		util.Debug("AllAnime episode URL retrieved via direct method",
-			"episode", episode.Number,
-			"quality", metadata["quality"],
-			"priority", metadata["priority"])
-
-		return url, nil
+	if resolved.Kind != SourceAllAnime {
+		return GetEpisodeStreamURL(episode, anime, quality)
 	}
 
-	// Fallback to regular enhanced API
-	return GetEpisodeStreamURL(episode, anime, quality)
+	url, metadata, err := GetAllAnimeEpisodeURLDirect(anime, providerEpisodeNumber(episode), quality)
+	if err != nil {
+		return "", fmt.Errorf("failed to get AllAnime episode URL: %w", err)
+	}
+
+	util.Debug("AllAnime episode URL retrieved via direct method",
+		"episode", providerEpisodeNumber(episode),
+		"quality", metadata["quality"],
+		"priority", metadata["priority"])
+
+	return url, nil
 }
 
 // GetAllAnimeEpisodeURLDirect gets streaming URL directly without circular dependencies
-func GetAllAnimeEpisodeURLDirect(anime *models.Anime, episodeNumber string, quality string) (string, map[string]string, error) {
-	if !isAllAnimeSourceAPI(anime) {
+func GetAllAnimeEpisodeURLDirect(anime *models.Anime, episodeNumber, quality string) (string, map[string]string, error) {
+	if !IsAllAnimeSource(anime) {
 		return "", nil, fmt.Errorf("this function is only for AllAnime sources")
 	}
 
 	// Use the cached scraper manager to get the AllAnime client (avoids re-creating each time)
-	sm := scraper.NewScraperManager()
-	scraperInstance, scErr := sm.GetScraper(scraper.AllAnimeType)
+	scraperInstance, scErr := getScraperForKind(SourceAllAnime)
 	var client *scraper.AllAnimeClient
 	if scErr == nil {
 		if adapter, ok := scraperInstance.(interface {
@@ -91,7 +58,7 @@ func GetAllAnimeEpisodeURLDirect(anime *models.Anime, episodeNumber string, qual
 		// Fallback: create directly (shouldn't happen with singleton manager)
 		client = scraper.NewAllAnimeClient()
 	}
-	animeID := extractAllAnimeIDAPI(anime.URL)
+	animeID := ExtractAllAnimeID(anime.URL)
 
 	if animeID == "" {
 		return "", nil, fmt.Errorf("could not extract anime ID from URL: %s", anime.URL)
@@ -106,9 +73,6 @@ func GetAllAnimeEpisodeURLDirect(anime *models.Anime, episodeNumber string, qual
 	if err != nil {
 		return "", nil, fmt.Errorf("failed to get episode URL: %w", err)
 	}
-	if referer, ok := metadata["referer"]; ok && referer != "" {
-		util.SetGlobalReferer(referer)
-	}
 
 	// Add additional metadata
 	metadata["navigator"] = "allanime"
@@ -121,44 +85,4 @@ func GetAllAnimeEpisodeURLDirect(anime *models.Anime, episodeNumber string, qual
 		"url_length", len(url))
 
 	return url, metadata, nil
-}
-
-// Helper function to check if anime is from AllAnime source (API module)
-func isAllAnimeSourceAPI(anime *models.Anime) bool {
-	if anime.Source == "AllAnime" {
-		return true
-	}
-
-	if strings.Contains(anime.URL, "allanime") {
-		return true
-	}
-
-	if len(anime.URL) < 30 &&
-		strings.ContainsAny(anime.URL, "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789") &&
-		!strings.Contains(anime.URL, "http") {
-		return true
-	}
-
-	return false
-}
-
-// Helper function to extract AllAnime ID from URL (API module)
-func extractAllAnimeIDAPI(url string) string {
-	// For AllAnime, the URL is often just the anime ID
-	if !strings.Contains(url, "http") && len(url) < 30 {
-		return url
-	}
-
-	// Extract ID from full AllAnime URLs if needed
-	if strings.Contains(url, "allanime") {
-		parts := strings.SplitSeq(url, "/")
-		for part := range parts {
-			if len(part) > 5 && len(part) < 30 &&
-				strings.ContainsAny(part, "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789") {
-				return part
-			}
-		}
-	}
-
-	return url // Return as-is if can't extract
 }

--- a/internal/api/allanime_smart.go
+++ b/internal/api/allanime_smart.go
@@ -248,7 +248,7 @@ func sanitizeSmartDest(p string) (string, error) {
 
 // validateSmartRangeInputs ensures correct source and quality defaulting
 func validateSmartRangeInputs(anime *models.Anime, startEp, endEp int, quality *string) error {
-	if !isAllAnimeSourceAPI(anime) {
+	if !IsAllAnimeSource(anime) {
 		return fmt.Errorf("AllAnime Smart Range is only available for AllAnime sources")
 	}
 	if quality != nil && *quality == "" {

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -138,6 +138,7 @@ func SafeTransport(timeout time.Duration) *http.Transport {
 		},
 		// Set the timeout for the TLS handshake process.
 		TLSHandshakeTimeout: timeout,
+		TLSClientConfig:     tlsConfig,
 		// Connection pooling for better performance on repeated requests
 		MaxIdleConns:        200,
 		MaxIdleConnsPerHost: 25,

--- a/internal/api/api_security_test.go
+++ b/internal/api/api_security_test.go
@@ -1,0 +1,124 @@
+package api
+
+import (
+	"context"
+	"crypto/tls"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsDisallowedIP(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name string
+		ip   string
+		want bool
+	}{
+		{name: "empty", ip: "", want: true},
+		{name: "invalid", ip: "not-an-ip", want: true},
+		{name: "loopback ipv4", ip: "127.0.0.1", want: true},
+		{name: "loopback ipv6", ip: "::1", want: true},
+		{name: "private ipv4", ip: "192.168.1.10", want: true},
+		{name: "multicast", ip: "224.0.0.1", want: true},
+		{name: "unspecified", ip: "0.0.0.0", want: true},
+		{name: "public", ip: "8.8.8.8", want: false},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, IsDisallowedIP(tc.ip))
+		})
+	}
+}
+
+func TestValidateExternalURL(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name        string
+		rawURL      string
+		wantErrLike string
+	}{
+		{name: "invalid url", rawURL: "://bad", wantErrLike: "invalid URL"},
+		{name: "missing hostname", rawURL: "http://", wantErrLike: "URL has no hostname"},
+		{name: "loopback ipv4", rawURL: "http://127.0.0.1:8080", wantErrLike: "disallowed IP 127.0.0.1"},
+		{name: "loopback ipv6", rawURL: "http://[::1]:8080", wantErrLike: "disallowed IP ::1"},
+		{name: "public ip literal", rawURL: "http://8.8.8.8", wantErrLike: ""},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := ValidateExternalURL(tc.rawURL)
+			if tc.wantErrLike == "" {
+				require.NoError(t, err)
+				return
+			}
+
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantErrLike)
+		})
+	}
+}
+
+func TestSafeTransportConfig(t *testing.T) {
+	t.Parallel()
+
+	timeout := 7 * time.Second
+	transport := SafeTransport(timeout)
+	require.NotNil(t, transport)
+	require.NotNil(t, transport.DialContext)
+	require.NotNil(t, transport.DialTLSContext)
+	require.NotNil(t, transport.TLSClientConfig)
+
+	assert.Equal(t, timeout, transport.TLSHandshakeTimeout)
+	assert.Equal(t, uint16(0), transport.TLSClientConfig.MaxVersion)
+	assert.Equal(t, uint16(tls.VersionTLS12), transport.TLSClientConfig.MinVersion)
+	assert.Equal(t, 200, transport.MaxIdleConns)
+	assert.Equal(t, 25, transport.MaxIdleConnsPerHost)
+	assert.Equal(t, 120*time.Second, transport.IdleConnTimeout)
+}
+
+func TestSafeDialContextRejectsLoopbackConnection(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer listener.Close()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		conn, acceptErr := listener.Accept()
+		if acceptErr == nil {
+			_ = conn.Close()
+		}
+	}()
+
+	dialContext := SafeDialContext(time.Second)
+	_, err = dialContext(context.Background(), "tcp", listener.Addr().String())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ip address is not allowed")
+	<-done
+}
+
+func TestSafeGetRejectsLoopbackServer(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	resp, err := SafeGet(server.URL)
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Contains(t, err.Error(), "ip address is not allowed")
+}

--- a/internal/api/enhanced.go
+++ b/internal/api/enhanced.go
@@ -94,7 +94,7 @@ func countSourceBreakdown(animes []*models.Anime) sourceBreakdown {
 	return breakdown
 }
 
-// Enhanced search that supports multiple sources - always searches both Animefire.io and allanime simultaneously
+// SearchAnimeEnhanced searches across the enhanced source set and returns the selected anime.
 func SearchAnimeEnhanced(name, source string) (*models.Anime, error) {
 	scraperManager := scraper.NewScraperManager()
 
@@ -267,7 +267,7 @@ func SearchAnimeEnhanced(name, source string) (*models.Anime, error) {
 	return selectedAnime, nil
 }
 
-// Enhanced episode fetching that works with different sources
+// GetAnimeEpisodesEnhanced fetches episodes using source-aware enhanced routing.
 func GetAnimeEpisodesEnhanced(anime *models.Anime) ([]models.Episode, error) {
 	resolved, resolveErr := ResolveSource(anime)
 	if resolveErr != nil {
@@ -276,12 +276,12 @@ func GetAnimeEpisodesEnhanced(anime *models.Anime) ([]models.Episode, error) {
 	return getEpisodesByResolvedSource(anime, resolved)
 }
 
-// Enhanced episode URL fetching with improved source detection
+// GetEpisodeStreamURL resolves the episode stream URL with source-aware routing.
 func GetEpisodeStreamURL(episode *models.Episode, anime *models.Anime, quality string) (string, error) {
 	return getStreamURLByResolvedSource(anime, episode, quality)
 }
 
-// Enhanced download support
+// DownloadEpisodeEnhanced downloads a single episode through the enhanced API flow.
 func DownloadEpisodeEnhanced(anime *models.Anime, episodeNum int, quality string) error {
 	util.Debugf("Fetching episodes for %s...", anime.Name)
 
@@ -309,7 +309,7 @@ func DownloadEpisodeEnhanced(anime *models.Anime, episodeNum int, quality string
 		sanitizeFilename(anime.Name), episodeNum))
 }
 
-// Enhanced range download support
+// DownloadEpisodeRangeEnhanced downloads an episode range through the enhanced API flow.
 func DownloadEpisodeRangeEnhanced(anime *models.Anime, startEp, endEp int, quality string) error {
 	util.Debugf("Fetching episodes for %s...", anime.Name)
 
@@ -368,7 +368,7 @@ func downloadFromURL(_, _ string) error {
 	return fmt.Errorf("enhanced download not implemented - use legacy downloader")
 }
 
-// Legacy wrapper functions to maintain compatibility
+// SearchAnimeWithSource preserves the legacy wrapper entrypoint over SearchAnimeEnhanced.
 func SearchAnimeWithSource(name, source string) (*models.Anime, error) {
 	return SearchAnimeEnhanced(name, source)
 }
@@ -706,6 +706,7 @@ func extractMediaIDFromURL(urlStr string) string {
 	return ""
 }
 
+// GetAnimeEpisodesWithSource preserves the legacy wrapper entrypoint over GetAnimeEpisodesEnhanced.
 func GetAnimeEpisodesWithSource(anime *models.Anime) ([]models.Episode, error) {
 	return GetAnimeEpisodesEnhanced(anime)
 }

--- a/internal/api/enhanced.go
+++ b/internal/api/enhanced.go
@@ -41,13 +41,11 @@ func isStdoutTerminal() bool {
 // callback when no terminal is attached.
 func runWithSpinner(title string, action func()) {
 	if isStdoutTerminal() {
-		_ = tui.RunClean(func() error {
-			return spinner.New().
-				Title(title).
-				Type(spinner.Dots).
-				Action(action).
-				Run()
-		})
+		_ = spinner.New().
+			Title(title).
+			Type(spinner.Dots).
+			Action(action).
+			Run()
 	} else {
 		action()
 	}
@@ -56,8 +54,48 @@ func runWithSpinner(title string, action func()) {
 // ErrBackToSearch is returned when user selects the back option to search again
 var ErrBackToSearch = errors.New("back to search requested")
 
+type sourceBreakdown struct {
+	AnimeFire  int
+	AllAnime   int
+	Goyabu     int
+	FlixHQ     int
+	NineAnime  int
+	SuperFlix  int
+	AnimeDrive int
+}
+
+func countSourceBreakdown(animes []*models.Anime) sourceBreakdown {
+	var breakdown sourceBreakdown
+
+	for _, anime := range animes {
+		resolved, err := ResolveSource(anime)
+		if err != nil {
+			continue
+		}
+
+		switch resolved.Kind {
+		case SourceAnimefire:
+			breakdown.AnimeFire++
+		case SourceAllAnime:
+			breakdown.AllAnime++
+		case SourceGoyabu:
+			breakdown.Goyabu++
+		case SourceFlixHQ:
+			breakdown.FlixHQ++
+		case SourceNineAnime:
+			breakdown.NineAnime++
+		case SourceSuperFlix:
+			breakdown.SuperFlix++
+		case SourceAnimeDrive:
+			breakdown.AnimeDrive++
+		}
+	}
+
+	return breakdown
+}
+
 // Enhanced search that supports multiple sources - always searches both Animefire.io and allanime simultaneously
-func SearchAnimeEnhanced(name string, source string) (*models.Anime, error) {
+func SearchAnimeEnhanced(name, source string) (*models.Anime, error) {
 	scraperManager := scraper.NewScraperManager()
 
 	var scraperType *scraper.ScraperType
@@ -121,27 +159,11 @@ func SearchAnimeEnhanced(name string, source string) (*models.Anime, error) {
 		return nil, fmt.Errorf("no results found for: %s", name)
 	}
 
-	// Enhance source identification - names already have language tags from unified.go
+	// Normalize source identification once so downstream flows share the same rules.
 	for _, anime := range animes {
-		// Ensure proper source identification (for internal use only)
-		if anime.Source == "" {
-			// Fallback source identification by URL analysis
-			if len(anime.URL) < 30 && strings.ContainsAny(anime.URL, "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789") && !strings.Contains(anime.URL, "http") {
-				anime.Source = "AllAnime"
-			} else if strings.Contains(anime.URL, "animefire") {
-				anime.Source = "Animefire.io"
-			} else if strings.Contains(anime.URL, "animesdrive") {
-				anime.Source = "AnimeDrive"
-			} else if strings.Contains(anime.URL, "goyabu") {
-				anime.Source = "Goyabu"
-			} else if strings.Contains(anime.URL, "flixhq") {
-				anime.Source = "FlixHQ"
-			}
-			// Note: 9Anime uses numeric IDs which can't be identified by URL alone;
-			// the Source field is already set by the scraper
+		if resolved, err := ResolveSource(anime); err == nil {
+			resolved.Apply(anime)
 		}
-
-		// Language tags are already added by unified.go, don't duplicate them here
 	}
 
 	util.Debug("Search results summary", "total", len(animes))
@@ -150,11 +172,11 @@ func SearchAnimeEnhanced(name string, source string) (*models.Anime, error) {
 	util.Debug("Source breakdown",
 		"AnimeFire", breakdown.AnimeFire,
 		"AllAnime", breakdown.AllAnime,
+		"Goyabu", breakdown.Goyabu,
 		"AnimeDrive", breakdown.AnimeDrive,
 		"FlixHQ", breakdown.FlixHQ,
 		"9Anime", breakdown.NineAnime,
 		"SuperFlix", breakdown.SuperFlix,
-		"Goyabu", breakdown.Goyabu,
 	)
 
 	// Sort results by language priority: Portuguese first, then Multilanguage, Movies/TV, English, others
@@ -164,7 +186,7 @@ func SearchAnimeEnhanced(name string, source string) (*models.Anime, error) {
 
 	// Create a special "back" option as the first item
 	backOption := &models.Anime{
-		Name:   "← Back",
+		Name:   "<- Back",
 		URL:    "__back__",
 		Source: "__back__",
 	}
@@ -247,299 +269,16 @@ func SearchAnimeEnhanced(name string, source string) (*models.Anime, error) {
 
 // Enhanced episode fetching that works with different sources
 func GetAnimeEpisodesEnhanced(anime *models.Anime) ([]models.Episode, error) {
-	// Check if this is a SuperFlix source
-	if anime.Source == "SuperFlix" {
-		return GetSuperFlixEpisodes(anime)
+	resolved, resolveErr := ResolveSource(anime)
+	if resolveErr != nil {
+		return nil, resolveErr
 	}
-
-	// Check if this is a FlixHQ movie/TV show
-	if anime.Source == "FlixHQ" || anime.MediaType == models.MediaTypeMovie || anime.MediaType == models.MediaTypeTV {
-		return GetFlixHQEpisodes(anime)
-	}
-
-	// Check if this is a 9Anime source
-	if anime.Source == "9Anime" {
-		return GetNineAnimeEpisodes(anime)
-	}
-
-	// Determine source type from multiple indicators with enhanced logic
-	var sourceName string
-
-	// Priority 1: Check the Source field (most reliable). Use a case-insensitive
-	// match for AnimeFire because the scraper emits "Animefire.io" (lowercase 'f')
-	// while older code paths/tests sometimes use the camelcase spelling "AnimeFire".
-	if anime.Source == "AllAnime" {
-		sourceName = "AllAnime"
-	} else if strings.Contains(strings.ToLower(anime.Source), "animefire") {
-		sourceName = "Animefire.io"
-	} else if anime.Source == "AnimeDrive" {
-		sourceName = "AnimeDrive"
-	} else if anime.Source == "Goyabu" {
-		sourceName = "Goyabu"
-	} else if strings.Contains(anime.Name, "[English]") {
-		// Priority 2: Check language tags
-		// Need to disambiguate between AllAnime and 9Anime both tagged [English]
-		// 9Anime source is already set above, so remaining [English] = AllAnime
-		sourceName = "AllAnime"
-		anime.Source = "AllAnime" // Update source field
-	} else if strings.Contains(anime.Name, "[PT-BR]") || strings.Contains(anime.Name, "[Português]") {
-		// AnimeFire or AnimeDrive = Portuguese
-		// Check URL to determine which one
-		if strings.Contains(anime.URL, "animesdrive") {
-			sourceName = "AnimeDrive"
-			anime.Source = "AnimeDrive"
-		} else if strings.Contains(anime.URL, "goyabu") {
-			sourceName = "Goyabu"
-			anime.Source = "Goyabu"
-		} else {
-			sourceName = "Animefire.io"
-			anime.Source = "Animefire.io"
-		}
-	} else if strings.Contains(anime.URL, "allanime") || (len(anime.URL) < 30 && strings.ContainsAny(anime.URL, "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789") && !strings.Contains(anime.URL, "http")) {
-		// Priority 3: URL analysis for AllAnime (short IDs or allanime URLs)
-		sourceName = "AllAnime"
-		anime.Source = "AllAnime" // Update source field
-	} else if strings.Contains(anime.URL, "animefire") {
-		// Priority 4: URL analysis for AnimeFire
-		sourceName = "Animefire.io"
-		anime.Source = "Animefire.io" // Update source field
-	} else if strings.Contains(anime.URL, "animesdrive") {
-		// Priority 5: URL analysis for AnimeDrive
-		sourceName = "AnimeDrive"
-		anime.Source = "AnimeDrive" // Update source field
-	} else {
-		// Default to AllAnime for unknown sources
-		sourceName = "AllAnime (default)"
-		anime.Source = "AllAnime"
-	}
-
-	cleanName := strings.TrimSpace(strings.ReplaceAll(strings.ReplaceAll(anime.Name, "[English]", ""), "[PT-BR]", ""))
-
-	util.Debug("Getting episodes", "source", sourceName, "anime", cleanName)
-
-	scraperManager := scraper.NewScraperManager()
-	var episodes []models.Episode
-	var err error
-
-	// Use different approaches based on source
-	if strings.Contains(sourceName, "AllAnime") {
-		scraperInstance, scErr := scraperManager.GetScraper(scraper.AllAnimeType)
-		if scErr != nil {
-			return nil, fmt.Errorf("failed to get AllAnime scraper: %w", scErr)
-		}
-
-		// Cast to AllAnime client to access enhanced features
-		if allAnimeClient, ok := scraperInstance.(*scraper.AllAnimeClient); ok && anime.MalID > 0 {
-			episodes, err = allAnimeClient.GetAnimeEpisodesWithAniSkip(anime.URL, anime.MalID, GetAndParseAniSkipData)
-			util.Debug("AniSkip integration enabled", "malID", anime.MalID)
-		} else {
-			episodes, err = scraperInstance.GetAnimeEpisodes(anime.URL)
-		}
-	} else if sourceName == "AnimeDrive" {
-		scraperInstance, scErr := scraperManager.GetScraper(scraper.AnimeDriveType)
-		if scErr != nil {
-			return nil, fmt.Errorf("failed to get AnimeDrive scraper: %w", scErr)
-		}
-		episodes, err = scraperInstance.GetAnimeEpisodes(anime.URL)
-	} else if sourceName == "Animefire.io" {
-		scraperInstance, scErr := scraperManager.GetScraper(scraper.AnimefireType)
-		if scErr != nil {
-			return nil, fmt.Errorf("failed to get AnimeFire scraper: %w", scErr)
-		}
-		episodes, err = scraperInstance.GetAnimeEpisodes(anime.URL)
-	} else if sourceName == "Goyabu" {
-		scraperInstance, scErr := scraperManager.GetScraper(scraper.GoyabuType)
-		if scErr != nil {
-			return nil, fmt.Errorf("failed to get Goyabu scraper: %w", scErr)
-		}
-		episodes, err = scraperInstance.GetAnimeEpisodes(anime.URL)
-	} else {
-		// For others, use the original API function
-		episodes, err = GetAnimeEpisodes(anime.URL)
-	}
-
-	if err != nil {
-		return nil, fmt.Errorf("failed to get episodes from %s: %w", sourceName, err)
-	}
-
-	if len(episodes) > 0 {
-		util.Debug("Episodes found", "count", len(episodes), "source", sourceName)
-
-		// Provide additional info for user based on source (debug only)
-		if strings.Contains(sourceName, "AllAnime") {
-			util.Debug("Source info", "type", "AllAnime", "quality", "high")
-		} else if sourceName == "AnimeDrive" {
-			util.Debug("Source info", "type", "AnimeDrive", "features", "multiple qualities")
-		} else {
-			util.Debug("Source info", "type", "Animefire.io", "features", "dubbed/subtitled")
-		}
-	} else {
-		util.Warn("No episodes found", "source", sourceName)
-	}
-
-	return episodes, nil
+	return getEpisodesByResolvedSource(anime, resolved)
 }
 
 // Enhanced episode URL fetching with improved source detection
 func GetEpisodeStreamURL(episode *models.Episode, anime *models.Anime, quality string) (string, error) {
-	// Clear any previous subtitles
-	util.ClearGlobalSubtitles()
-
-	// Track anime source globally for subtitle selection and other source-specific behavior
-	if anime != nil && anime.Source != "" {
-		util.SetGlobalAnimeSource(anime.Source)
-	}
-
-	// Check if this is SuperFlix content
-	if anime.Source == "SuperFlix" {
-		return GetSuperFlixStreamURL(anime, episode, quality)
-	}
-
-	// Check if this is FlixHQ content
-	if anime.Source == "FlixHQ" || anime.MediaType == models.MediaTypeMovie || anime.MediaType == models.MediaTypeTV {
-		streamURL, subtitles, err := GetFlixHQStreamURL(anime, episode, quality)
-		if err != nil {
-			return "", err
-		}
-
-		// Store subtitles globally for playback
-		if len(subtitles) > 0 && !util.GlobalNoSubs {
-			var subInfos []util.SubtitleInfo
-			for _, sub := range subtitles {
-				subInfos = append(subInfos, util.SubtitleInfo{
-					URL:      sub.URL,
-					Language: sub.Language,
-					Label:    sub.Label,
-				})
-			}
-			util.SetGlobalSubtitles(subInfos)
-		}
-
-		return streamURL, nil
-	}
-
-	// Check if this is 9Anime content
-	if anime.Source == "9Anime" {
-		return GetNineAnimeStreamURL(anime, episode, quality)
-	}
-
-	scraperManager := scraper.NewScraperManager()
-
-	// Determine source type with enhanced logic
-	var scraperType scraper.ScraperType
-	var sourceName string
-
-	// Priority 1: Check the Source field (most reliable)
-	sourceLower := strings.ToLower(anime.Source)
-	if sourceLower == "allanime" {
-		scraperType = scraper.AllAnimeType
-		sourceName = "AllAnime"
-	} else if strings.Contains(sourceLower, "animefire") {
-		scraperType = scraper.AnimefireType
-		sourceName = "Animefire.io"
-	} else if sourceLower == "animedrive" {
-		scraperType = scraper.AnimeDriveType
-		sourceName = "AnimeDrive"
-	} else if sourceLower == "goyabu" {
-		scraperType = scraper.GoyabuType
-		sourceName = "Goyabu"
-	} else if strings.Contains(anime.Name, "[English]") {
-		// Priority 2: Check language tags (AllAnime = English)
-		scraperType = scraper.AllAnimeType
-		sourceName = "AllAnime"
-	} else if strings.Contains(anime.Name, "[PT-BR]") || strings.Contains(anime.Name, "[Português]") {
-		// AnimeFire, Goyabu, or AnimeDrive = Portuguese
-		// Check URL to determine which one
-		if strings.Contains(anime.URL, "animesdrive") {
-			scraperType = scraper.AnimeDriveType
-			sourceName = "AnimeDrive"
-		} else if strings.Contains(anime.URL, "goyabu") {
-			scraperType = scraper.GoyabuType
-			sourceName = "Goyabu"
-		} else {
-			scraperType = scraper.AnimefireType
-			sourceName = "Animefire.io"
-		}
-	} else if len(anime.URL) < 30 && strings.ContainsAny(anime.URL, "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789") && !strings.Contains(anime.URL, "http") {
-		// Priority 3: URL analysis for AllAnime (short IDs)
-		scraperType = scraper.AllAnimeType
-		sourceName = "AllAnime"
-	} else if strings.Contains(anime.URL, "animefire") {
-		// Priority 4: URL analysis for AnimeFire
-		scraperType = scraper.AnimefireType
-		sourceName = "Animefire.io"
-	} else if strings.Contains(anime.URL, "animesdrive") {
-		// Priority 5: URL analysis for AnimeDrive
-		scraperType = scraper.AnimeDriveType
-		sourceName = "AnimeDrive"
-	} else if strings.Contains(anime.URL, "goyabu") {
-		// Priority 5b: URL analysis for Goyabu
-		scraperType = scraper.GoyabuType
-		sourceName = "Goyabu"
-	} else if strings.Contains(anime.URL, "allanime") {
-		// Priority 6: AllAnime full URLs
-		scraperType = scraper.AllAnimeType
-		sourceName = "AllAnime"
-	} else {
-		// Default to AllAnime
-		scraperType = scraper.AllAnimeType
-		sourceName = "AllAnime (default)"
-	}
-
-	util.Debug("Getting stream URL", "source", sourceName, "episode", episode.Number)
-
-	util.Debug("Source details",
-		"scraperType", scraperType,
-		"animeURL", anime.URL,
-		"episodeURL", episode.URL,
-		"episodeNumber", episode.Number,
-		"quality", quality)
-
-	scraperInstance, err := scraperManager.GetScraper(scraperType)
-	if err != nil {
-		return "", fmt.Errorf("failed to get scraper for %s: %w", sourceName, err)
-	}
-
-	if quality == "" {
-		quality = "best"
-	}
-
-	var streamURL string
-	var streamErr error
-
-	// Handle different scraper types with appropriate parameters
-	switch scraperType {
-	case scraper.AllAnimeType:
-		util.Debug("Processing through AllAnime")
-		streamURL, _, streamErr = scraperInstance.GetStreamURL(anime.URL, episode.Number, quality)
-	case scraper.AnimeDriveType:
-		util.Debug("Processing through AnimeDrive")
-		// Use "auto" to skip interactive server selection (this runs inside a spinner)
-		streamURL, _, streamErr = scraperInstance.GetStreamURL(episode.URL, "auto")
-	case scraper.GoyabuType:
-		util.Debug("Processing through Goyabu")
-		streamURL, _, streamErr = scraperInstance.GetStreamURL(episode.URL)
-	default:
-		util.Debug("Processing through Animefire.io")
-		streamURL, _, streamErr = scraperInstance.GetStreamURL(episode.URL, quality)
-	}
-
-	if streamErr != nil {
-		// Propagate back request error without wrapping
-		if errors.Is(streamErr, scraper.ErrBackRequested) {
-			return "", streamErr
-		}
-		return "", fmt.Errorf("failed to get stream URL from %s: %w", sourceName, streamErr)
-	}
-
-	if streamURL == "" {
-		return "", fmt.Errorf("empty stream URL returned from %s", sourceName)
-	}
-
-	util.Debug("Stream URL obtained", "source", sourceName)
-	util.Debug("Stream URL details", "url", streamURL)
-
-	return streamURL, nil
+	return getStreamURLByResolvedSource(anime, episode, quality)
 }
 
 // Enhanced download support
@@ -608,7 +347,7 @@ func sanitizeFilename(name string) string {
 	// Remove language tags
 	name = strings.ReplaceAll(name, "[English]", "")
 	name = strings.ReplaceAll(name, "[PT-BR]", "")
-	name = strings.ReplaceAll(name, "[Português]", "")
+	name = strings.ReplaceAll(name, "[Portugu\u00eas]", "")
 	name = strings.ReplaceAll(name, "(Legendado)", "")
 	name = strings.ReplaceAll(name, "(Dublado)", "")
 	name = strings.TrimSpace(name)
@@ -623,14 +362,14 @@ func sanitizeFilename(name string) string {
 }
 
 // Basic download function (placeholder - integrate with your existing downloader)
-func downloadFromURL(_ string, _ string) error {
+func downloadFromURL(_, _ string) error {
 	// This is a placeholder that should fail to trigger fallback to the proper downloader
 	util.Debugf("Enhanced API downloadFromURL is a placeholder - returning error to trigger fallback")
 	return fmt.Errorf("enhanced download not implemented - use legacy downloader")
 }
 
 // Legacy wrapper functions to maintain compatibility
-func SearchAnimeWithSource(name string, source string) (*models.Anime, error) {
+func SearchAnimeWithSource(name, source string) (*models.Anime, error) {
 	return SearchAnimeEnhanced(name, source)
 }
 
@@ -777,9 +516,6 @@ func GetFlixHQEpisodes(media *models.Anime) ([]models.Episode, error) {
 		return seasons[i].Title
 	}, fuzzyfinder.WithPromptString("Select season: "))
 	if err != nil {
-		if errors.Is(err, fuzzyfinder.ErrAbort) {
-			return nil, ErrBackToSearch
-		}
 		return nil, fmt.Errorf("season selection cancelled: %w", err)
 	}
 
@@ -1039,9 +775,6 @@ func GetSuperFlixEpisodes(media *models.Anime) ([]models.Episode, error) {
 		return seasonLabels[i]
 	}, fuzzyfinder.WithPromptString("Select season: "))
 	if err != nil {
-		if errors.Is(err, fuzzyfinder.ErrAbort) {
-			return nil, ErrBackToSearch
-		}
 		return nil, fmt.Errorf("season selection cancelled: %w", err)
 	}
 
@@ -1145,55 +878,12 @@ func GetSuperFlixStreamURL(media *models.Anime, episode *models.Episode, quality
 	return result.StreamURL, nil
 }
 
-// sourceBreakdown holds per-source result counts for the debug "Source breakdown"
-// diagnostic line. Counted via countSourceBreakdown so the predicate stays
-// testable in isolation.
-type sourceBreakdown struct {
-	AnimeFire  int
-	AllAnime   int
-	AnimeDrive int
-	FlixHQ     int
-	NineAnime  int
-	SuperFlix  int
-	Goyabu     int
-}
-
-// countSourceBreakdown tallies anime results by Source field using
-// case-insensitive matching for AnimeFire. The scraper canonical Source is
-// "Animefire.io" (lowercase 'f'), but older callers and tests sometimes emit
-// "AnimeFire"; both must be counted so the diagnostic line never lies.
-func countSourceBreakdown(animes []*models.Anime) sourceBreakdown {
-	var b sourceBreakdown
-	for _, anime := range animes {
-		if anime == nil {
-			continue
-		}
-		switch {
-		case strings.Contains(strings.ToLower(anime.Source), "animefire"):
-			b.AnimeFire++
-		case anime.Source == "AllAnime":
-			b.AllAnime++
-		case anime.Source == "AnimeDrive":
-			b.AnimeDrive++
-		case anime.Source == "FlixHQ":
-			b.FlixHQ++
-		case anime.Source == "9Anime":
-			b.NineAnime++
-		case anime.Source == "SuperFlix":
-			b.SuperFlix++
-		case anime.Source == "Goyabu":
-			b.Goyabu++
-		}
-	}
-	return b
-}
-
 // languagePriority returns a sort key for language-based ordering.
-// Lower values sort first: Portuguese → Multilanguage → English → Movies/TV → Unknown.
+// Lower values sort first: Portuguese -> Multilanguage -> English -> Movies/TV -> Unknown.
 func languagePriority(name string) int {
 	lower := strings.ToLower(name)
 	// Check for [PT-BR] anywhere (covers "[Movie] [PT-BR] ...", "[TV] [PT-BR] ...", etc.)
-	if strings.Contains(lower, "[pt-br]") || strings.Contains(lower, "[portuguese]") || strings.Contains(lower, "[português]") {
+	if strings.Contains(lower, "[pt-br]") || strings.Contains(lower, "[portuguese]") || strings.Contains(lower, "[portugu\u00eas]") {
 		return 0
 	}
 	switch {

--- a/internal/api/source_orchestration.go
+++ b/internal/api/source_orchestration.go
@@ -1,0 +1,110 @@
+// Package api coordinates source resolution and playback-oriented orchestration.
+package api
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/alvarorichard/Goanime/internal/models"
+	"github.com/alvarorichard/Goanime/internal/scraper"
+	"github.com/alvarorichard/Goanime/internal/util"
+)
+
+var (
+	orchestrateGetSuperFlixEpisodes  = GetSuperFlixEpisodes
+	orchestrateGetFlixHQEpisodes     = GetFlixHQEpisodes
+	orchestrateGetNineAnimeEpisodes  = GetNineAnimeEpisodes
+	orchestrateGetSuperFlixStreamURL = GetSuperFlixStreamURL
+	orchestrateGetFlixHQStreamURL    = GetFlixHQStreamURL
+	orchestrateGetNineAnimeStreamURL = GetNineAnimeStreamURL
+)
+
+func getEpisodesByResolvedSource(anime *models.Anime, resolved ResolvedSource) ([]models.Episode, error) {
+	resolved.Apply(anime)
+
+	var episodes []models.Episode
+	var err error
+	switch resolved.Kind {
+	case SourceSuperFlix:
+		episodes, err = orchestrateGetSuperFlixEpisodes(anime)
+	case SourceFlixHQ:
+		episodes, err = orchestrateGetFlixHQEpisodes(anime)
+	case SourceNineAnime:
+		episodes, err = orchestrateGetNineAnimeEpisodes(anime)
+	default:
+		episodes, err = fetchEpisodesWithResolvedSource(anime, resolved, sourceProviderFor)
+		if err == nil && resolved.Kind == SourceAllAnime && anime.MalID > 0 {
+			util.Debug("AniSkip integration enabled", "malID", anime.MalID)
+		}
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to get episodes from %s: %w", resolved.Name, err)
+	}
+	return episodes, nil
+}
+
+func getStreamURLByResolvedSource(anime *models.Anime, episode *models.Episode, quality string) (string, error) {
+	if anime == nil {
+		return "", fmt.Errorf("cannot get stream URL for nil anime")
+	}
+	if episode == nil {
+		return "", fmt.Errorf("cannot get stream URL for nil episode")
+	}
+
+	util.ClearGlobalSubtitles()
+
+	resolved, err := ResolveSource(anime)
+	if err != nil {
+		return "", err
+	}
+	resolved.Apply(anime)
+	util.SetGlobalAnimeSource(resolved.Name)
+
+	switch resolved.Kind {
+	case SourceSuperFlix:
+		return orchestrateGetSuperFlixStreamURL(anime, episode, quality)
+	case SourceFlixHQ:
+		streamURL, subtitles, streamErr := orchestrateGetFlixHQStreamURL(anime, episode, quality)
+		if streamErr != nil {
+			return "", streamErr
+		}
+
+		if len(subtitles) > 0 && !util.GlobalNoSubs {
+			var subInfos []util.SubtitleInfo
+			for _, sub := range subtitles {
+				subInfos = append(subInfos, util.SubtitleInfo{
+					URL:      sub.URL,
+					Language: sub.Language,
+					Label:    sub.Label,
+				})
+			}
+			util.SetGlobalSubtitles(subInfos)
+		}
+		return streamURL, nil
+	case SourceNineAnime:
+		return orchestrateGetNineAnimeStreamURL(anime, episode, quality)
+	default:
+		util.Debug("Getting stream URL", "source", resolved.Name, "episode", episode.Number)
+		util.Debug("Source details",
+			"resolvedSource", resolved.Name,
+			"animeURL", anime.URL,
+			"episodeURL", episode.URL,
+			"episodeNumber", episode.Number,
+			"quality", quality)
+
+		streamURL, streamErr := fetchStreamURLWithResolvedSource(anime, episode, quality, resolved, sourceProviderFor)
+		if streamErr != nil {
+			if errors.Is(streamErr, scraper.ErrBackRequested) {
+				return "", streamErr
+			}
+			return "", fmt.Errorf("failed to get stream URL from %s: %w", resolved.Name, streamErr)
+		}
+		if streamURL == "" {
+			return "", fmt.Errorf("empty stream URL returned from %s", resolved.Name)
+		}
+
+		util.Debug("Stream URL obtained", "source", resolved.Name)
+		util.Debug("Stream URL details", "url", streamURL)
+		return streamURL, nil
+	}
+}

--- a/internal/api/source_orchestration_test.go
+++ b/internal/api/source_orchestration_test.go
@@ -1,0 +1,271 @@
+package api
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/alvarorichard/Goanime/internal/models"
+	"github.com/alvarorichard/Goanime/internal/scraper"
+	"github.com/alvarorichard/Goanime/internal/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// These tests mutate package-level seams and playback globals.
+// Keep them sequential and do not add t.Parallel().
+
+func resetSourceOrchestrationSeams() {
+	orchestrateGetSuperFlixEpisodes = GetSuperFlixEpisodes
+	orchestrateGetFlixHQEpisodes = GetFlixHQEpisodes
+	orchestrateGetNineAnimeEpisodes = GetNineAnimeEpisodes
+	orchestrateGetSuperFlixStreamURL = GetSuperFlixStreamURL
+	orchestrateGetFlixHQStreamURL = GetFlixHQStreamURL
+	orchestrateGetNineAnimeStreamURL = GetNineAnimeStreamURL
+}
+
+func resetSourceOrchestrationGlobals() {
+	util.ClearGlobalSubtitles()
+	util.ClearGlobalReferer()
+	util.SetGlobalAnimeSource("")
+	util.GlobalNoSubs = false
+}
+
+func TestGetEpisodesByResolvedSourceDedicatedSources(t *testing.T) {
+	testCases := []struct {
+		name string
+		kind SourceKind
+		set  func(t *testing.T, anime *models.Anime, want []models.Episode)
+	}{
+		{
+			name: "FlixHQ",
+			kind: SourceFlixHQ,
+			set: func(t *testing.T, anime *models.Anime, want []models.Episode) {
+				orchestrateGetFlixHQEpisodes = func(got *models.Anime) ([]models.Episode, error) {
+					assert.Same(t, anime, got)
+					return want, nil
+				}
+			},
+		},
+		{
+			name: "9Anime",
+			kind: SourceNineAnime,
+			set: func(t *testing.T, anime *models.Anime, want []models.Episode) {
+				orchestrateGetNineAnimeEpisodes = func(got *models.Anime) ([]models.Episode, error) {
+					assert.Same(t, anime, got)
+					return want, nil
+				}
+			},
+		},
+		{
+			name: "SuperFlix",
+			kind: SourceSuperFlix,
+			set: func(t *testing.T, anime *models.Anime, want []models.Episode) {
+				orchestrateGetSuperFlixEpisodes = func(got *models.Anime) ([]models.Episode, error) {
+					assert.Same(t, anime, got)
+					return want, nil
+				}
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			resetSourceOrchestrationSeams()
+			t.Cleanup(resetSourceOrchestrationSeams)
+
+			anime := &models.Anime{Name: "Dexter"}
+			want := []models.Episode{{Number: "1", Num: 1}}
+			tc.set(t, anime, want)
+
+			episodes, err := getEpisodesByResolvedSource(anime, ResolvedSource{Kind: tc.kind, Name: string(tc.kind)})
+			require.NoError(t, err)
+			assert.Equal(t, want, episodes)
+			assert.Equal(t, string(tc.kind), anime.Source)
+		})
+	}
+}
+
+func TestGetEpisodesByResolvedSourceProviderBackedWrapsErrors(t *testing.T) {
+	oldProvider, hadProvider := defaultSourceProviders[SourceAnimefire]
+	t.Cleanup(func() {
+		if hadProvider {
+			defaultSourceProviders[SourceAnimefire] = oldProvider
+		} else {
+			delete(defaultSourceProviders, SourceAnimefire)
+		}
+	})
+
+	defaultSourceProviders[SourceAnimefire] = &mockSourceProvider{
+		kind:        SourceAnimefire,
+		episodesErr: fmt.Errorf("upstream failed"),
+	}
+
+	anime := &models.Anime{Name: "Naruto"}
+	_, err := getEpisodesByResolvedSource(anime, ResolvedSource{Kind: SourceAnimefire, Name: string(SourceAnimefire)})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to get episodes from Animefire.io")
+	assert.Contains(t, err.Error(), "upstream failed")
+	assert.Equal(t, "Animefire.io", anime.Source)
+}
+
+func TestGetStreamURLByResolvedSourceRejectsNilInputs(t *testing.T) {
+	_, err := getStreamURLByResolvedSource(nil, &models.Episode{Number: "1"}, "best")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "nil anime")
+
+	_, err = getStreamURLByResolvedSource(&models.Anime{Source: "Animefire.io"}, nil, "best")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "nil episode")
+}
+
+func TestGetStreamURLByResolvedSourceFlixHQStoresSubtitles(t *testing.T) {
+	resetSourceOrchestrationSeams()
+	resetSourceOrchestrationGlobals()
+	t.Cleanup(resetSourceOrchestrationSeams)
+	t.Cleanup(resetSourceOrchestrationGlobals)
+
+	util.SetGlobalSubtitles([]util.SubtitleInfo{{URL: "https://stale/sub.vtt", Label: "Stale", Language: "eng"}})
+	orchestrateGetFlixHQStreamURL = func(anime *models.Anime, episode *models.Episode, quality string) (string, []models.Subtitle, error) {
+		assert.Equal(t, "1080", quality)
+		assert.Equal(t, "FlixHQ", anime.Source)
+		assert.Equal(t, "1", episode.Number)
+		return "https://example.com/video.m3u8", []models.Subtitle{
+			{URL: "https://example.com/sub.vtt", Language: "eng", Label: "English"},
+		}, nil
+	}
+
+	streamURL, err := getStreamURLByResolvedSource(&models.Anime{Source: "FlixHQ"}, &models.Episode{Number: "1"}, "1080")
+	require.NoError(t, err)
+	assert.Equal(t, "https://example.com/video.m3u8", streamURL)
+	assert.Equal(t, "FlixHQ", util.GetGlobalAnimeSource())
+	require.Len(t, util.GlobalSubtitles, 1)
+	assert.Equal(t, "English", util.GlobalSubtitles[0].Label)
+}
+
+func TestGetStreamURLByResolvedSourceProviderBackedClearsStaleSubtitles(t *testing.T) {
+	resetSourceOrchestrationGlobals()
+	t.Cleanup(resetSourceOrchestrationGlobals)
+
+	oldProvider, hadProvider := defaultSourceProviders[SourceAnimefire]
+	t.Cleanup(func() {
+		if hadProvider {
+			defaultSourceProviders[SourceAnimefire] = oldProvider
+		} else {
+			delete(defaultSourceProviders, SourceAnimefire)
+		}
+	})
+
+	util.SetGlobalSubtitles([]util.SubtitleInfo{{URL: "https://stale/sub.vtt", Label: "Stale", Language: "eng"}})
+	provider := &mockSourceProvider{
+		kind:      SourceAnimefire,
+		streamURL: "https://example.com/provider.m3u8",
+	}
+	defaultSourceProviders[SourceAnimefire] = provider
+
+	anime := &models.Anime{Name: "Naruto", Source: "Animefire.io"}
+	episode := &models.Episode{Number: "3", URL: "https://example.com/episode/3"}
+
+	streamURL, err := getStreamURLByResolvedSource(anime, episode, "720")
+	require.NoError(t, err)
+	assert.Equal(t, "https://example.com/provider.m3u8", streamURL)
+	assert.Equal(t, 1, provider.streamHit)
+	assert.Equal(t, "720", provider.gotQuality)
+	assert.Empty(t, util.GlobalSubtitles)
+	assert.Equal(t, "Animefire.io", util.GetGlobalAnimeSource())
+}
+
+func TestGetStreamURLByResolvedSourceProviderBackedErrorHandling(t *testing.T) {
+	testCases := []struct {
+		name        string
+		streamURL   string
+		streamErr   error
+		wantErrLike string
+		wantIsBack  bool
+	}{
+		{
+			name:        "wraps regular provider errors",
+			streamErr:   fmt.Errorf("provider failed"),
+			wantErrLike: "failed to get stream URL from Animefire.io",
+		},
+		{
+			name:       "passes through back request",
+			streamErr:  scraper.ErrBackRequested,
+			wantIsBack: true,
+		},
+		{
+			name:        "rejects empty stream url",
+			streamURL:   "",
+			wantErrLike: "empty stream URL returned from Animefire.io",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			resetSourceOrchestrationGlobals()
+			t.Cleanup(resetSourceOrchestrationGlobals)
+
+			oldProvider, hadProvider := defaultSourceProviders[SourceAnimefire]
+			t.Cleanup(func() {
+				if hadProvider {
+					defaultSourceProviders[SourceAnimefire] = oldProvider
+				} else {
+					delete(defaultSourceProviders, SourceAnimefire)
+				}
+			})
+
+			defaultSourceProviders[SourceAnimefire] = &mockSourceProvider{
+				kind:      SourceAnimefire,
+				streamURL: tc.streamURL,
+				streamErr: tc.streamErr,
+			}
+
+			_, err := getStreamURLByResolvedSource(&models.Anime{Source: "Animefire.io"}, &models.Episode{Number: "1", URL: "https://example.com/episode/1"}, "best")
+			require.Error(t, err)
+			if tc.wantIsBack {
+				assert.True(t, errors.Is(err, scraper.ErrBackRequested))
+				return
+			}
+			assert.Contains(t, err.Error(), tc.wantErrLike)
+		})
+	}
+}
+
+func TestAnimefireHermeticProviderFlow(t *testing.T) {
+	resetSourceOrchestrationGlobals()
+	t.Cleanup(resetSourceOrchestrationGlobals)
+
+	oldProvider, hadProvider := defaultSourceProviders[SourceAnimefire]
+	t.Cleanup(func() {
+		if hadProvider {
+			defaultSourceProviders[SourceAnimefire] = oldProvider
+		} else {
+			delete(defaultSourceProviders, SourceAnimefire)
+		}
+	})
+
+	provider := &mockSourceProvider{
+		kind:      SourceAnimefire,
+		episodes:  []models.Episode{{Number: "1", Num: 1, URL: "https://example.com/episode/1"}},
+		streamURL: "https://example.com/provider-flow.m3u8",
+	}
+	defaultSourceProviders[SourceAnimefire] = provider
+
+	anime := &models.Anime{
+		Name:   "[PT-BR] Naruto",
+		Source: "Animefire.io",
+		URL:    "https://animefire.plus/anime/naruto",
+	}
+
+	episodes, err := GetAnimeEpisodesEnhanced(anime)
+	require.NoError(t, err)
+	require.Len(t, episodes, 1)
+	assert.Equal(t, 1, provider.episodesHit)
+	assert.Equal(t, "Animefire.io", anime.Source)
+
+	streamURL, err := GetEpisodeStreamURL(&episodes[0], anime, "best")
+	require.NoError(t, err)
+	assert.Equal(t, "https://example.com/provider-flow.m3u8", streamURL)
+	assert.Equal(t, 1, provider.streamHit)
+	assert.Equal(t, "Animefire.io", util.GetGlobalAnimeSource())
+}

--- a/internal/api/source_providers.go
+++ b/internal/api/source_providers.go
@@ -1,0 +1,163 @@
+// Package api coordinates source resolution and playback-oriented orchestration.
+package api
+
+import (
+	"fmt"
+
+	"github.com/alvarorichard/Goanime/internal/models"
+	"github.com/alvarorichard/Goanime/internal/scraper"
+)
+
+// SourceProvider fetches episodes and stream URLs for a resolved source.
+type SourceProvider interface {
+	Kind() SourceKind
+	FetchEpisodes(anime *models.Anime) ([]models.Episode, error)
+	FetchStreamURL(anime *models.Anime, episode *models.Episode, quality string) (string, error)
+}
+
+type sourceProviderLookup func(SourceKind) (SourceProvider, bool)
+
+var defaultSourceProviders = map[SourceKind]SourceProvider{
+	SourceAllAnime:   allAnimeSourceProvider{},
+	SourceAnimefire:  scraperBackedSourceProvider{kind: SourceAnimefire, streamQualityMode: streamQualityRequested},
+	SourceAnimeDrive: scraperBackedSourceProvider{kind: SourceAnimeDrive, streamQualityMode: streamQualityAuto},
+	SourceGoyabu:     scraperBackedSourceProvider{kind: SourceGoyabu, streamQualityMode: streamQualityNone},
+}
+
+var (
+	providerScraperForKind           = getScraperForKind
+	providerAllAnimeEpisodeURLDirect = GetAllAnimeEpisodeURLDirect
+	providerAniSkipFetcher           = GetAndParseAniSkipData
+)
+
+type streamQualityMode int
+
+const (
+	streamQualityRequested streamQualityMode = iota
+	streamQualityAuto
+	streamQualityNone
+)
+
+type allAnimeSourceProvider struct{}
+
+func (allAnimeSourceProvider) Kind() SourceKind {
+	return SourceAllAnime
+}
+
+func (allAnimeSourceProvider) FetchEpisodes(anime *models.Anime) ([]models.Episode, error) {
+	scraperInstance, err := providerScraperForKind(SourceAllAnime)
+	if err != nil {
+		return nil, err
+	}
+
+	if allAnimeClient, ok := scraperInstance.(*scraper.AllAnimeClient); ok && anime.MalID > 0 {
+		return allAnimeClient.GetAnimeEpisodesWithAniSkip(anime.URL, anime.MalID, providerAniSkipFetcher)
+	}
+
+	return scraperInstance.GetAnimeEpisodes(anime.URL)
+}
+
+func (allAnimeSourceProvider) FetchStreamURL(anime *models.Anime, episode *models.Episode, quality string) (string, error) {
+	streamURL, _, err := providerAllAnimeEpisodeURLDirect(anime, providerEpisodeNumber(episode), normalizeStreamQuality(quality))
+	if err != nil {
+		return "", err
+	}
+	return streamURL, nil
+}
+
+type scraperBackedSourceProvider struct {
+	kind              SourceKind
+	streamQualityMode streamQualityMode
+}
+
+func (p scraperBackedSourceProvider) Kind() SourceKind {
+	return p.kind
+}
+
+func (p scraperBackedSourceProvider) FetchEpisodes(anime *models.Anime) ([]models.Episode, error) {
+	scraperInstance, err := providerScraperForKind(p.kind)
+	if err != nil {
+		return nil, err
+	}
+	return scraperInstance.GetAnimeEpisodes(anime.URL)
+}
+
+func (p scraperBackedSourceProvider) FetchStreamURL(_ *models.Anime, episode *models.Episode, quality string) (string, error) {
+	scraperInstance, err := providerScraperForKind(p.kind)
+	if err != nil {
+		return "", err
+	}
+
+	switch p.streamQualityMode {
+	case streamQualityAuto:
+		streamURL, _, streamErr := scraperInstance.GetStreamURL(episode.URL, "auto")
+		return streamURL, streamErr
+	case streamQualityNone:
+		streamURL, _, streamErr := scraperInstance.GetStreamURL(episode.URL)
+		return streamURL, streamErr
+	default:
+		streamURL, _, streamErr := scraperInstance.GetStreamURL(episode.URL, normalizeStreamQuality(quality))
+		return streamURL, streamErr
+	}
+}
+
+func getScraperForKind(kind SourceKind) (scraper.UnifiedScraper, error) {
+	scraperType, ok := kind.ScraperType()
+	if !ok {
+		return nil, fmt.Errorf("source %s does not map to a scraper", kind)
+	}
+	return scraper.NewScraperManager().GetScraper(scraperType)
+}
+
+func sourceProviderFor(kind SourceKind) (SourceProvider, bool) {
+	provider, ok := defaultSourceProviders[kind]
+	return provider, ok
+}
+
+func fetchEpisodesWithResolvedSource(anime *models.Anime, resolved ResolvedSource, lookup sourceProviderLookup) ([]models.Episode, error) {
+	provider, ok := lookup(resolved.Kind)
+	if !ok {
+		return nil, fmt.Errorf("no source provider registered for %s", resolved.Name)
+	}
+
+	episodes, err := provider.FetchEpisodes(anime)
+	if err != nil {
+		return nil, err
+	}
+
+	return episodes, nil
+}
+
+func fetchStreamURLWithResolvedSource(anime *models.Anime, episode *models.Episode, quality string, resolved ResolvedSource, lookup sourceProviderLookup) (string, error) {
+	provider, ok := lookup(resolved.Kind)
+	if !ok {
+		return "", fmt.Errorf("no source provider registered for %s", resolved.Name)
+	}
+
+	streamURL, err := provider.FetchStreamURL(anime, episode, quality)
+	if err != nil {
+		return "", err
+	}
+
+	return streamURL, nil
+}
+
+func normalizeStreamQuality(quality string) string {
+	if quality == "" {
+		return "best"
+	}
+	return quality
+}
+
+func providerEpisodeNumber(episode *models.Episode) string {
+	if episode == nil {
+		return ""
+	}
+	if episode.Number != "" {
+		return episode.Number
+	}
+	if episode.Num > 0 {
+		return fmt.Sprintf("%d", episode.Num)
+	}
+	return "1"
+}

--- a/internal/api/source_providers_test.go
+++ b/internal/api/source_providers_test.go
@@ -1,0 +1,258 @@
+package api
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/alvarorichard/Goanime/internal/models"
+	"github.com/alvarorichard/Goanime/internal/scraper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type mockSourceProvider struct {
+	kind        SourceKind
+	episodes    []models.Episode
+	streamURL   string
+	episodesHit int
+	streamHit   int
+	gotAnime    *models.Anime
+	gotEpisode  *models.Episode
+	gotQuality  string
+	episodesErr error
+	streamErr   error
+}
+
+func (m *mockSourceProvider) Kind() SourceKind {
+	return m.kind
+}
+
+func (m *mockSourceProvider) FetchEpisodes(anime *models.Anime) ([]models.Episode, error) {
+	m.episodesHit++
+	m.gotAnime = anime
+	return m.episodes, m.episodesErr
+}
+
+func (m *mockSourceProvider) FetchStreamURL(anime *models.Anime, episode *models.Episode, quality string) (string, error) {
+	m.streamHit++
+	m.gotAnime = anime
+	m.gotEpisode = episode
+	m.gotQuality = quality
+	return m.streamURL, m.streamErr
+}
+
+type mockUnifiedScraper struct {
+	episodes       []models.Episode
+	episodesErr    error
+	streamURL      string
+	streamErr      error
+	gotEpisodesURL string
+	gotStreamURL   string
+	gotOptions     []any
+}
+
+func (m *mockUnifiedScraper) SearchAnime(string, ...any) ([]*models.Anime, error) {
+	return nil, nil
+}
+
+func (m *mockUnifiedScraper) GetAnimeEpisodes(animeURL string) ([]models.Episode, error) {
+	m.gotEpisodesURL = animeURL
+	return m.episodes, m.episodesErr
+}
+
+func (m *mockUnifiedScraper) GetStreamURL(episodeURL string, options ...any) (string, map[string]string, error) {
+	m.gotStreamURL = episodeURL
+	m.gotOptions = options
+	return m.streamURL, nil, m.streamErr
+}
+
+func (m *mockUnifiedScraper) GetType() scraper.ScraperType {
+	return scraper.AllAnimeType
+}
+
+func TestFetchEpisodesWithResolvedSourceDispatchesProviders(t *testing.T) {
+	t.Parallel()
+
+	for _, kind := range []SourceKind{SourceAllAnime, SourceAnimefire, SourceAnimeDrive, SourceGoyabu} {
+		kind := kind
+		t.Run(string(kind), func(t *testing.T) {
+			t.Parallel()
+
+			provider := &mockSourceProvider{
+				kind:     kind,
+				episodes: []models.Episode{{Number: "1", Num: 1}},
+			}
+			anime := &models.Anime{Name: "Naruto", Source: string(kind)}
+			resolved := ResolvedSource{Kind: kind, Name: string(kind)}
+
+			episodes, err := fetchEpisodesWithResolvedSource(anime, resolved, func(requested SourceKind) (SourceProvider, bool) {
+				if requested != kind {
+					return nil, false
+				}
+				return provider, true
+			})
+
+			require.NoError(t, err)
+			require.Len(t, episodes, 1)
+			assert.Equal(t, 1, provider.episodesHit)
+			assert.Same(t, anime, provider.gotAnime)
+		})
+	}
+}
+
+func TestFetchStreamURLWithResolvedSourceDispatchesProviders(t *testing.T) {
+	t.Parallel()
+
+	for _, kind := range []SourceKind{SourceAllAnime, SourceAnimefire, SourceAnimeDrive, SourceGoyabu} {
+		kind := kind
+		t.Run(string(kind), func(t *testing.T) {
+			t.Parallel()
+
+			provider := &mockSourceProvider{
+				kind:      kind,
+				streamURL: "https://example.com/video.m3u8",
+			}
+			anime := &models.Anime{Name: "Naruto", Source: string(kind)}
+			episode := &models.Episode{Number: "1", URL: "https://example.com/episode/1"}
+			resolved := ResolvedSource{Kind: kind, Name: string(kind)}
+
+			streamURL, err := fetchStreamURLWithResolvedSource(anime, episode, "1080", resolved, func(requested SourceKind) (SourceProvider, bool) {
+				if requested != kind {
+					return nil, false
+				}
+				return provider, true
+			})
+
+			require.NoError(t, err)
+			assert.Equal(t, "https://example.com/video.m3u8", streamURL)
+			assert.Equal(t, 1, provider.streamHit)
+			assert.Same(t, anime, provider.gotAnime)
+			assert.Same(t, episode, provider.gotEpisode)
+			assert.Equal(t, "1080", provider.gotQuality)
+		})
+	}
+}
+
+func TestFetchEpisodesWithResolvedSourceRequiresRegisteredProvider(t *testing.T) {
+	t.Parallel()
+
+	anime := &models.Anime{Name: "Naruto"}
+	resolved := ResolvedSource{Kind: SourceAnimefire, Name: string(SourceAnimefire)}
+
+	_, err := fetchEpisodesWithResolvedSource(anime, resolved, func(SourceKind) (SourceProvider, bool) {
+		return nil, false
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no source provider registered")
+}
+
+func TestFetchStreamURLWithResolvedSourceRequiresRegisteredProvider(t *testing.T) {
+	t.Parallel()
+
+	anime := &models.Anime{Name: "Naruto"}
+	episode := &models.Episode{Number: "1"}
+	resolved := ResolvedSource{Kind: SourceAnimefire, Name: string(SourceAnimefire)}
+
+	_, err := fetchStreamURLWithResolvedSource(anime, episode, "best", resolved, func(SourceKind) (SourceProvider, bool) {
+		return nil, false
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no source provider registered")
+}
+
+func TestScraperBackedSourceProviderFetchEpisodesUsesResolvedScraper(t *testing.T) {
+	original := providerScraperForKind
+	t.Cleanup(func() {
+		providerScraperForKind = original
+	})
+
+	mockScraper := &mockUnifiedScraper{
+		episodes: []models.Episode{{Number: "1", Num: 1}},
+	}
+	providerScraperForKind = func(kind SourceKind) (scraper.UnifiedScraper, error) {
+		if kind != SourceAnimeDrive {
+			return nil, fmt.Errorf("unexpected kind %s", kind)
+		}
+		return mockScraper, nil
+	}
+
+	provider := scraperBackedSourceProvider{kind: SourceAnimeDrive, streamQualityMode: streamQualityAuto}
+	anime := &models.Anime{URL: "https://example.com/anime"}
+
+	episodes, err := provider.FetchEpisodes(anime)
+	require.NoError(t, err)
+	require.Len(t, episodes, 1)
+	assert.Equal(t, anime.URL, mockScraper.gotEpisodesURL)
+}
+
+func TestScraperBackedSourceProviderFetchStreamURLModes(t *testing.T) {
+	testCases := []struct {
+		name        string
+		mode        streamQualityMode
+		quality     string
+		wantOptions []any
+	}{
+		{name: "requested quality", mode: streamQualityRequested, quality: "1080", wantOptions: []any{"1080"}},
+		{name: "auto quality", mode: streamQualityAuto, quality: "720", wantOptions: []any{"auto"}},
+		{name: "no quality option", mode: streamQualityNone, quality: "720", wantOptions: nil},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			original := providerScraperForKind
+			t.Cleanup(func() {
+				providerScraperForKind = original
+			})
+
+			mockScraper := &mockUnifiedScraper{streamURL: "https://example.com/video.m3u8"}
+			providerScraperForKind = func(kind SourceKind) (scraper.UnifiedScraper, error) {
+				if kind != SourceAnimefire {
+					return nil, fmt.Errorf("unexpected kind %s", kind)
+				}
+				return mockScraper, nil
+			}
+
+			provider := scraperBackedSourceProvider{kind: SourceAnimefire, streamQualityMode: tc.mode}
+			streamURL, err := provider.FetchStreamURL(nil, &models.Episode{URL: "https://example.com/episode"}, tc.quality)
+			require.NoError(t, err)
+			assert.Equal(t, "https://example.com/video.m3u8", streamURL)
+			assert.Equal(t, "https://example.com/episode", mockScraper.gotStreamURL)
+			assert.Equal(t, tc.wantOptions, mockScraper.gotOptions)
+		})
+	}
+}
+
+func TestAllAnimeSourceProviderFetchStreamURLUsesNormalizedInputs(t *testing.T) {
+	original := providerAllAnimeEpisodeURLDirect
+	t.Cleanup(func() {
+		providerAllAnimeEpisodeURLDirect = original
+	})
+
+	var gotEpisodeNumber string
+	var gotQuality string
+	providerAllAnimeEpisodeURLDirect = func(anime *models.Anime, episodeNumber, quality string) (string, map[string]string, error) {
+		assert.Equal(t, "naruto123abc", anime.URL)
+		gotEpisodeNumber = episodeNumber
+		gotQuality = quality
+		return "https://example.com/video.m3u8", nil, nil
+	}
+
+	provider := allAnimeSourceProvider{}
+	streamURL, err := provider.FetchStreamURL(&models.Anime{URL: "naruto123abc"}, &models.Episode{Num: 7}, "")
+	require.NoError(t, err)
+	assert.Equal(t, "https://example.com/video.m3u8", streamURL)
+	assert.Equal(t, "7", gotEpisodeNumber)
+	assert.Equal(t, "best", gotQuality)
+}
+
+func TestNormalizeStreamQualityAndProviderEpisodeNumber(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "best", normalizeStreamQuality(""))
+	assert.Equal(t, "720", normalizeStreamQuality("720"))
+
+	assert.Equal(t, "", providerEpisodeNumber(nil))
+	assert.Equal(t, "12", providerEpisodeNumber(&models.Episode{Number: "12", Num: 99}))
+	assert.Equal(t, "3", providerEpisodeNumber(&models.Episode{Num: 3}))
+	assert.Equal(t, "1", providerEpisodeNumber(&models.Episode{}))
+}

--- a/internal/api/source_resolution.go
+++ b/internal/api/source_resolution.go
@@ -14,6 +14,7 @@ import (
 type SourceKind string
 
 const (
+	// SourceKind values identify the canonical media/source backends recognized by the API layer.
 	// SourceUnknown marks entries whose source could not be resolved safely.
 	SourceUnknown    SourceKind = "Unknown"
 	SourceAllAnime   SourceKind = "AllAnime"

--- a/internal/api/source_resolution.go
+++ b/internal/api/source_resolution.go
@@ -1,0 +1,303 @@
+// Package api coordinates source resolution and playback-oriented orchestration.
+package api
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/alvarorichard/Goanime/internal/models"
+	"github.com/alvarorichard/Goanime/internal/scraper"
+)
+
+// SourceKind represents the canonical scraper/media source for an anime entry.
+type SourceKind string
+
+const (
+	// SourceUnknown marks entries whose source could not be resolved safely.
+	SourceUnknown    SourceKind = "Unknown"
+	SourceAllAnime   SourceKind = "AllAnime"
+	SourceAnimefire  SourceKind = "Animefire.io"
+	SourceAnimeDrive SourceKind = "AnimeDrive"
+	SourceGoyabu     SourceKind = "Goyabu"
+	SourceNineAnime  SourceKind = "9Anime"
+	SourceFlixHQ     SourceKind = "FlixHQ"
+	SourceSuperFlix  SourceKind = "SuperFlix"
+)
+
+// ResolvedSource is the normalized source resolution result for an anime entry.
+type ResolvedSource struct {
+	Kind   SourceKind
+	Name   string
+	Reason string
+}
+
+// Apply normalizes the source field on the provided anime when a source was resolved.
+func (r ResolvedSource) Apply(anime *models.Anime) {
+	if anime == nil || r.Name == "" {
+		return
+	}
+	anime.Source = r.Name
+}
+
+// IsProviderBacked returns true when this source should dispatch through the source-provider registry.
+func (r ResolvedSource) IsProviderBacked() bool {
+	return r.Kind.IsProviderBacked()
+}
+
+// IsProviderBacked returns true when this source should dispatch through the source-provider registry.
+func (k SourceKind) IsProviderBacked() bool {
+	switch k {
+	case SourceAllAnime, SourceAnimefire, SourceAnimeDrive, SourceGoyabu:
+		return true
+	default:
+		return false
+	}
+}
+
+// ScraperType returns the unified scraper type when the source maps directly to one.
+func (k SourceKind) ScraperType() (scraper.ScraperType, bool) {
+	switch k {
+	case SourceAllAnime:
+		return scraper.AllAnimeType, true
+	case SourceAnimefire:
+		return scraper.AnimefireType, true
+	case SourceAnimeDrive:
+		return scraper.AnimeDriveType, true
+	case SourceGoyabu:
+		return scraper.GoyabuType, true
+	case SourceNineAnime:
+		return scraper.NineAnimeType, true
+	case SourceFlixHQ:
+		return scraper.FlixHQType, true
+	case SourceSuperFlix:
+		return scraper.SuperFlixType, true
+	default:
+		return 0, false
+	}
+}
+
+// ResolveSource infers the canonical source once so downstream code can share the same rules.
+func ResolveSource(anime *models.Anime) (ResolvedSource, error) {
+	if anime == nil {
+		return ResolvedSource{}, fmt.Errorf("cannot resolve source for nil anime")
+	}
+
+	if resolved, ok := resolveSourceFromExplicit(anime.Source); ok {
+		return resolved, nil
+	}
+
+	if anime.MediaType == models.MediaTypeMovie || anime.MediaType == models.MediaTypeTV {
+		return newResolvedSource(SourceFlixHQ, "media type"), nil
+	}
+
+	if IsAllAnimeShortID(anime.URL) && !hasPTBRTag(anime.Name) {
+		return newResolvedSource(SourceAllAnime, "AllAnime short ID"), nil
+	}
+
+	if resolved, handled, err := resolveSourceFromTags(anime.Name, anime.URL); handled {
+		if err != nil {
+			return ResolvedSource{}, err
+		}
+		return resolved, nil
+	}
+
+	if resolved, ok := resolveSourceFromURL(anime.URL); ok {
+		return resolved, nil
+	}
+
+	return ResolvedSource{}, fmt.Errorf(
+		"could not resolve source for %q (source=%q mediaType=%q url=%q)",
+		anime.Name,
+		anime.Source,
+		anime.MediaType,
+		anime.URL,
+	)
+}
+
+// IsAllAnimeSource reports whether the given anime resolves to the AllAnime source.
+func IsAllAnimeSource(anime *models.Anime) bool {
+	resolved, err := ResolveSource(anime)
+	return err == nil && resolved.Kind == SourceAllAnime
+}
+
+// IsAllAnimeShortID reports whether a string matches the short identifier style used by AllAnime.
+func IsAllAnimeShortID(value string) bool {
+	value = strings.TrimSpace(value)
+	if value == "" || strings.Contains(strings.ToLower(value), "http") {
+		return false
+	}
+	if isNumericLike(value) {
+		return false
+	}
+	return len(value) >= 6 && len(value) < 30 && containsASCIILetter(value)
+}
+
+// ExtractAllAnimeID extracts the AllAnime ID from either a short ID or a full URL.
+func ExtractAllAnimeID(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ""
+	}
+
+	if !strings.Contains(strings.ToLower(value), "http") && len(value) < 30 {
+		return value
+	}
+
+	if strings.Contains(strings.ToLower(value), "allanime") {
+		parsed, err := url.Parse(value)
+		if err == nil {
+			for part := range strings.SplitSeq(parsed.Path, "/") {
+				if IsAllAnimeShortID(part) {
+					return part
+				}
+			}
+		}
+
+		for part := range strings.SplitSeq(value, "/") {
+			if strings.Contains(part, ".") {
+				continue
+			}
+			if IsAllAnimeShortID(part) {
+				return part
+			}
+		}
+	}
+
+	return value
+}
+
+func newResolvedSource(kind SourceKind, reason string) ResolvedSource {
+	return ResolvedSource{
+		Kind:   kind,
+		Name:   string(kind),
+		Reason: reason,
+	}
+}
+
+func resolveSourceFromExplicit(source string) (ResolvedSource, bool) {
+	source = strings.TrimSpace(source)
+	if source == "" {
+		return ResolvedSource{}, false
+	}
+
+	lower := strings.ToLower(source)
+	switch {
+	case lower == strings.ToLower(string(SourceAllAnime)) || strings.Contains(lower, "allanime"):
+		return newResolvedSource(SourceAllAnime, "explicit source"), true
+	case lower == strings.ToLower(string(SourceAnimefire)) || strings.Contains(lower, "animefire"):
+		return newResolvedSource(SourceAnimefire, "explicit source"), true
+	case lower == strings.ToLower(string(SourceAnimeDrive)) || strings.Contains(lower, "animedrive"):
+		return newResolvedSource(SourceAnimeDrive, "explicit source"), true
+	case lower == strings.ToLower(string(SourceGoyabu)) || strings.Contains(lower, "goyabu"):
+		return newResolvedSource(SourceGoyabu, "explicit source"), true
+	case lower == strings.ToLower(string(SourceNineAnime)) || strings.Contains(lower, "9anime") || strings.Contains(lower, "nineanime"):
+		return newResolvedSource(SourceNineAnime, "explicit source"), true
+	case lower == strings.ToLower(string(SourceFlixHQ)) || lower == "movie" || lower == "tv" || strings.Contains(lower, "flixhq"):
+		return newResolvedSource(SourceFlixHQ, "explicit source"), true
+	case lower == strings.ToLower(string(SourceSuperFlix)) || strings.Contains(lower, "superflix"):
+		return newResolvedSource(SourceSuperFlix, "explicit source"), true
+	default:
+		return ResolvedSource{}, false
+	}
+}
+
+func resolveSourceFromTags(name, url string) (ResolvedSource, bool, error) {
+	lowerName := strings.ToLower(name)
+	switch {
+	case strings.Contains(lowerName, "[allanime]") || strings.Contains(lowerName, "[english]"):
+		return newResolvedSource(SourceAllAnime, "language tag"), true, nil
+	case strings.Contains(lowerName, "[animefire]"):
+		return newResolvedSource(SourceAnimefire, "legacy AnimeFire tag"), true, nil
+	case strings.Contains(lowerName, "[multilanguage]"):
+		return newResolvedSource(SourceNineAnime, "language tag"), true, nil
+	case strings.Contains(lowerName, "[pt-br]") ||
+		strings.Contains(lowerName, "[portuguese]") ||
+		strings.Contains(lowerName, "[português]"):
+		if resolved, ok := resolvePTBRSource(url); ok {
+			resolved.Reason = "PT-BR tag + URL"
+			return resolved, true, nil
+		}
+		return ResolvedSource{}, true, fmt.Errorf(
+			"could not resolve PT-BR source for %q without an explicit source or recognizable URL",
+			name,
+		)
+	default:
+		return ResolvedSource{}, false, nil
+	}
+}
+
+func resolveSourceFromURL(url string) (ResolvedSource, bool) {
+	lowerURL := strings.ToLower(strings.TrimSpace(url))
+	switch {
+	case strings.Contains(lowerURL, "animefire"):
+		return newResolvedSource(SourceAnimefire, "URL"), true
+	case strings.Contains(lowerURL, "animesdrive"):
+		return newResolvedSource(SourceAnimeDrive, "URL"), true
+	case strings.Contains(lowerURL, "goyabu"):
+		return newResolvedSource(SourceGoyabu, "URL"), true
+	case strings.Contains(lowerURL, "allanime"):
+		return newResolvedSource(SourceAllAnime, "URL"), true
+	case strings.Contains(lowerURL, "flixhq") || strings.Contains(lowerURL, "sflix"):
+		return newResolvedSource(SourceFlixHQ, "URL"), true
+	case strings.Contains(lowerURL, "superflix"):
+		return newResolvedSource(SourceSuperFlix, "URL"), true
+	case strings.Contains(lowerURL, "9anime"):
+		return newResolvedSource(SourceNineAnime, "URL"), true
+	default:
+		return ResolvedSource{}, false
+	}
+}
+
+func resolvePTBRSource(url string) (ResolvedSource, bool) {
+	resolved, ok := resolveSourceFromURL(url)
+	if !ok {
+		return ResolvedSource{}, false
+	}
+
+	switch resolved.Kind {
+	case SourceAnimefire, SourceAnimeDrive, SourceGoyabu, SourceSuperFlix:
+		return resolved, true
+	default:
+		return ResolvedSource{}, false
+	}
+}
+
+func isNumericLike(value string) bool {
+	if value == "" {
+		return false
+	}
+
+	dotCount := 0
+	for _, r := range value {
+		switch {
+		case r >= '0' && r <= '9':
+		case r == '.':
+			dotCount++
+			if dotCount > 1 {
+				return false
+			}
+		default:
+			return false
+		}
+	}
+
+	return true
+}
+
+func containsASCIILetter(value string) bool {
+	for _, r := range value {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') {
+			return true
+		}
+	}
+	return false
+}
+
+func hasPTBRTag(name string) bool {
+	lowerName := strings.ToLower(name)
+	return strings.Contains(lowerName, "[pt-br]") ||
+		strings.Contains(lowerName, "[portuguese]") ||
+		strings.Contains(lowerName, "[portugu\u00eas]") ||
+		strings.Contains(lowerName, "[animefire]")
+}

--- a/internal/api/source_resolution_test.go
+++ b/internal/api/source_resolution_test.go
@@ -1,0 +1,227 @@
+package api
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/alvarorichard/Goanime/internal/models"
+	"github.com/alvarorichard/Goanime/internal/scraper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveSource(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name           string
+		anime          models.Anime
+		wantKind       SourceKind
+		wantName       string
+		wantReasonLike string
+		wantErrLike    string
+	}{
+		{
+			name: "AllAnime by short ID",
+			anime: models.Anime{
+				Name: "Naruto",
+				URL:  "naruto123abc",
+			},
+			wantKind:       SourceAllAnime,
+			wantName:       "AllAnime",
+			wantReasonLike: "short ID",
+		},
+		{
+			name: "PT-BR tag plus URL resolves Goyabu",
+			anime: models.Anime{
+				Name: "[PT-BR] Naruto",
+				URL:  "https://goyabu.to/anime/naruto",
+			},
+			wantKind:       SourceGoyabu,
+			wantName:       "Goyabu",
+			wantReasonLike: "PT-BR",
+		},
+		{
+			name: "Goyabu by host",
+			anime: models.Anime{
+				Name: "Naruto",
+				URL:  "https://goyabu.to/anime/naruto",
+			},
+			wantKind:       SourceGoyabu,
+			wantName:       "Goyabu",
+			wantReasonLike: "URL",
+		},
+		{
+			name: "FlixHQ by media type",
+			anime: models.Anime{
+				Name:      "Inception",
+				MediaType: models.MediaTypeMovie,
+			},
+			wantKind:       SourceFlixHQ,
+			wantName:       "FlixHQ",
+			wantReasonLike: "media type",
+		},
+		{
+			name: "9Anime explicit source",
+			anime: models.Anime{
+				Name:   "[Multilanguage] Naruto",
+				URL:    "8143",
+				Source: "9Anime",
+			},
+			wantKind:       SourceNineAnime,
+			wantName:       "9Anime",
+			wantReasonLike: "explicit",
+		},
+		{
+			name: "ambiguous PT-BR without URL fails",
+			anime: models.Anime{
+				Name: "[PT-BR] Naruto",
+				URL:  "naruto",
+			},
+			wantErrLike: "could not resolve PT-BR source",
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			resolved, err := ResolveSource(&tc.anime)
+			if tc.wantErrLike != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.wantErrLike)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantKind, resolved.Kind)
+			assert.Equal(t, tc.wantName, resolved.Name)
+			assert.True(t, strings.Contains(strings.ToLower(resolved.Reason), strings.ToLower(tc.wantReasonLike)))
+
+			resolved.Apply(&tc.anime)
+			assert.Equal(t, tc.wantName, tc.anime.Source)
+		})
+	}
+}
+
+func TestDefaultSourceProvidersCoverMigratedKinds(t *testing.T) {
+	t.Parallel()
+
+	kinds := []SourceKind{
+		SourceAllAnime,
+		SourceAnimefire,
+		SourceAnimeDrive,
+		SourceGoyabu,
+	}
+
+	for _, kind := range kinds {
+		kind := kind
+		t.Run(string(kind), func(t *testing.T) {
+			t.Parallel()
+
+			provider, ok := sourceProviderFor(kind)
+			require.True(t, ok)
+			assert.Equal(t, kind, provider.Kind())
+		})
+	}
+}
+
+func TestSourceKindHelpers(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		kind                 SourceKind
+		wantProviderBacked   bool
+		wantScraperType      scraper.ScraperType
+		wantScraperTypeFound bool
+	}{
+		{kind: SourceAllAnime, wantProviderBacked: true, wantScraperType: scraper.AllAnimeType, wantScraperTypeFound: true},
+		{kind: SourceAnimefire, wantProviderBacked: true, wantScraperType: scraper.AnimefireType, wantScraperTypeFound: true},
+		{kind: SourceAnimeDrive, wantProviderBacked: true, wantScraperType: scraper.AnimeDriveType, wantScraperTypeFound: true},
+		{kind: SourceGoyabu, wantProviderBacked: true, wantScraperType: scraper.GoyabuType, wantScraperTypeFound: true},
+		{kind: SourceNineAnime, wantProviderBacked: false, wantScraperType: scraper.NineAnimeType, wantScraperTypeFound: true},
+		{kind: SourceFlixHQ, wantProviderBacked: false, wantScraperType: scraper.FlixHQType, wantScraperTypeFound: true},
+		{kind: SourceSuperFlix, wantProviderBacked: false, wantScraperType: scraper.SuperFlixType, wantScraperTypeFound: true},
+		{kind: SourceUnknown, wantProviderBacked: false, wantScraperTypeFound: false},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(string(tc.kind), func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tc.wantProviderBacked, tc.kind.IsProviderBacked())
+
+			gotType, ok := tc.kind.ScraperType()
+			assert.Equal(t, tc.wantScraperTypeFound, ok)
+			if tc.wantScraperTypeFound {
+				assert.Equal(t, tc.wantScraperType, gotType)
+			}
+
+			resolved := ResolvedSource{Kind: tc.kind, Name: string(tc.kind)}
+			assert.Equal(t, tc.wantProviderBacked, resolved.IsProviderBacked())
+		})
+	}
+}
+
+func TestResolvedSourceApplyNoOp(t *testing.T) {
+	t.Parallel()
+
+	anime := &models.Anime{Source: "keep"}
+	ResolvedSource{}.Apply(anime)
+	assert.Equal(t, "keep", anime.Source)
+
+	ResolvedSource{Name: "AllAnime"}.Apply(nil)
+}
+
+func TestResolveSourceNilAnime(t *testing.T) {
+	t.Parallel()
+
+	_, err := ResolveSource(nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "nil anime")
+}
+
+func TestAllAnimeIDHelpers(t *testing.T) {
+	t.Parallel()
+
+	isShortIDCases := []struct {
+		name  string
+		value string
+		want  bool
+	}{
+		{name: "short id with letters and numbers", value: "naruto123abc", want: true},
+		{name: "url is not short id", value: "https://allanime.to/anime/naruto123abc", want: false},
+		{name: "numeric value is not short id", value: "123456", want: false},
+		{name: "too short", value: "abc", want: false},
+		{name: "empty", value: "", want: false},
+	}
+
+	for _, tc := range isShortIDCases {
+		tc := tc
+		t.Run("IsAllAnimeShortID/"+tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, IsAllAnimeShortID(tc.value))
+		})
+	}
+
+	extractCases := []struct {
+		name  string
+		value string
+		want  string
+	}{
+		{name: "short id preserved", value: "naruto123abc", want: "naruto123abc"},
+		{name: "allanime url extracts short id", value: "https://allanime.to/anime/naruto123abc/watch", want: "naruto123abc"},
+		{name: "blank returns blank", value: " ", want: ""},
+		{name: "non all-anime url preserved", value: "https://example.com/watch/naruto", want: "https://example.com/watch/naruto"},
+	}
+
+	for _, tc := range extractCases {
+		tc := tc
+		t.Run("ExtractAllAnimeID/"+tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, ExtractAllAnimeID(tc.value))
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- centralize source resolution into shared helpers used by enhanced API flows
- add provider-backed orchestration seams and focused tests for source dispatch
- cover SSRF and transport safety paths in the API layer

## Why
The API/source slice was the next clean dependency after suite stabilization. This PR makes source identification and provider routing testable in isolation, and it locks in the security-sensitive transport behavior with hermetic tests.

## Validation
- go test ./internal/api -count=1
- go test ./internal/api -cover -count=1
- go build ./cmd/goanime
- go run ./cmd/goanime --version
- go run ./cmd/goanime --help

## Notes
- This stays draft while GitHub checks run.
- Full repo short-suite execution in this fresh worktree exceeded the local command timeout, so GitHub CI remains the source of truth for whole-repo validation.
