### PR TITLE
Add support to AnimeWorld for italian anime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ result
 goanime
 goanime-test
 build/goanime-local
+bin
 
 #Ignore vscode AI rules
 .github/copilot-instructions.md

--- a/internal/api/enhanced.go
+++ b/internal/api/enhanced.go
@@ -114,6 +114,10 @@ func SearchAnimeEnhanced(name string, source string) (*models.Anime, error) {
 		t := scraper.SuperFlixType
 		scraperType = &t
 		util.Debug("Searching specific source", "source", "SuperFlix")
+	case "animeworld":
+		t := scraper.AnimeWorldType
+		scraperType = &t
+		util.Debug("Searching specific source", "source", "AnimeWorld")
 	case "ptbr", "pt-br":
 		isPTBR = true
 		util.Debug("Searching all PT-BR sources (AnimeFire + Goyabu + SuperFlix)")
@@ -153,8 +157,11 @@ func SearchAnimeEnhanced(name string, source string) (*models.Anime, error) {
 				anime.Source = "Animefire.io"
 			case strings.Contains(anime.URL, "goyabu"):
 				anime.Source = "Goyabu"
+			case strings.Contains(anime.URL, "animeworld"):
+				anime.Source = "AnimeWorld"
 			}
-			}
+
+		}
 
 		// Language tags are already added by unified.go, don't duplicate them here
 	}
@@ -167,6 +174,7 @@ func SearchAnimeEnhanced(name string, source string) (*models.Anime, error) {
 		"AllAnime", breakdown.AllAnime,
 		"SuperFlix", breakdown.SuperFlix,
 		"Goyabu", breakdown.Goyabu,
+		"AnimeWorld", breakdown.AnimeWorld,
 	)
 
 	// Sort results by language priority: Portuguese first, then Multilanguage, Movies/TV, English, others
@@ -277,6 +285,8 @@ func GetAnimeEpisodesEnhanced(anime *models.Anime) ([]models.Episode, error) {
 		sourceName = "Animefire.io"
 	case anime.Source == "Goyabu":
 		sourceName = "Goyabu"
+	case anime.Source == "AnimeWorld":
+		sourceName = "AnimeWorld"
 	case strings.Contains(anime.Name, "[English]"):
 		// Priority 2: Check language tags
 		sourceName = "AllAnime"
@@ -341,6 +351,12 @@ func GetAnimeEpisodesEnhanced(anime *models.Anime) ([]models.Episode, error) {
 			return nil, fmt.Errorf("failed to get Goyabu scraper: %w", scErr)
 		}
 		episodes, err = scraperInstance.GetAnimeEpisodes(anime.URL)
+	case sourceName == "AnimeWorld":
+		scraperInstance, scErr := scraperManager.GetScraper(scraper.AnimeWorldType)
+		if scErr != nil {
+			return nil, fmt.Errorf("failed to get AnimeWorld scraper: %w", scErr)
+		}
+		episodes, err = scraperInstance.GetAnimeEpisodes(anime.URL)
 	default:
 		// For others, use the original API function
 		episodes, err = GetAnimeEpisodes(anime.URL)
@@ -400,6 +416,9 @@ func GetEpisodeStreamURL(episode *models.Episode, anime *models.Anime, quality s
 	case sourceLower == "goyabu":
 		scraperType = scraper.GoyabuType
 		sourceName = "Goyabu"
+	case sourceLower == "animeworld":
+		scraperType = scraper.AnimeWorldType
+		sourceName = "AnimeWorld"
 	case strings.Contains(anime.Name, "[English]"):
 		// Priority 2: Check language tags (AllAnime = English)
 		scraperType = scraper.AllAnimeType
@@ -427,6 +446,9 @@ func GetEpisodeStreamURL(episode *models.Episode, anime *models.Anime, quality s
 	case strings.Contains(anime.URL, "allanime"):
 		scraperType = scraper.AllAnimeType
 		sourceName = "AllAnime"
+	case strings.Contains(anime.Name, "animeworld"):
+		scraperType = scraper.AnimeWorldType
+		sourceName = "AnimeWorld"
 	default:
 		scraperType = scraper.AllAnimeType
 		sourceName = "AllAnime (default)"
@@ -461,6 +483,9 @@ func GetEpisodeStreamURL(episode *models.Episode, anime *models.Anime, quality s
 	case scraper.GoyabuType:
 		util.Debug("Processing through Goyabu")
 		streamURL, _, streamErr = scraperInstance.GetStreamURL(episode.URL)
+	case scraper.AnimeWorldType:
+		util.Debug("Processing through AnimeWorld")
+		streamURL, _, streamErr = scraperInstance.GetStreamURL(episode.URL, quality)
 	default:
 		util.Debug("Processing through Animefire.io")
 		streamURL, _, streamErr = scraperInstance.GetStreamURL(episode.URL, quality)
@@ -549,6 +574,7 @@ func sanitizeFilename(name string) string {
 	name = strings.ReplaceAll(name, "[Português]", "")
 	name = strings.ReplaceAll(name, "(Legendado)", "")
 	name = strings.ReplaceAll(name, "(Dublado)", "")
+	name = strings.ReplaceAll(name, "[Italian]", "")
 	name = strings.TrimSpace(name)
 
 	// Replace invalid characters
@@ -571,7 +597,6 @@ func downloadFromURL(_ string, _ string) error {
 func SearchAnimeWithSource(name string, source string) (*models.Anime, error) {
 	return SearchAnimeEnhanced(name, source)
 }
-
 
 func GetAnimeEpisodesWithSource(anime *models.Anime) ([]models.Episode, error) {
 	return GetAnimeEpisodesEnhanced(anime)
@@ -753,10 +778,11 @@ func GetSuperFlixStreamURL(media *models.Anime, episode *models.Episode, quality
 // diagnostic line. Counted via countSourceBreakdown so the predicate stays
 // testable in isolation.
 type sourceBreakdown struct {
-	AnimeFire int
-	AllAnime  int
-	SuperFlix int
-	Goyabu    int
+	AnimeFire  int
+	AllAnime   int
+	SuperFlix  int
+	Goyabu     int
+	AnimeWorld int
 }
 
 // countSourceBreakdown tallies anime results by Source field using
@@ -778,13 +804,15 @@ func countSourceBreakdown(animes []*models.Anime) sourceBreakdown {
 			b.SuperFlix++
 		case anime.Source == "Goyabu":
 			b.Goyabu++
+		case anime.Source == "AnimeWorld":
+			b.AnimeWorld++
 		}
 	}
 	return b
 }
 
 // languagePriority returns a sort key for language-based ordering.
-// Lower values sort first: Portuguese → Multilanguage → English → Movies/TV → Unknown.
+// Lower values sort first: Portuguese → Multilanguage → English → Italian → Movies/TV → Unknown.
 func languagePriority(name string) int {
 	lower := strings.ToLower(name)
 	// Check for [PT-BR] anywhere (covers "[Movie] [PT-BR] ...", "[TV] [PT-BR] ...", etc.)
@@ -796,9 +824,11 @@ func languagePriority(name string) int {
 		return 1
 	case strings.HasPrefix(lower, "[english]"):
 		return 2
-	case strings.HasPrefix(lower, "[movie]") || strings.HasPrefix(lower, "[tv]") || strings.HasPrefix(lower, "[movies/tv]"):
+	case strings.HasPrefix(lower, "[italian]"):
 		return 3
-	default:
+	case strings.HasPrefix(lower, "[movie]") || strings.HasPrefix(lower, "[tv]") || strings.HasPrefix(lower, "[movies/tv]"):
 		return 4
+	default:
+		return 5
 	}
 }

--- a/internal/api/enhanced_pure_test.go
+++ b/internal/api/enhanced_pure_test.go
@@ -43,10 +43,11 @@ func TestLanguagePriority(t *testing.T) {
 		{"movie + ptbr", "[Movie] [PT-BR] Inception", 0},
 		{"multilanguage", "[Multilanguage] Naruto", 1},
 		{"english", "[English] Naruto", 2},
-		{"movie", "[Movie] Inception", 3},
-		{"tv", "[TV] Show", 3},
-		{"movies tv", "[Movies/TV] Show", 3},
-		{"unknown default", "Plain title", 4},
+		{"italian tag", "[Italian] Naruto", 3},
+		{"movie", "[Movie] Inception", 4},
+		{"tv", "[TV] Show", 4},
+		{"movies tv", "[Movies/TV] Show", 4},
+		{"unknown default", "Plain title", 5},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/api/providers/source_providers.go
+++ b/internal/api/providers/source_providers.go
@@ -301,4 +301,3 @@ func (p *superFlixProvider) FetchStreamURL(_ context.Context, episode *models.Ep
 	}
 	return url, nil
 }
-

--- a/internal/downloader/download_inject_test.go
+++ b/internal/downloader/download_inject_test.go
@@ -86,7 +86,7 @@ func makeInjectedDownloader(t *testing.T) (*EpisodeDownloader, *mockProgressSend
 	d := makeEpisodeDownloader(t, "Foo", makeEpisodes(1), false)
 	d.opts = downloaderOptions{
 		httpClient: &http.Client{Timeout: 5 * time.Second}, // bypass SafeTransport for loopback
-		sleep:      func(time.Duration) {},                  // skip the 1s/500ms pauses
+		sleep:      func(time.Duration) {},                 // skip the 1s/500ms pauses
 		newSender:  func(tea.Model) progressSender { return sender },
 	}
 	return d, sender

--- a/internal/downloader/downloader.go
+++ b/internal/downloader/downloader.go
@@ -56,8 +56,8 @@ type progressSender interface {
 // the corresponding helper method falls back to a production default when the
 // field is nil. Tests set these via SetTestHooks (test-only constructor).
 type downloaderOptions struct {
-	httpClient *http.Client                 // override SafeTransport client
-	sleep      func(time.Duration)          // override time.Sleep (skip waits)
+	httpClient *http.Client                   // override SafeTransport client
+	sleep      func(time.Duration)            // override time.Sleep (skip waits)
 	newSender  func(tea.Model) progressSender // override tui.NewProgram
 }
 

--- a/internal/downloader/downloader_test.go
+++ b/internal/downloader/downloader_test.go
@@ -600,4 +600,3 @@ func withClosedStdin(t *testing.T) {
 		_ = f.Close()
 	})
 }
-

--- a/internal/playback/series.go
+++ b/internal/playback/series.go
@@ -215,7 +215,7 @@ type extractEpisodeNumberFuncType func(s string) string
 // selectEpisodeFunc and extractEpisodeNumberFunc are package-level
 // indirections injected by tests. Production code never touches them.
 var (
-	selectEpisodeFunc       selectEpisodeFuncType       = player.SelectEpisodeWithFuzzyFinder
+	selectEpisodeFunc        selectEpisodeFuncType        = player.SelectEpisodeWithFuzzyFinder
 	extractEpisodeNumberFunc extractEpisodeNumberFuncType = player.ExtractEpisodeNumber
 )
 

--- a/internal/player/download.go
+++ b/internal/player/download.go
@@ -22,7 +22,6 @@ import (
 	"charm.land/bubbles/v2/progress"
 	tea "charm.land/bubbletea/v2"
 	"charm.land/huh/v2"
-	"golang.org/x/term"
 	"github.com/alvarorichard/Goanime/internal/api"
 	"github.com/alvarorichard/Goanime/internal/downloader/hls"
 	"github.com/alvarorichard/Goanime/internal/models"
@@ -31,6 +30,7 @@ import (
 	"github.com/alvarorichard/Goanime/internal/util"
 	"github.com/ktr0731/go-fuzzyfinder"
 	"github.com/lrstanley/go-ytdlp"
+	"golang.org/x/term"
 )
 
 // Pre-compiled regexes for download quality parsing

--- a/internal/player/playvideo_pure_test.go
+++ b/internal/player/playvideo_pure_test.go
@@ -643,4 +643,3 @@ func TestInitDiscordPresence_SymbolPinned(t *testing.T) {
 	t.Parallel()
 	assert.NotNil(t, initDiscordPresence)
 }
-

--- a/internal/player/scraper.go
+++ b/internal/player/scraper.go
@@ -362,7 +362,7 @@ func GetVideoURLForEpisodeEnhanced(episode *models.Episode, anime *models.Anime)
 		return "", fmt.Errorf("cannot resolve stream without anime context for episode %s; missing anime identifier", episode.Number)
 	}
 
-// Movie/TV routing: SuperFlix and FlixHQ both flow through the enhanced API,
+	// Movie/TV routing: SuperFlix and FlixHQ both flow through the enhanced API,
 	// which dispatches by anime.Source internally. Label logs by the actual
 	// source so triage isn't misled into thinking SuperFlix failures came from
 	// FlixHQ.

--- a/internal/player/scraper_pure_test.go
+++ b/internal/player/scraper_pure_test.go
@@ -423,4 +423,3 @@ func TestSelectQualityFromOptions_EmptyDataReturnsEmpty(t *testing.T) {
 	t.Parallel()
 	assert.Equal(t, "", selectQualityFromOptions(nil, "best"))
 }
-

--- a/internal/scraper/adapters_test.go
+++ b/internal/scraper/adapters_test.go
@@ -42,3 +42,12 @@ func TestNewSuperFlixAdapterWithClient(t *testing.T) {
 	assert.Same(t, client, a.GetClient())
 	assert.Equal(t, SuperFlixType, a.GetType())
 }
+
+func TestNewAnimeWorldAdapterWithClient(t *testing.T) {
+	t.Parallel()
+	client := NewAnimeWorldClient()
+	a := NewAnimeWorldAdapterWithClient(client)
+	require.NotNil(t, a)
+	assert.Same(t, client, a.GetClient())
+	assert.Equal(t, AnimeWorldType, a.GetType())
+}

--- a/internal/scraper/animeworld.go
+++ b/internal/scraper/animeworld.go
@@ -1,3 +1,4 @@
+// Package scraper provides web scraping functionality for animeworld.ac
 package scraper
 
 import (
@@ -18,7 +19,7 @@ import (
 
 const (
 	animeWorldBase       = "https://www.animeworld.ac"
-	animeWorldApiEpisode = "https://www.animeworld.ac/api/episode/info"
+	animeWorldAPIEpisode = "https://www.animeworld.ac/api/episode/info"
 	animeWorldSource     = "AnimeWorld"
 )
 
@@ -30,7 +31,7 @@ var animeWorldEpisodeURLPattern = regexp.MustCompile(`^/play/[^/?#]+(/[^/?#]+)?$
 type AnimeWorldClient struct {
 	client        *http.Client
 	baseURL       string
-	episodeApiURL string
+	episodeAPIURL string
 	userAgent     string
 	maxRetries    int
 	retryDelay    time.Duration
@@ -42,7 +43,7 @@ func NewAnimeWorldClient() *AnimeWorldClient {
 	return &AnimeWorldClient{
 		client:        util.NewFastClient(),
 		baseURL:       animeWorldBase,
-		episodeApiURL: animeWorldApiEpisode,
+		episodeAPIURL: animeWorldAPIEpisode,
 		userAgent:     UserAgent,
 		maxRetries:    2,
 		retryDelay:    300 * time.Millisecond,
@@ -212,7 +213,7 @@ func (c *AnimeWorldClient) searchVideoURLApi(episodeURL string) (string, error) 
 
 	util.Debug("AnimeWorld API request", "episodeID", episodeID)
 
-	reqURL := fmt.Sprintf("%s?id=%s", c.episodeApiURL, episodeID)
+	reqURL := fmt.Sprintf("%s?id=%s", c.episodeAPIURL, episodeID)
 	req, err := http.NewRequest(http.MethodGet, reqURL, nil)
 	if err != nil {
 		return "", fmt.Errorf("create API request: %w", err)

--- a/internal/scraper/animeworld.go
+++ b/internal/scraper/animeworld.go
@@ -22,11 +22,11 @@ const (
 	animeWorldSource     = "AnimeWorld"
 )
 
+// animeWorldEpisodeURLPattern matches AnimeWorld play paths, e.g. /play/naruto-ita.9XRsD/TMWIn.
+// It also matches bare anime pages since they share the same /play/ prefix.
 var animeWorldEpisodeURLPattern = regexp.MustCompile(`^/play/[^/?#]+(/[^/?#]+)?$`)
 
-// TODO CHECK ALSO THE MANAGER THERE ARE ADAOTER ETC... I DONT THINK THIS SHOULD IMPLEMENT THE SCRAPER INTERFACE, BUT MAYBE AN ADAPTER MUST BE USED!
-// ALSO FOR SCRAPERTYPE I DUNNOOOO. GOYABUCLIENT DOESNT IMPLEMENT INTERFACE, BUT ITS IN A ADAPTOR
-// QUEL MAP PUZZA, NON CI STA DOCUMENTAZIONE CHE DICE CHE COSA E'
+// AnimeWorldClient handles interactions with animeworld.ac.
 type AnimeWorldClient struct {
 	client        *http.Client
 	baseURL       string
@@ -37,6 +37,7 @@ type AnimeWorldClient struct {
 	scraperType   ScraperType
 }
 
+// NewAnimeWorldClient creates a ready-to-use AnimeWorld client.
 func NewAnimeWorldClient() *AnimeWorldClient {
 	return &AnimeWorldClient{
 		client:        util.NewFastClient(),
@@ -49,53 +50,58 @@ func NewAnimeWorldClient() *AnimeWorldClient {
 	}
 }
 
-// SearchAnime searches for anime on animeworld.ac
+// SearchAnime searches animeworld.ac for the given query and returns matching anime.
 func (c *AnimeWorldClient) SearchAnime(query string) ([]*models.Anime, error) {
-	// query "attacco dei giganti"
-	// url => https://www.animeworld.ac/search?keyword=attacco+dei+giganti
 	query = normalizeQuery(query)
-
 	util.Debug("AnimeWorld search", "query", query)
-
-	searchURL := c.buildRequestURL(query)
-	return c.searchAnimeHTML(searchURL)
+	return c.searchAnimeHTML(c.buildRequestURL(query))
 }
 
-// GetAnimeEpisodes scrapes the episodes of an anime given its URL
+// GetAnimeEpisodes returns all episodes for the anime at animeURL.
 func (c *AnimeWorldClient) GetAnimeEpisodes(animeURL string) ([]models.Episode, error) {
+	util.Debug("AnimeWorld episodes", "url", animeURL)
 	if err := c.validateEpisodeURL(animeURL); err != nil {
 		return nil, err
 	}
 	return c.searchAnimeEpisodesHTML(animeURL)
 }
 
-// GetStreamURL fetches the video source URL of an episode
+// GetStreamURL returns the direct video URL for the episode at episodeURL.
+// It tries the JSON API first and falls back to HTML scraping.
 func (c *AnimeWorldClient) GetStreamURL(episodeURL string) (string, error) {
+	util.Debug("AnimeWorld stream URL", "url", episodeURL)
 	if err := c.validateEpisodeURL(episodeURL); err != nil {
 		return "", err
 	}
+
 	source, apiErr := c.searchVideoURLApi(episodeURL)
 	if apiErr == nil {
+		util.Debug("AnimeWorld stream URL found via API", "url", source)
 		return source, nil
 	}
-	// fallback to HTML
+	util.Debug("AnimeWorld API strategy failed, trying HTML fallback", "error", apiErr)
+
 	source, htmlErr := c.searchVideoURLHTML(episodeURL)
 	if htmlErr == nil {
+		util.Debug("AnimeWorld stream URL found via HTML", "url", source)
 		return source, nil
 	}
-	return "", fmt.Errorf("AnimeWorld search failed for episode URL: %s: %w",
-		episodeURL,
-		errors.Join(apiErr, htmlErr))
+	util.Debug("AnimeWorld HTML strategy failed", "error", htmlErr)
+
+	return "", fmt.Errorf("AnimeWorld: all strategies failed for %s: %w",
+		episodeURL, errors.Join(apiErr, htmlErr))
 }
 
+// searchAnimeHTML fetches searchURL and extracts anime search results.
 func (c *AnimeWorldClient) searchAnimeHTML(searchURL string) ([]*models.Anime, error) {
-	doc, err := c.fetchDoc(searchURL, "AnimeWorld Anime search HTML")
+	doc, err := c.fetchDoc(searchURL, "AnimeWorld search")
 	if err != nil {
 		return nil, err
 	}
 	return c.extractAnimeSearchResults(doc)
 }
 
+// extractAnimeSearchResults parses the .film-list grid into Anime models.
 func (c *AnimeWorldClient) extractAnimeSearchResults(doc *goquery.Document) ([]*models.Anime, error) {
 	var anime []*models.Anime
 
@@ -106,10 +112,7 @@ func (c *AnimeWorldClient) extractAnimeSearchResults(doc *goquery.Document) ([]*
 		if name == "" || href == "" {
 			return
 		}
-
-		// unhandled error: an empty imgURL is self-explanatory
 		imgURL, _ := s.Find("a.poster img").Attr("src")
-
 		anime = append(anime, &models.Anime{
 			Name:      name,
 			URL:       resolveURL(c.baseURL, href),
@@ -118,173 +121,175 @@ func (c *AnimeWorldClient) extractAnimeSearchResults(doc *goquery.Document) ([]*
 			MediaType: models.MediaTypeAnime,
 		})
 	})
+
+	util.Debug("AnimeWorld search results", "count", len(anime))
 	return anime, nil
 }
 
+// searchAnimeEpisodesHTML fetches the anime page and extracts its episode list.
 func (c *AnimeWorldClient) searchAnimeEpisodesHTML(animeURL string) ([]models.Episode, error) {
-	doc, err := c.fetchDoc(animeURL, "AnimeWorld Episodes search HTML")
+	doc, err := c.fetchDoc(animeURL, "AnimeWorld episodes")
 	if err != nil {
 		return nil, err
 	}
 	return c.extractEpisodesSearchResults(doc)
 }
 
-// TODO NUM EPISODE CHECK IF BREAKS THE APPLICATION
-
-// animeWorldRawEpisodes represents the raw episode data scraped from World Anime
-type animeWorldRawEpisodes struct {
-	episodeNumberStr string
-	episodeNumber    int
-	episodeURL       string
+// rawEpisode holds intermediate episode data before conversion to models.Episode.
+type rawEpisode struct {
+	numberStr string
+	number    int
+	url       string
 }
 
-// extractEpisodesSearchResults ignores episodes that for some resons are not found
+// extractEpisodesSearchResults parses episode links from the anime page.
 //
-// handles also the case of a "double episode". It's not common, but sometimes
-// a video source contains two episodes one after others. Probably because it was aired in this way in Italy
-// A double episode can be for example "45-46"
-// I don't know how to handle this case for the Num field in models.Episode.
+// AnimeWorld occasionally airs two episodes back-to-back; in that case
+// data-episode-num contains a range like "45-46". The Num field is set to
+// the first episode in the range; the full string is preserved in Number.
 func (c *AnimeWorldClient) extractEpisodesSearchResults(doc *goquery.Document) ([]models.Episode, error) {
-	var episodes []animeWorldRawEpisodes
-	doc.Find("ul.episodes li.episode a").Each(func(i int, s *goquery.Selection) {
-		numberStr, exists := s.Attr("data-episode-num")
+	var raw []rawEpisode
+
+	doc.Find("ul.episodes li.episode a").Each(func(_ int, s *goquery.Selection) {
+		numStr, exists := s.Attr("data-episode-num")
 		if !exists {
 			return
 		}
-		num, err := strconv.Atoi(numberStr)
+		num, err := strconv.Atoi(numStr)
 		if err != nil {
+			util.Debug("AnimeWorld skipping episode with non-integer num", "data-episode-num", numStr)
 			return
 		}
 		href, exists := s.Attr("href")
 		if !exists {
 			return
 		}
-
-		episodes = append(episodes, animeWorldRawEpisodes{
-			episodeNumberStr: fmt.Sprintf("%d", num),
-			episodeNumber:    num,
-			episodeURL:       href,
+		raw = append(raw, rawEpisode{
+			numberStr: fmt.Sprintf("%d", num),
+			number:    num,
+			url:       href,
 		})
 	})
-	return c.adjustEpisodes(episodes), nil
+
+	episodes := c.normalizeEpisodes(raw)
+	util.Debug("AnimeWorld episodes parsed", "count", len(episodes))
+	return episodes, nil
 }
 
-// adjustEpisodes synchronizes the episode name number with the episode name if there are double episodes
-// Otherwise just maps to []models.Episode. See Tests for more info
-func (c *AnimeWorldClient) adjustEpisodes(rawEps []animeWorldRawEpisodes) []models.Episode {
-	var episodes []models.Episode
+// normalizeEpisodes converts raw episode data to models.Episode, resolving
+// double-episode ranges (e.g. "45-46") to their first episode number.
+func (c *AnimeWorldClient) normalizeEpisodes(rawEps []rawEpisode) []models.Episode {
+	episodes := make([]models.Episode, 0, len(rawEps))
 	for _, raw := range rawEps {
-		// Parse the actual episode number from the string (handles "3", "3-4", etc.)
-		firstNum := raw.episodeNumber // fallback if parsing fails
-		if parts := strings.SplitN(raw.episodeNumberStr, "-", 2); len(parts) > 0 {
+		firstNum := raw.number
+		if parts := strings.SplitN(raw.numberStr, "-", 2); len(parts) > 0 {
 			if n, err := strconv.Atoi(parts[0]); err == nil {
 				firstNum = n
 			}
 		}
 		episodes = append(episodes, models.Episode{
-			Number: "Episodio " + raw.episodeNumberStr,
+			Number: "Episodio " + raw.numberStr,
 			Num:    firstNum,
-			URL:    resolveURL(c.baseURL, raw.episodeURL),
+			URL:    resolveURL(c.baseURL, raw.url),
 		})
 	}
 	return episodes
 }
 
+// animeWorldAPIResponse is the JSON shape returned by /api/episode/info.
 type animeWorldAPIResponse struct {
-	Grabber string `json:"grabber"` // source URL
+	Grabber string `json:"grabber"` // direct video URL
 	Name    string `json:"name"`
 	Target  string `json:"target"`
 }
 
-// searchVideoURLApi fetches the videoURL source of the episode from the AnimeWorld api.
-// This is the preferred way.
+// searchVideoURLApi resolves the video URL for episodeURL via the AnimeWorld JSON API.
 func (c *AnimeWorldClient) searchVideoURLApi(episodeURL string) (string, error) {
-	// extract the episode ID
 	episodeID, err := c.extractEpisodeIDFromURL(episodeURL)
 	if err != nil {
 		return "", err
 	}
+
+	util.Debug("AnimeWorld API request", "episodeID", episodeID)
+
 	reqURL := fmt.Sprintf("%s?id=%s", c.episodeApiURL, episodeID)
-	req, err := http.NewRequest("GET", reqURL, nil)
+	req, err := http.NewRequest(http.MethodGet, reqURL, nil)
 	if err != nil {
-		return "", fmt.Errorf("request creation failed: %w", err)
+		return "", fmt.Errorf("create API request: %w", err)
 	}
+	c.decorateRequest(req)
+
 	resp, err := c.client.Do(req)
 	if err != nil {
-		return "", fmt.Errorf("AnimeWorld api call: %w", err)
+		return "", fmt.Errorf("API call failed: %w", err)
 	}
-	defer resp.Body.Close()
-	var rBody animeWorldAPIResponse
-	if err := json.NewDecoder(resp.Body).Decode(&rBody); err != nil {
-		return "", fmt.Errorf("AnimeWorld animeWorldAPIResponse unmarshalling: %w", err)
+	defer func() { _ = resp.Body.Close() }()
+
+	if err := checkHTTPStatus(resp, "AnimeWorld episode API"); err != nil {
+		return "", err
 	}
-	if rBody.Grabber == "" {
-		return "", fmt.Errorf("AnimeWorld no episode url found from the api")
+
+	var body animeWorldAPIResponse
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return "", fmt.Errorf("decode API response: %w", err)
 	}
-	return rBody.Grabber, nil
+	if body.Grabber == "" {
+		util.Debug("AnimeWorld API returned empty grabber", "episodeID", episodeID)
+		return "", errors.New("API returned no video URL")
+	}
+
+	util.Debug("AnimeWorld API response", "grabber", body.Grabber, "name", body.Name)
+	return body.Grabber, nil
 }
 
+// extractEpisodeIDFromURL returns the last path segment of episodeURL, which
+// AnimeWorld uses as the episode ID (e.g. "TMWIn" from /play/naruto.9XRsD/TMWIn).
 func (c *AnimeWorldClient) extractEpisodeIDFromURL(episodeURL string) (string, error) {
-	// Example episode URL: https://www.animeworld.ac/play/naruto-shippuden-ita.9XRsD/TMWIn
-	// ID: TMWIn
-	lastDotIndex := strings.LastIndex(episodeURL, "/")
-	if lastDotIndex == -1 {
-		return "", errors.New("invalid URL format: episode ID not found")
+	idx := strings.LastIndex(episodeURL, "/")
+	if idx == -1 || idx == len(episodeURL)-1 {
+		return "", fmt.Errorf("cannot extract episode ID from URL: %s", episodeURL)
 	}
-	episodeID := episodeURL[lastDotIndex+1:]
-	if len(episodeID) == 0 {
-		return "", errors.New("invalid URL format: episode ID is empty")
-	}
-	return episodeID, nil
+	return episodeURL[idx+1:], nil
 }
 
-// searchVideoURLHTML fetches the video source URL of the episode.
-// AnimeWorld can offer more than one URL. The first scraped URL is returned
+// searchVideoURLHTML scrapes the download links from the episode page as a
+// fallback when the API is unavailable.
 func (c *AnimeWorldClient) searchVideoURLHTML(episodeURL string) (string, error) {
-	doc, err := c.fetchDoc(episodeURL, "AnimeWorld episode video source fetch HTML")
+	doc, err := c.fetchDoc(episodeURL, "AnimeWorld episode page")
 	if err != nil {
-		return "", fmt.Errorf("AnimeWorld failed to parse HTML: %s", episodeURL)
+		return "", err
 	}
 
-	get := func(selector string) (string, bool) {
+	for _, selector := range []string{"#alternativeDownloadLink", "#downloadLink"} {
 		sel := doc.Find(selector)
 		if sel.Length() == 0 {
-			return "", false
+			util.Debug("AnimeWorld HTML selector miss", "selector", selector)
+			continue
 		}
-
 		href, ok := sel.Attr("href")
 		if !ok {
-			return "", false
+			util.Debug("AnimeWorld HTML selector found but no href", "selector", selector)
+			continue
 		}
-
-		vURL, err := c.normalizeAnimeWorldVideoURL(href)
+		videoURL, err := c.normalizeVideoURL(href)
 		if err != nil {
-			return "", false
+			util.Debug("AnimeWorld video URL normalization failed", "selector", selector, "href", href, "error", err)
+			continue
 		}
-
-		return vURL, true
+		util.Debug("AnimeWorld HTML selector hit", "selector", selector, "url", videoURL)
+		return videoURL, nil
 	}
 
-	// preference order
-	if url, ok := get("#alternativeDownloadLink"); ok {
-		return url, nil
-	}
-
-	if url, ok := get("#downloadLink"); ok {
-		return url, nil
-	}
-
-	return "", fmt.Errorf("AnimeWorld no video source found for episode: %s", episodeURL)
+	return "", fmt.Errorf("no video source found for episode: %s", episodeURL)
 }
 
-// fetchDoc makes an HTTP call to the given url and parses the HTML to a goquery.Document struct.
-// It requires a httpSource string that will be used by checkHTTPStatus
+// fetchDoc performs a GET request to url with retries and returns the parsed HTML document.
 func (c *AnimeWorldClient) fetchDoc(url, httpSource string) (*goquery.Document, error) {
 	var lastErr error
-	attempts := c.maxRetries + 1
 
-	for attempt := 0; attempt < attempts; attempt++ {
+	for attempt := range c.maxRetries + 1 {
 		if attempt > 0 {
+			util.Debug("AnimeWorld retrying request", "source", httpSource, "attempt", attempt+1, "url", url)
 			time.Sleep(c.retryDelay)
 		}
 
@@ -297,84 +302,80 @@ func (c *AnimeWorldClient) fetchDoc(url, httpSource string) (*goquery.Document, 
 		resp, err := c.client.Do(req)
 		if err != nil {
 			lastErr = fmt.Errorf("request failed (attempt %d): %w", attempt+1, err)
+			util.Debug("AnimeWorld request error", "source", httpSource, "attempt", attempt+1, "error", err)
 			continue
 		}
 
 		if err := checkHTTPStatus(resp, httpSource); err != nil {
 			_ = resp.Body.Close()
-			lastErr = fmt.Errorf("bad animeWorldAPIResponse (attempt %d): %w", attempt+1, err)
+			lastErr = fmt.Errorf("bad response (attempt %d): %w", attempt+1, err)
+			util.Debug("AnimeWorld bad HTTP status", "source", httpSource, "status", resp.StatusCode, "attempt", attempt+1)
 			continue
 		}
 
 		doc, err := goquery.NewDocumentFromReader(resp.Body)
 		_ = resp.Body.Close()
 		if err != nil {
-			return nil, fmt.Errorf("failed to parse HTML: %w", err)
+			return nil, fmt.Errorf("parse HTML: %w", err)
 		}
 
+		util.Debug("AnimeWorld page fetched", "source", httpSource, "status", resp.StatusCode, "url", url)
 		return doc, nil
 	}
 
 	return nil, lastErr
 }
 
+// buildRequestURL constructs the search endpoint URL for the given query.
 func (c *AnimeWorldClient) buildRequestURL(query string) string {
-	query = strings.ReplaceAll(query, " ", "+")
-	return fmt.Sprintf("%s/search?keyword=%s", c.baseURL, query)
+	return fmt.Sprintf("%s/search?keyword=%s", c.baseURL, url.QueryEscape(query))
 }
 
+// decorateRequest adds standard browser-like headers to req.
 func (c *AnimeWorldClient) decorateRequest(req *http.Request) {
 	req.Header.Set("User-Agent", c.userAgent)
 	req.Header.Set("Cache-Control", "no-cache")
 	req.Header.Set("Accept-Language", "it-IT,it;q=0.9,en-US;q=0.8,en;q=0.7")
 	req.Header.Set("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8")
-	// referer? try if you get 403
 }
 
-// validateEpisodeURL works also on anime URL because AnimeWorld
-// the anime URL and the URL of the first episode of the first season
-// is the same
+// validateEpisodeURL returns an error if episodeURL does not match the expected
+// AnimeWorld /play/ path pattern. Anime page URLs are also accepted because
+// AnimeWorld uses the same /play/ prefix for both.
 func (c *AnimeWorldClient) validateEpisodeURL(episodeURL string) error {
 	u, err := url.Parse(episodeURL)
 	if err != nil {
-		return fmt.Errorf("AnimeWorld invalid URL: %s", episodeURL)
+		return fmt.Errorf("invalid URL %q: %w", episodeURL, err)
 	}
 	if !animeWorldEpisodeURLPattern.MatchString(u.Path) {
-		return fmt.Errorf("AnimeWorld invalid URL path: %s", u.String())
+		return fmt.Errorf("unexpected URL path %q", u.String())
 	}
 	return nil
 }
 
-// normalizeAnimeWorldVideoURL converts wrapper URLs (download-file.php?id=...)
-// into direct .mp4 URLs by extracting the id parameter.
-// Returns the original URL if already a direct .mp4 link.
-func (c *AnimeWorldClient) normalizeAnimeWorldVideoURL(raw string) (string, error) {
+// normalizeVideoURL converts download-file.php?id=<path> wrapper URLs into
+// direct .mp4 URLs. Already-direct .mp4 URLs are returned unchanged.
+func (c *AnimeWorldClient) normalizeVideoURL(raw string) (string, error) {
 	u, err := url.Parse(raw)
 	if err != nil {
-		return "", fmt.Errorf("invalid url: %w", err)
+		return "", fmt.Errorf("invalid video URL: %w", err)
 	}
 
-	// Case 1: download-file.php?id=...
 	if strings.Contains(u.Path, "download-file.php") {
 		id := u.Query().Get("id")
 		if id == "" {
-			return "", fmt.Errorf("missing id in url: %s", raw)
+			return "", fmt.Errorf("missing id parameter in URL: %s", raw)
 		}
-
-		// build proper URL using url.URL
-		normalized := &url.URL{
+		return (&url.URL{
 			Scheme: u.Scheme,
 			Host:   u.Host,
-			Path:   fmt.Sprintf("/%s", strings.TrimPrefix(id, "/")),
-		}
-
-		return normalized.String(), nil
+			Path:   "/" + strings.TrimPrefix(id, "/"),
+		}).String(), nil
 	}
 
-	// Case 2: already direct mp4
 	if strings.HasSuffix(u.Path, ".mp4") {
 		return u.String(), nil
 	}
 
-	return "", fmt.Errorf("unsupported video url: %s", raw)
+	return "", fmt.Errorf("unsupported video URL: %s", raw)
 }

--- a/internal/scraper/animeworld.go
+++ b/internal/scraper/animeworld.go
@@ -1,0 +1,380 @@
+package scraper
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/PuerkitoBio/goquery"
+	"github.com/alvarorichard/Goanime/internal/models"
+	"github.com/alvarorichard/Goanime/internal/util"
+)
+
+const (
+	animeWorldBase       = "https://www.animeworld.ac"
+	animeWorldApiEpisode = "https://www.animeworld.ac/api/episode/info"
+	animeWorldSource     = "AnimeWorld"
+)
+
+var animeWorldEpisodeURLPattern = regexp.MustCompile(`^/play/[^/?#]+(/[^/?#]+)?$`)
+
+// TODO CHECK ALSO THE MANAGER THERE ARE ADAOTER ETC... I DONT THINK THIS SHOULD IMPLEMENT THE SCRAPER INTERFACE, BUT MAYBE AN ADAPTER MUST BE USED!
+// ALSO FOR SCRAPERTYPE I DUNNOOOO. GOYABUCLIENT DOESNT IMPLEMENT INTERFACE, BUT ITS IN A ADAPTOR
+// QUEL MAP PUZZA, NON CI STA DOCUMENTAZIONE CHE DICE CHE COSA E'
+type AnimeWorldClient struct {
+	client        *http.Client
+	baseURL       string
+	episodeApiURL string
+	userAgent     string
+	maxRetries    int
+	retryDelay    time.Duration
+	scraperType   ScraperType
+}
+
+func NewAnimeWorldClient() *AnimeWorldClient {
+	return &AnimeWorldClient{
+		client:        util.NewFastClient(),
+		baseURL:       animeWorldBase,
+		episodeApiURL: animeWorldApiEpisode,
+		userAgent:     UserAgent,
+		maxRetries:    2,
+		retryDelay:    300 * time.Millisecond,
+		scraperType:   AnimeWorldType,
+	}
+}
+
+// SearchAnime searches for anime on animeworld.ac
+func (c *AnimeWorldClient) SearchAnime(query string) ([]*models.Anime, error) {
+	// query "attacco dei giganti"
+	// url => https://www.animeworld.ac/search?keyword=attacco+dei+giganti
+	query = normalizeQuery(query)
+
+	util.Debug("AnimeWorld search", "query", query)
+
+	searchURL := c.buildRequestURL(query)
+	return c.searchAnimeHTML(searchURL)
+}
+
+// GetAnimeEpisodes scrapes the episodes of an anime given its URL
+func (c *AnimeWorldClient) GetAnimeEpisodes(animeURL string) ([]models.Episode, error) {
+	if err := c.validateEpisodeURL(animeURL); err != nil {
+		return nil, err
+	}
+	return c.searchAnimeEpisodesHTML(animeURL)
+}
+
+// GetStreamURL fetches the video source URL of an episode
+func (c *AnimeWorldClient) GetStreamURL(episodeURL string) (string, error) {
+	if err := c.validateEpisodeURL(episodeURL); err != nil {
+		return "", err
+	}
+	source, apiErr := c.searchVideoURLApi(episodeURL)
+	if apiErr == nil {
+		return source, nil
+	}
+	// fallback to HTML
+	source, htmlErr := c.searchVideoURLHTML(episodeURL)
+	if htmlErr == nil {
+		return source, nil
+	}
+	return "", fmt.Errorf("AnimeWorld search failed for episode URL: %s: %w",
+		episodeURL,
+		errors.Join(apiErr, htmlErr))
+}
+
+func (c *AnimeWorldClient) searchAnimeHTML(searchURL string) ([]*models.Anime, error) {
+	doc, err := c.fetchDoc(searchURL, "AnimeWorld Anime search HTML")
+	if err != nil {
+		return nil, err
+	}
+	return c.extractAnimeSearchResults(doc)
+}
+
+func (c *AnimeWorldClient) extractAnimeSearchResults(doc *goquery.Document) ([]*models.Anime, error) {
+	var anime []*models.Anime
+
+	doc.Find(".film-list .item .inner").Each(func(_ int, s *goquery.Selection) {
+		nameEl := s.Find("a.name")
+		name := strings.TrimSpace(nameEl.Text())
+		href, _ := nameEl.Attr("href")
+		if name == "" || href == "" {
+			return
+		}
+
+		// unhandled error: an empty imgURL is self-explanatory
+		imgURL, _ := s.Find("a.poster img").Attr("src")
+
+		anime = append(anime, &models.Anime{
+			Name:      name,
+			URL:       resolveURL(c.baseURL, href),
+			ImageURL:  imgURL,
+			Source:    animeWorldSource,
+			MediaType: models.MediaTypeAnime,
+		})
+	})
+	return anime, nil
+}
+
+func (c *AnimeWorldClient) searchAnimeEpisodesHTML(animeURL string) ([]models.Episode, error) {
+	doc, err := c.fetchDoc(animeURL, "AnimeWorld Episodes search HTML")
+	if err != nil {
+		return nil, err
+	}
+	return c.extractEpisodesSearchResults(doc)
+}
+
+// TODO NUM EPISODE CHECK IF BREAKS THE APPLICATION
+
+// animeWorldRawEpisodes represents the raw episode data scraped from World Anime
+type animeWorldRawEpisodes struct {
+	episodeNumberStr string
+	episodeNumber    int
+	episodeURL       string
+}
+
+// extractEpisodesSearchResults ignores episodes that for some resons are not found
+//
+// handles also the case of a "double episode". It's not common, but sometimes
+// a video source contains two episodes one after others. Probably because it was aired in this way in Italy
+// A double episode can be for example "45-46"
+// I don't know how to handle this case for the Num field in models.Episode.
+func (c *AnimeWorldClient) extractEpisodesSearchResults(doc *goquery.Document) ([]models.Episode, error) {
+	var episodes []animeWorldRawEpisodes
+	doc.Find("ul.episodes li.episode a").Each(func(i int, s *goquery.Selection) {
+		numberStr, exists := s.Attr("data-episode-num")
+		if !exists {
+			return
+		}
+		num, err := strconv.Atoi(numberStr)
+		if err != nil {
+			return
+		}
+		href, exists := s.Attr("href")
+		if !exists {
+			return
+		}
+
+		episodes = append(episodes, animeWorldRawEpisodes{
+			episodeNumberStr: fmt.Sprintf("%d", num),
+			episodeNumber:    num,
+			episodeURL:       href,
+		})
+	})
+	return c.adjustEpisodes(episodes), nil
+}
+
+// adjustEpisodes synchronizes the episode name number with the episode name if there are double episodes
+// Otherwise just maps to []models.Episode. See Tests for more info
+func (c *AnimeWorldClient) adjustEpisodes(rawEps []animeWorldRawEpisodes) []models.Episode {
+	var episodes []models.Episode
+	for _, raw := range rawEps {
+		// Parse the actual episode number from the string (handles "3", "3-4", etc.)
+		firstNum := raw.episodeNumber // fallback if parsing fails
+		if parts := strings.SplitN(raw.episodeNumberStr, "-", 2); len(parts) > 0 {
+			if n, err := strconv.Atoi(parts[0]); err == nil {
+				firstNum = n
+			}
+		}
+		episodes = append(episodes, models.Episode{
+			Number: "Episodio " + raw.episodeNumberStr,
+			Num:    firstNum,
+			URL:    resolveURL(c.baseURL, raw.episodeURL),
+		})
+	}
+	return episodes
+}
+
+type animeWorldAPIResponse struct {
+	Grabber string `json:"grabber"` // source URL
+	Name    string `json:"name"`
+	Target  string `json:"target"`
+}
+
+// searchVideoURLApi fetches the videoURL source of the episode from the AnimeWorld api.
+// This is the preferred way.
+func (c *AnimeWorldClient) searchVideoURLApi(episodeURL string) (string, error) {
+	// extract the episode ID
+	episodeID, err := c.extractEpisodeIDFromURL(episodeURL)
+	if err != nil {
+		return "", err
+	}
+	reqURL := fmt.Sprintf("%s?id=%s", c.episodeApiURL, episodeID)
+	req, err := http.NewRequest("GET", reqURL, nil)
+	if err != nil {
+		return "", fmt.Errorf("request creation failed: %w", err)
+	}
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("AnimeWorld api call: %w", err)
+	}
+	defer resp.Body.Close()
+	var rBody animeWorldAPIResponse
+	if err := json.NewDecoder(resp.Body).Decode(&rBody); err != nil {
+		return "", fmt.Errorf("AnimeWorld animeWorldAPIResponse unmarshalling: %w", err)
+	}
+	if rBody.Grabber == "" {
+		return "", fmt.Errorf("AnimeWorld no episode url found from the api")
+	}
+	return rBody.Grabber, nil
+}
+
+func (c *AnimeWorldClient) extractEpisodeIDFromURL(episodeURL string) (string, error) {
+	// Example episode URL: https://www.animeworld.ac/play/naruto-shippuden-ita.9XRsD/TMWIn
+	// ID: TMWIn
+	lastDotIndex := strings.LastIndex(episodeURL, "/")
+	if lastDotIndex == -1 {
+		return "", errors.New("invalid URL format: episode ID not found")
+	}
+	episodeID := episodeURL[lastDotIndex+1:]
+	if len(episodeID) == 0 {
+		return "", errors.New("invalid URL format: episode ID is empty")
+	}
+	return episodeID, nil
+}
+
+// searchVideoURLHTML fetches the video source URL of the episode.
+// AnimeWorld can offer more than one URL. The first scraped URL is returned
+func (c *AnimeWorldClient) searchVideoURLHTML(episodeURL string) (string, error) {
+	doc, err := c.fetchDoc(episodeURL, "AnimeWorld episode video source fetch HTML")
+	if err != nil {
+		return "", fmt.Errorf("AnimeWorld failed to parse HTML: %s", episodeURL)
+	}
+
+	get := func(selector string) (string, bool) {
+		sel := doc.Find(selector)
+		if sel.Length() == 0 {
+			return "", false
+		}
+
+		href, ok := sel.Attr("href")
+		if !ok {
+			return "", false
+		}
+
+		vURL, err := c.normalizeAnimeWorldVideoURL(href)
+		if err != nil {
+			return "", false
+		}
+
+		return vURL, true
+	}
+
+	// preference order
+	if url, ok := get("#alternativeDownloadLink"); ok {
+		return url, nil
+	}
+
+	if url, ok := get("#downloadLink"); ok {
+		return url, nil
+	}
+
+	return "", fmt.Errorf("AnimeWorld no video source found for episode: %s", episodeURL)
+}
+
+// fetchDoc makes an HTTP call to the given url and parses the HTML to a goquery.Document struct.
+// It requires a httpSource string that will be used by checkHTTPStatus
+func (c *AnimeWorldClient) fetchDoc(url, httpSource string) (*goquery.Document, error) {
+	var lastErr error
+	attempts := c.maxRetries + 1
+
+	for attempt := 0; attempt < attempts; attempt++ {
+		if attempt > 0 {
+			time.Sleep(c.retryDelay)
+		}
+
+		req, err := http.NewRequest(http.MethodGet, url, nil)
+		if err != nil {
+			return nil, fmt.Errorf("create request: %w", err)
+		}
+		c.decorateRequest(req)
+
+		resp, err := c.client.Do(req)
+		if err != nil {
+			lastErr = fmt.Errorf("request failed (attempt %d): %w", attempt+1, err)
+			continue
+		}
+
+		if err := checkHTTPStatus(resp, httpSource); err != nil {
+			_ = resp.Body.Close()
+			lastErr = fmt.Errorf("bad animeWorldAPIResponse (attempt %d): %w", attempt+1, err)
+			continue
+		}
+
+		doc, err := goquery.NewDocumentFromReader(resp.Body)
+		_ = resp.Body.Close()
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse HTML: %w", err)
+		}
+
+		return doc, nil
+	}
+
+	return nil, lastErr
+}
+
+func (c *AnimeWorldClient) buildRequestURL(query string) string {
+	query = strings.ReplaceAll(query, " ", "+")
+	return fmt.Sprintf("%s/search?keyword=%s", c.baseURL, query)
+}
+
+func (c *AnimeWorldClient) decorateRequest(req *http.Request) {
+	req.Header.Set("User-Agent", c.userAgent)
+	req.Header.Set("Cache-Control", "no-cache")
+	req.Header.Set("Accept-Language", "it-IT,it;q=0.9,en-US;q=0.8,en;q=0.7")
+	req.Header.Set("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8")
+	// referer? try if you get 403
+}
+
+// validateEpisodeURL works also on anime URL because AnimeWorld
+// the anime URL and the URL of the first episode of the first season
+// is the same
+func (c *AnimeWorldClient) validateEpisodeURL(episodeURL string) error {
+	u, err := url.Parse(episodeURL)
+	if err != nil {
+		return fmt.Errorf("AnimeWorld invalid URL: %s", episodeURL)
+	}
+	if !animeWorldEpisodeURLPattern.MatchString(u.Path) {
+		return fmt.Errorf("AnimeWorld invalid URL path: %s", u.String())
+	}
+	return nil
+}
+
+// normalizeAnimeWorldVideoURL converts wrapper URLs (download-file.php?id=...)
+// into direct .mp4 URLs by extracting the id parameter.
+// Returns the original URL if already a direct .mp4 link.
+func (c *AnimeWorldClient) normalizeAnimeWorldVideoURL(raw string) (string, error) {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return "", fmt.Errorf("invalid url: %w", err)
+	}
+
+	// Case 1: download-file.php?id=...
+	if strings.Contains(u.Path, "download-file.php") {
+		id := u.Query().Get("id")
+		if id == "" {
+			return "", fmt.Errorf("missing id in url: %s", raw)
+		}
+
+		// build proper URL using url.URL
+		normalized := &url.URL{
+			Scheme: u.Scheme,
+			Host:   u.Host,
+			Path:   fmt.Sprintf("/%s", strings.TrimPrefix(id, "/")),
+		}
+
+		return normalized.String(), nil
+	}
+
+	// Case 2: already direct mp4
+	if strings.HasSuffix(u.Path, ".mp4") {
+		return u.String(), nil
+	}
+
+	return "", fmt.Errorf("unsupported video url: %s", raw)
+}

--- a/internal/scraper/animeworld_integration_test.go
+++ b/internal/scraper/animeworld_integration_test.go
@@ -1,0 +1,143 @@
+package scraper_test
+
+import (
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/alvarorichard/Goanime/internal/scraper"
+	"github.com/stretchr/testify/assert"
+)
+
+// Integration Tests following superflix_integration_test.go as an example
+// Real website used
+
+func TestIntegration_RealAnimeWorld_SearchAndVerify(t *testing.T) {
+	if v := strings.ToLower(os.Getenv("GITHUB_ACTIONS")); v == "true" || v == "1" {
+		t.Skip("skipped in CI: real upstream call")
+	}
+	if v := strings.ToLower(os.Getenv("CI")); v == "true" || v == "1" {
+		t.Skip("skipped in CI: real upstream call")
+	}
+	if testing.Short() {
+		t.Skip("Skipping integration test that hits real AnimeWorld website")
+	}
+
+	searches := []string{"Naruto", "Bleach", "One Piece"}
+	client := scraper.NewAnimeWorldClient()
+
+	for _, query := range searches {
+		t.Run(query, func(t *testing.T) {
+			anime, err := client.SearchAnime(query)
+			assert.NoError(t, err)
+			assert.NotEmpty(t, anime)
+
+			for _, a := range anime {
+				assert.NotEmpty(t, a.Name)
+				assert.NotEmpty(t, a.URL)
+				assert.NotEmpty(t, a.ImageURL)
+			}
+		})
+	}
+}
+
+func TestIntegration_RealAnimeWorld_SearchEpisodes(t *testing.T) {
+	if v := strings.ToLower(os.Getenv("GITHUB_ACTIONS")); v == "true" || v == "1" {
+		t.Skip("skipped in CI: real upstream call")
+	}
+	if v := strings.ToLower(os.Getenv("CI")); v == "true" || v == "1" {
+		t.Skip("skipped in CI: real upstream call")
+	}
+	if testing.Short() {
+		t.Skip("Skipping integration test that hits real AnimeWorld website")
+	}
+
+	// finished airing anime
+	table := []struct {
+		animeName     string
+		animeURL      string
+		totalEpisodes int
+		// some episodes are were double aired on TV
+		// For these three animes, I manually checked their number
+		doubleEpisodeNumber int
+	}{
+		{
+			animeName:           "Naruto Shippuden",
+			animeURL:            "https://www.animeworld.ac/play/naruto-shippuden.v3U8a/ZXFbr",
+			totalEpisodes:       500,
+			doubleEpisodeNumber: 12,
+		},
+		{
+			animeName:           "Bleach",
+			animeURL:            "https://www.animeworld.ac/play/bleach.1xU4f/d7tDd",
+			totalEpisodes:       366,
+			doubleEpisodeNumber: 6,
+		},
+		{
+			animeName:           "Dragonball Z",
+			animeURL:            "https://www.animeworld.ac/play/dragon-ball-z-ita.NND05/O7sga",
+			totalEpisodes:       291,
+			doubleEpisodeNumber: 0,
+		},
+		//{
+		//	animeName:     "One Piece",
+		//	animeURL:      "https://www.animeworld.ac/play/one-piece-subita.qzG-LE/HPKmX1",
+		//	totalEpisodes: getInfinite(),
+		//},
+	}
+
+	client := scraper.NewAnimeWorldClient()
+	for _, tt := range table {
+		t.Run(tt.animeName, func(t *testing.T) {
+			eps, err := client.GetAnimeEpisodes(tt.animeURL)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.totalEpisodes-tt.doubleEpisodeNumber, len(eps))
+
+			for _, ep := range eps {
+				assert.NotEmpty(t, ep.URL)
+
+				// check if double episode is correctly extracted
+				// Episodio 12-13  => Num = 12
+				epStr := ep.Number
+				epStr = strings.Split(epStr, " ")[1]
+				epStrLeft := strings.Split(epStr, "-")[0]
+				epNum, err := strconv.Atoi(epStrLeft)
+				assert.NoError(t, err)
+				assert.Equal(t, ep.Num, epNum)
+			}
+		})
+	}
+
+}
+
+func TestIntegration_RealAnimeWorld_GetStreamURL(t *testing.T) {
+	if v := strings.ToLower(os.Getenv("GITHUB_ACTIONS")); v == "true" || v == "1" {
+		t.Skip("skipped in CI: real upstream call")
+	}
+	if v := strings.ToLower(os.Getenv("CI")); v == "true" || v == "1" {
+		t.Skip("skipped in CI: real upstream call")
+	}
+	if testing.Short() {
+		t.Skip("Skipping integration test that hits real AnimeWorld website")
+	}
+
+	client := scraper.NewAnimeWorldClient()
+	table := []struct {
+		animeName  string
+		episodeURL string
+	}{
+		{animeName: "Naruto Shippuden EP 24", episodeURL: "https://www.animeworld.ac/play/naruto-shippuden.v3U8a/KtvO4"},
+		{animeName: "One Piece EP 405", episodeURL: "https://www.animeworld.ac/play/one-piece-subita.qzG-LE/mJk6qG"},
+		{animeName: "Frieren EP 7", episodeURL: "https://www.animeworld.ac/play/sousou-no-frieren.kbcPv/wBsiqn"},
+	}
+
+	for _, tt := range table {
+		t.Run(tt.animeName, func(t *testing.T) {
+			stream, err := client.GetStreamURL(tt.episodeURL)
+			assert.NoError(t, err)
+			assert.NotEmpty(t, stream)
+			assert.True(t, strings.HasSuffix(stream, ".mp4"))
+		})
+	}
+}

--- a/internal/scraper/animeworld_test.go
+++ b/internal/scraper/animeworld_test.go
@@ -80,7 +80,7 @@ func TestAnimeWorldSearchAnime(t *testing.T) {
 func TestAnimeWorldSearchAnime_Empty(t *testing.T) {
 	t.Parallel()
 
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = fmt.Fprint(w, `<html><body><div class="film-list"></div></body></html>`)
 	}))
 	defer srv.Close()
@@ -146,7 +146,7 @@ func TestAnimeWorldGetAnimeEpisodes(t *testing.T) {
 	t.Parallel()
 
 	mux := http.NewServeMux()
-	mux.HandleFunc("/play/naruto-ita1", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/play/naruto-ita1", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
 		_, err := fmt.Fprint(w, animeWorldEpisodesFixture)
 		require.NoError(t, err)
@@ -417,7 +417,7 @@ func TestAnimeWorldStreamURL_FromAPI(t *testing.T) {
 	defer s.Close()
 
 	client := NewAnimeWorldClient()
-	client.episodeApiURL = s.URL
+	client.episodeAPIURL = s.URL
 
 	respURL, err := client.GetStreamURL(episodeURL)
 	assert.NoError(t, err)

--- a/internal/scraper/animeworld_test.go
+++ b/internal/scraper/animeworld_test.go
@@ -1,0 +1,424 @@
+package scraper
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/alvarorichard/Goanime/internal/models"
+)
+
+const animeWorldSearchFixture = `<html><body>
+<div class="film-list">
+    <div class="item"><div class="inner">
+        <a href="/play/naruto.abc123" class="poster">
+            <img src="https://img.example.com/naruto.jpg" alt="Naruto">
+        </a>
+        <a href="/play/naruto.abc123" class="name">Naruto</a>
+    </div></div>
+    <div class="item"><div class="inner">
+        <a href="/play/naruto-shippuden.def456" class="poster">
+            <img src="https://img.example.com/shippuden.jpg" alt="Naruto Shippuden">
+        </a>
+        <a href="/play/naruto-shippuden.def456" class="name">Naruto Shippuden</a>
+    </div></div>
+</div>
+</body></html>`
+
+const animeWorldEpisodesFixture = `
+<html>
+	<body>
+      <ul class="episodes">
+        <li class="episode"> <a href="/play/naruto-ita1" data-episode-num="1"> 1 </a></li>
+        <li class="episode"> <a href="/play/naruto-ita2" data-episode-num="2"> 2 </a></li>
+        <li class="episode"> <a href="/play/naruto-ita3" data-episode-num="3"> 3 </a></li>
+      </ul>
+      <ul class="episodes">
+        <li class="episode"> <a href="/play/naruto-ita4" data-episode-num="4"> 4 </a></li>
+        <li class="episode"> <a href="/play/naruto-ita5" data-episode-num="5"> 5 </a></li>
+        <li class="episode"> <a href="/play/naruto-ita6" data-episode-num="6"> 6 </a></li>
+      </ul>
+	</body>
+</html>
+`
+
+// Unit tests SEARCH ANIME
+
+func TestAnimeWorldSearchAnime(t *testing.T) {
+	t.Parallel()
+
+	var receivedKeyword string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedKeyword = r.URL.Query().Get("keyword")
+		_, _ = fmt.Fprint(w, animeWorldSearchFixture)
+	}))
+	defer srv.Close()
+
+	client := NewAnimeWorldClient()
+	client.baseURL = srv.URL
+	client.maxRetries = 0
+	client.retryDelay = 0
+
+	results, err := client.SearchAnime("naruto-shippuden")
+	require.NoError(t, err)
+	require.Len(t, results, 2)
+
+	assert.Equal(t, "naruto shippuden", receivedKeyword, "hyphens should normalize to spaces")
+	assert.Equal(t, "Naruto", results[0].Name)
+	assert.Equal(t, animeWorldSource, results[0].Source)
+	assert.Equal(t, models.MediaTypeAnime, results[0].MediaType)
+	assert.Contains(t, results[0].URL, "/play/naruto.abc123")
+	assert.Equal(t, "https://img.example.com/naruto.jpg", results[0].ImageURL)
+}
+
+func TestAnimeWorldSearchAnime_Empty(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = fmt.Fprint(w, `<html><body><div class="film-list"></div></body></html>`)
+	}))
+	defer srv.Close()
+
+	client := NewAnimeWorldClient()
+	client.baseURL = srv.URL
+	client.maxRetries = 0
+	client.retryDelay = 0
+
+	results, err := client.SearchAnime("nothing-matches")
+	require.NoError(t, err)
+	assert.Empty(t, results)
+}
+
+func TestAnimeWorldSearchAnime_RetriesGiveUp(t *testing.T) {
+	t.Parallel()
+
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	client := NewAnimeWorldClient()
+	client.baseURL = srv.URL
+	client.maxRetries = 2
+	client.retryDelay = 0
+
+	_, err := client.SearchAnime("naruto")
+	require.Error(t, err)
+	assert.Equal(t, int32(3), atomic.LoadInt32(&calls), "should attempt maxRetries+1 times")
+}
+
+// Unit tests GET ANIME EPISODES
+
+func TestAnimeWorld_adjustEpisodes(t *testing.T) {
+	client := NewAnimeWorldClient()
+
+	raws := []animeWorldRawEpisodes{
+		{episodeNumberStr: "1", episodeNumber: 1, episodeURL: "/ep1"},
+		{episodeNumberStr: "2", episodeNumber: 2, episodeURL: "/ep2"},
+		{episodeNumberStr: "3-4", episodeNumber: 3, episodeURL: "/ep34"},
+		{episodeNumberStr: "5-6", episodeNumber: 4, episodeURL: "/ep56"},
+		{episodeNumberStr: "7", episodeNumber: 5, episodeURL: "/ep7"},
+		{episodeNumberStr: "8-9", episodeNumber: 6, episodeURL: "/ep89"},
+	}
+	expected := []models.Episode{
+		{Number: "Episodio 1", Num: 1, URL: client.baseURL + "/ep1"},
+		{Number: "Episodio 2", Num: 2, URL: client.baseURL + "/ep2"},
+		{Number: "Episodio 3-4", Num: 3, URL: client.baseURL + "/ep34"},
+		{Number: "Episodio 5-6", Num: 5, URL: client.baseURL + "/ep56"},
+		{Number: "Episodio 7", Num: 7, URL: client.baseURL + "/ep7"},
+		{Number: "Episodio 8-9", Num: 8, URL: client.baseURL + "/ep89"},
+	}
+
+	assert.Equal(t, expected, client.adjustEpisodes(raws))
+}
+
+func TestAnimeWorldGetAnimeEpisodes(t *testing.T) {
+	t.Parallel()
+
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/play/naruto-ita1", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		_, err := fmt.Fprint(w, animeWorldEpisodesFixture)
+		require.NoError(t, err)
+	})
+
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	client := NewAnimeWorldClient()
+	client.baseURL = srv.URL
+	client.maxRetries = 0
+	client.retryDelay = 0
+
+	animeURL := fmt.Sprintf("%s/play/naruto-ita1", client.baseURL)
+
+	eps, err := client.GetAnimeEpisodes(animeURL)
+
+	assert.NoError(t, err)
+	assert.Len(t, eps, 6)
+	for i, ep := range eps {
+		assert.Equal(t, i+1, ep.Num)
+		assert.Equal(t, fmt.Sprintf("Episodio %d", i+1), ep.Number)
+		assert.Equal(t, fmt.Sprintf("%s/play/naruto-ita%d", client.baseURL, ep.Num), ep.URL)
+	}
+}
+
+func TestAnimeWorldGetAnimeEpisodes_NoEpisode(t *testing.T) {
+	t.Parallel()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/play/naruto-ita1", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		_, err := fmt.Fprint(w, "<html> <body> </body> </html>")
+		require.NoError(t, err)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	client := NewAnimeWorldClient()
+	client.baseURL = srv.URL
+	client.maxRetries = 0
+	client.retryDelay = 0
+
+	animeURL := fmt.Sprintf("%s/play/naruto-ita1", client.baseURL)
+
+	eps, err := client.GetAnimeEpisodes(animeURL)
+
+	assert.NoError(t, err)
+	assert.Empty(t, eps)
+}
+
+// Unit tests GET STREAM URL
+const (
+	animeWorldhellsingEpPath    = "/play/hellsing-ep1"
+	animeWorldhellsingDirectMP4 = "https://srv28-greeneyes.sweetpixel.org/DDL/ANIME/HellsingITA/Hellsing_Ep_01_ITA.mp4"
+	animeWorldhellsingWrapURL   = "https://srv28-greeneyes.sweetpixel.org/download-file.php?id=DDL/ANIME/HellsingITA/Hellsing_Ep_01_ITA.mp4"
+)
+
+// Snippet taken from a real animeworld.ac episode page (Hellsing ep. 1).
+const hellsingEpisodePage = `<html><body>
+<div class="widget-body" style="padding-top: 17px;padding-bottom: 17px;">
+	<center>
+		<a href="https://srv28-greeneyes.sweetpixel.org/download-file.php?id=DDL/ANIME/HellsingITA/Hellsing_Ep_01_ITA.mp4" id="downloadLink" class="m-1 btn btn-sm btn-primary" target="_blank">Download Diretto - Ep. 1</a>
+		<a href="https://srv28-greeneyes.sweetpixel.org/DDL/ANIME/HellsingITA/Hellsing_Ep_01_ITA.mp4" id="alternativeDownloadLink" class="m-1 btn btn-sm btn-primary" target="_blank" download>Download Alternativo - Ep. 1</a>
+		<a href="" id="customDownloadButton" class="m-1 btn btn-sm btn-primary hidden" target="_blank">Download - Ep. 1</a>
+	</center>
+</div>
+</body></html>`
+
+func newAnimeWorldTestClient(t *testing.T, body string) (*AnimeWorldClient, string) {
+	t.Helper()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc(animeWorldhellsingEpPath, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		_, _ = fmt.Fprint(w, body)
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	c := NewAnimeWorldClient()
+	c.baseURL = srv.URL
+	c.maxRetries = 0
+	c.retryDelay = 0
+
+	return c, srv.URL + animeWorldhellsingEpPath
+}
+
+// Both links present → alternative (direct .mp4) wins.
+func TestAnimeWorldGetStreamURL_PrefersAlternativeLink(t *testing.T) {
+	t.Parallel()
+	client, epURL := newAnimeWorldTestClient(t, hellsingEpisodePage)
+
+	streamURL, err := client.GetStreamURL(epURL)
+	require.NoError(t, err)
+	assert.Equal(t, animeWorldhellsingDirectMP4, streamURL)
+}
+
+// Only #downloadLink present → wrapper URL is normalized to the direct mp4.
+func TestAnimeWorldGetStreamURL_FallsBackToDownloadLink(t *testing.T) {
+	t.Parallel()
+	body := fmt.Sprintf(`<html><body><center>
+		<a href="%s" id="downloadLink">Diretto</a>
+	</center></body></html>`, animeWorldhellsingWrapURL)
+	client, epURL := newAnimeWorldTestClient(t, body)
+
+	streamURL, err := client.GetStreamURL(epURL)
+	require.NoError(t, err)
+	assert.Equal(t, animeWorldhellsingDirectMP4, streamURL)
+}
+
+// Page has no recognized links.
+func TestAnimeWorldGetStreamURL_NoLinks(t *testing.T) {
+	t.Parallel()
+	client, epURL := newAnimeWorldTestClient(t, `<html><body><center></center></body></html>`)
+
+	_, err := client.GetStreamURL(epURL)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no video source found")
+}
+
+// download-file.php wrapper without the id param → normalize fails, no fallback.
+func TestAnimeWorldGetStreamURL_DownloadLinkMissingID(t *testing.T) {
+	t.Parallel()
+	body := `<html><body><center>
+		<a href="https://srv28-greeneyes.sweetpixel.org/download-file.php" id="downloadLink">Diretto</a>
+	</center></body></html>`
+	client, epURL := newAnimeWorldTestClient(t, body)
+
+	_, err := client.GetStreamURL(epURL)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no video source found")
+}
+
+// Alternative link present but with a junk href → must fall through to downloadLink.
+func TestAnimeWorldGetStreamURL_FallsThroughBadAlternative(t *testing.T) {
+	t.Parallel()
+	body := fmt.Sprintf(`<html><body><center>
+		<a href="not-a-url" id="alternativeDownloadLink">Alt</a>
+		<a href="%s" id="downloadLink">Diretto</a>
+	</center></body></html>`, animeWorldhellsingWrapURL)
+	client, epURL := newAnimeWorldTestClient(t, body)
+
+	streamURL, err := client.GetStreamURL(epURL)
+	require.NoError(t, err)
+	assert.Equal(t, animeWorldhellsingDirectMP4, streamURL)
+}
+
+// URL doesn't match /play/<slug> → validation rejects it before any HTTP call.
+func TestAnimeWorldGetStreamURL_InvalidEpisodeURL(t *testing.T) {
+	t.Parallel()
+	client := NewAnimeWorldClient()
+
+	_, err := client.GetStreamURL("https://www.animeworld.ac/not-a-play-path")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid URL path")
+}
+
+// Server replies non-2xx → bubbles up as an error.
+func TestAnimeWorldGetStreamURL_ServerError(t *testing.T) {
+	t.Parallel()
+	mux := http.NewServeMux()
+	mux.HandleFunc(animeWorldhellsingEpPath, func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	client := NewAnimeWorldClient()
+	client.baseURL = srv.URL
+	client.maxRetries = 0
+	client.retryDelay = 0
+
+	_, err := client.GetStreamURL(srv.URL + animeWorldhellsingEpPath)
+	require.Error(t, err)
+}
+
+// download url selection
+// download url selection
+func TestAnimeWorldNormalizationStreamURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		input   string
+		want    string
+		wantErr string // substring match; empty = no error. No sentinel error
+	}{
+		{
+			name:  "wrapper url is normalized to direct mp4",
+			input: "https://srv28-greeneyes.sweetpixel.org/download-file.php?id=DDL/ANIME/HellsingITA/Hellsing_Ep_01_ITA.mp4",
+			want:  "https://srv28-greeneyes.sweetpixel.org/DDL/ANIME/HellsingITA/Hellsing_Ep_01_ITA.mp4",
+		},
+		{
+			name:  "wrapper id with leading slash is not doubled",
+			input: "https://srv28-greeneyes.sweetpixel.org/download-file.php?id=/DDL/foo.mp4",
+			want:  "https://srv28-greeneyes.sweetpixel.org/DDL/foo.mp4",
+		},
+		{
+			name:  "wrapper id is a flat filename",
+			input: "https://example.com/download-file.php?id=video.mp4",
+			want:  "https://example.com/video.mp4",
+		},
+		{
+			name:  "direct mp4 is returned as-is",
+			input: "https://srv28-greeneyes.sweetpixel.org/DDL/ANIME/HellsingITA/Hellsing_Ep_01_ITA.mp4",
+			want:  "https://srv28-greeneyes.sweetpixel.org/DDL/ANIME/HellsingITA/Hellsing_Ep_01_ITA.mp4",
+		},
+		{
+			name:    "wrapper without id param",
+			input:   "https://srv28-greeneyes.sweetpixel.org/download-file.php",
+			wantErr: "missing id",
+		},
+		{
+			name:    "wrapper with empty id",
+			input:   "https://srv28-greeneyes.sweetpixel.org/download-file.php?id=",
+			wantErr: "missing id",
+		},
+		{
+			name:    "non-mp4 non-wrapper url is rejected",
+			input:   "https://example.com/stream/playlist.m3u8",
+			wantErr: "unsupported video url",
+		},
+		{
+			name:    "malformed url is rejected",
+			input:   "http://[::1",
+			wantErr: "invalid url",
+		},
+	}
+
+	c := NewAnimeWorldClient()
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := c.normalizeAnimeWorldVideoURL(tt.input)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestAnimeWorldStreamURL_FromAPI(t *testing.T) {
+	t.Parallel()
+	streamURL := "https://www.animeworld.ac/jojo.mp4"
+	epID := "TMWIn"
+	episodeURL := fmt.Sprintf("https://www.animeworld.ac/play/%s", epID)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, epID, r.URL.Query().Get("id"))
+
+		w.Header().Set("Content-Type", "application/json")
+		b, err := json.Marshal(animeWorldAPIResponse{
+			Grabber: streamURL,
+			Name:    "Jojo",
+			Target:  "/api/jojo",
+		})
+		require.NoError(t, err)
+		_, err = w.Write(b)
+		require.NoError(t, err)
+	})
+	s := httptest.NewServer(mux)
+	defer s.Close()
+
+	client := NewAnimeWorldClient()
+	client.episodeApiURL = s.URL
+
+	respURL, err := client.GetStreamURL(episodeURL)
+	assert.NoError(t, err)
+	assert.Equal(t, streamURL, respURL)
+}

--- a/internal/scraper/animeworld_test.go
+++ b/internal/scraper/animeworld_test.go
@@ -48,7 +48,7 @@ const animeWorldEpisodesFixture = `
 </html>
 `
 
-// Unit tests SEARCH ANIME
+// --- SearchAnime ---
 
 func TestAnimeWorldSearchAnime(t *testing.T) {
 	t.Parallel()
@@ -115,18 +115,18 @@ func TestAnimeWorldSearchAnime_RetriesGiveUp(t *testing.T) {
 	assert.Equal(t, int32(3), atomic.LoadInt32(&calls), "should attempt maxRetries+1 times")
 }
 
-// Unit tests GET ANIME EPISODES
+// --- normalizeEpisodes ---
 
-func TestAnimeWorld_adjustEpisodes(t *testing.T) {
+func TestAnimeWorld_normalizeEpisodes(t *testing.T) {
 	client := NewAnimeWorldClient()
 
-	raws := []animeWorldRawEpisodes{
-		{episodeNumberStr: "1", episodeNumber: 1, episodeURL: "/ep1"},
-		{episodeNumberStr: "2", episodeNumber: 2, episodeURL: "/ep2"},
-		{episodeNumberStr: "3-4", episodeNumber: 3, episodeURL: "/ep34"},
-		{episodeNumberStr: "5-6", episodeNumber: 4, episodeURL: "/ep56"},
-		{episodeNumberStr: "7", episodeNumber: 5, episodeURL: "/ep7"},
-		{episodeNumberStr: "8-9", episodeNumber: 6, episodeURL: "/ep89"},
+	raws := []rawEpisode{
+		{numberStr: "1", number: 1, url: "/ep1"},
+		{numberStr: "2", number: 2, url: "/ep2"},
+		{numberStr: "3-4", number: 3, url: "/ep34"},
+		{numberStr: "5-6", number: 4, url: "/ep56"},
+		{numberStr: "7", number: 5, url: "/ep7"},
+		{numberStr: "8-9", number: 6, url: "/ep89"},
 	}
 	expected := []models.Episode{
 		{Number: "Episodio 1", Num: 1, URL: client.baseURL + "/ep1"},
@@ -137,14 +137,15 @@ func TestAnimeWorld_adjustEpisodes(t *testing.T) {
 		{Number: "Episodio 8-9", Num: 8, URL: client.baseURL + "/ep89"},
 	}
 
-	assert.Equal(t, expected, client.adjustEpisodes(raws))
+	assert.Equal(t, expected, client.normalizeEpisodes(raws))
 }
+
+// --- GetAnimeEpisodes ---
 
 func TestAnimeWorldGetAnimeEpisodes(t *testing.T) {
 	t.Parallel()
 
 	mux := http.NewServeMux()
-
 	mux.HandleFunc("/play/naruto-ita1", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
 		_, err := fmt.Fprint(w, animeWorldEpisodesFixture)
@@ -162,7 +163,6 @@ func TestAnimeWorldGetAnimeEpisodes(t *testing.T) {
 	animeURL := fmt.Sprintf("%s/play/naruto-ita1", client.baseURL)
 
 	eps, err := client.GetAnimeEpisodes(animeURL)
-
 	assert.NoError(t, err)
 	assert.Len(t, eps, 6)
 	for i, ep := range eps {
@@ -174,10 +174,11 @@ func TestAnimeWorldGetAnimeEpisodes(t *testing.T) {
 
 func TestAnimeWorldGetAnimeEpisodes_NoEpisode(t *testing.T) {
 	t.Parallel()
+
 	mux := http.NewServeMux()
 	mux.HandleFunc("/play/naruto-ita1", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
-		_, err := fmt.Fprint(w, "<html> <body> </body> </html>")
+		_, err := fmt.Fprint(w, "<html><body></body></html>")
 		require.NoError(t, err)
 	})
 	srv := httptest.NewServer(mux)
@@ -188,19 +189,17 @@ func TestAnimeWorldGetAnimeEpisodes_NoEpisode(t *testing.T) {
 	client.maxRetries = 0
 	client.retryDelay = 0
 
-	animeURL := fmt.Sprintf("%s/play/naruto-ita1", client.baseURL)
-
-	eps, err := client.GetAnimeEpisodes(animeURL)
-
+	eps, err := client.GetAnimeEpisodes(fmt.Sprintf("%s/play/naruto-ita1", srv.URL))
 	assert.NoError(t, err)
 	assert.Empty(t, eps)
 }
 
-// Unit tests GET STREAM URL
+// --- GetStreamURL ---
+
 const (
-	animeWorldhellsingEpPath    = "/play/hellsing-ep1"
-	animeWorldhellsingDirectMP4 = "https://srv28-greeneyes.sweetpixel.org/DDL/ANIME/HellsingITA/Hellsing_Ep_01_ITA.mp4"
-	animeWorldhellsingWrapURL   = "https://srv28-greeneyes.sweetpixel.org/download-file.php?id=DDL/ANIME/HellsingITA/Hellsing_Ep_01_ITA.mp4"
+	animeWorldHellsingEpPath    = "/play/hellsing-ep1"
+	animeWorldHellsingDirectMP4 = "https://srv28-greeneyes.sweetpixel.org/DDL/ANIME/HellsingITA/Hellsing_Ep_01_ITA.mp4"
+	animeWorldHellsingWrapURL   = "https://srv28-greeneyes.sweetpixel.org/download-file.php?id=DDL/ANIME/HellsingITA/Hellsing_Ep_01_ITA.mp4"
 )
 
 // Snippet taken from a real animeworld.ac episode page (Hellsing ep. 1).
@@ -218,7 +217,7 @@ func newAnimeWorldTestClient(t *testing.T, body string) (*AnimeWorldClient, stri
 	t.Helper()
 
 	mux := http.NewServeMux()
-	mux.HandleFunc(animeWorldhellsingEpPath, func(w http.ResponseWriter, _ *http.Request) {
+	mux.HandleFunc(animeWorldHellsingEpPath, func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
 		_, _ = fmt.Fprint(w, body)
 	})
@@ -230,7 +229,7 @@ func newAnimeWorldTestClient(t *testing.T, body string) (*AnimeWorldClient, stri
 	c.maxRetries = 0
 	c.retryDelay = 0
 
-	return c, srv.URL + animeWorldhellsingEpPath
+	return c, srv.URL + animeWorldHellsingEpPath
 }
 
 // Both links present → alternative (direct .mp4) wins.
@@ -240,7 +239,7 @@ func TestAnimeWorldGetStreamURL_PrefersAlternativeLink(t *testing.T) {
 
 	streamURL, err := client.GetStreamURL(epURL)
 	require.NoError(t, err)
-	assert.Equal(t, animeWorldhellsingDirectMP4, streamURL)
+	assert.Equal(t, animeWorldHellsingDirectMP4, streamURL)
 }
 
 // Only #downloadLink present → wrapper URL is normalized to the direct mp4.
@@ -248,12 +247,12 @@ func TestAnimeWorldGetStreamURL_FallsBackToDownloadLink(t *testing.T) {
 	t.Parallel()
 	body := fmt.Sprintf(`<html><body><center>
 		<a href="%s" id="downloadLink">Diretto</a>
-	</center></body></html>`, animeWorldhellsingWrapURL)
+	</center></body></html>`, animeWorldHellsingWrapURL)
 	client, epURL := newAnimeWorldTestClient(t, body)
 
 	streamURL, err := client.GetStreamURL(epURL)
 	require.NoError(t, err)
-	assert.Equal(t, animeWorldhellsingDirectMP4, streamURL)
+	assert.Equal(t, animeWorldHellsingDirectMP4, streamURL)
 }
 
 // Page has no recognized links.
@@ -266,7 +265,7 @@ func TestAnimeWorldGetStreamURL_NoLinks(t *testing.T) {
 	assert.Contains(t, err.Error(), "no video source found")
 }
 
-// download-file.php wrapper without the id param → normalize fails, no fallback.
+// download-file.php wrapper without the id param → normalize fails, falls through to error.
 func TestAnimeWorldGetStreamURL_DownloadLinkMissingID(t *testing.T) {
 	t.Parallel()
 	body := `<html><body><center>
@@ -285,12 +284,12 @@ func TestAnimeWorldGetStreamURL_FallsThroughBadAlternative(t *testing.T) {
 	body := fmt.Sprintf(`<html><body><center>
 		<a href="not-a-url" id="alternativeDownloadLink">Alt</a>
 		<a href="%s" id="downloadLink">Diretto</a>
-	</center></body></html>`, animeWorldhellsingWrapURL)
+	</center></body></html>`, animeWorldHellsingWrapURL)
 	client, epURL := newAnimeWorldTestClient(t, body)
 
 	streamURL, err := client.GetStreamURL(epURL)
 	require.NoError(t, err)
-	assert.Equal(t, animeWorldhellsingDirectMP4, streamURL)
+	assert.Equal(t, animeWorldHellsingDirectMP4, streamURL)
 }
 
 // URL doesn't match /play/<slug> → validation rejects it before any HTTP call.
@@ -300,14 +299,14 @@ func TestAnimeWorldGetStreamURL_InvalidEpisodeURL(t *testing.T) {
 
 	_, err := client.GetStreamURL("https://www.animeworld.ac/not-a-play-path")
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "invalid URL path")
+	assert.Contains(t, err.Error(), "unexpected URL path")
 }
 
 // Server replies non-2xx → bubbles up as an error.
 func TestAnimeWorldGetStreamURL_ServerError(t *testing.T) {
 	t.Parallel()
 	mux := http.NewServeMux()
-	mux.HandleFunc(animeWorldhellsingEpPath, func(w http.ResponseWriter, _ *http.Request) {
+	mux.HandleFunc(animeWorldHellsingEpPath, func(w http.ResponseWriter, _ *http.Request) {
 		http.Error(w, "boom", http.StatusInternalServerError)
 	})
 	srv := httptest.NewServer(mux)
@@ -318,12 +317,12 @@ func TestAnimeWorldGetStreamURL_ServerError(t *testing.T) {
 	client.maxRetries = 0
 	client.retryDelay = 0
 
-	_, err := client.GetStreamURL(srv.URL + animeWorldhellsingEpPath)
+	_, err := client.GetStreamURL(srv.URL + animeWorldHellsingEpPath)
 	require.Error(t, err)
 }
 
-// download url selection
-// download url selection
+// --- normalizeVideoURL ---
+
 func TestAnimeWorldNormalizationStreamURL(t *testing.T) {
 	t.Parallel()
 
@@ -331,7 +330,7 @@ func TestAnimeWorldNormalizationStreamURL(t *testing.T) {
 		name    string
 		input   string
 		want    string
-		wantErr string // substring match; empty = no error. No sentinel error
+		wantErr string // substring match; empty = no error
 	}{
 		{
 			name:  "wrapper url is normalized to direct mp4",
@@ -366,12 +365,12 @@ func TestAnimeWorldNormalizationStreamURL(t *testing.T) {
 		{
 			name:    "non-mp4 non-wrapper url is rejected",
 			input:   "https://example.com/stream/playlist.m3u8",
-			wantErr: "unsupported video url",
+			wantErr: "unsupported video URL",
 		},
 		{
 			name:    "malformed url is rejected",
 			input:   "http://[::1",
-			wantErr: "invalid url",
+			wantErr: "invalid video URL",
 		},
 	}
 
@@ -380,7 +379,7 @@ func TestAnimeWorldNormalizationStreamURL(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got, err := c.normalizeAnimeWorldVideoURL(tt.input)
+			got, err := c.normalizeVideoURL(tt.input)
 			if tt.wantErr != "" {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.wantErr)
@@ -392,8 +391,11 @@ func TestAnimeWorldNormalizationStreamURL(t *testing.T) {
 	}
 }
 
+// --- API path ---
+
 func TestAnimeWorldStreamURL_FromAPI(t *testing.T) {
 	t.Parallel()
+
 	streamURL := "https://www.animeworld.ac/jojo.mp4"
 	epID := "TMWIn"
 	episodeURL := fmt.Sprintf("https://www.animeworld.ac/play/%s", epID)
@@ -401,7 +403,6 @@ func TestAnimeWorldStreamURL_FromAPI(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, epID, r.URL.Query().Get("id"))
-
 		w.Header().Set("Content-Type", "application/json")
 		b, err := json.Marshal(animeWorldAPIResponse{
 			Grabber: streamURL,

--- a/internal/scraper/goyabu.go
+++ b/internal/scraper/goyabu.go
@@ -91,14 +91,7 @@ type goyabuSearchResult struct {
 // SearchAnime searches for anime on goyabu.io
 // Uses the WordPress REST API search endpoint
 func (c *GoyabuClient) SearchAnime(query string) ([]*models.Anime, error) {
-	// Normalize query: replace hyphens/underscores with spaces for WordPress search
-	// (CLI args arrive hyphenated like "cavaleiro-do-zodiaco" but Goyabu needs spaces)
-	query = strings.TrimSpace(query)
-	query = strings.ReplaceAll(query, "-", " ")
-	query = strings.ReplaceAll(query, "_", " ")
-	for strings.Contains(query, "  ") {
-		query = strings.ReplaceAll(query, "  ", " ")
-	}
+	query = normalizeQuery(query)
 
 	util.Debug("Goyabu search", "query", query)
 
@@ -793,6 +786,28 @@ func (c *GoyabuClient) sleep() {
 }
 
 func (c *GoyabuClient) resolveURL(base, ref string) string {
+	if strings.HasPrefix(ref, "http") {
+		return ref
+	}
+	if strings.HasPrefix(ref, "/") {
+		return base + ref
+	}
+	return base + "/" + ref
+}
+
+// normalizeQuery replaces hyphens/underscores with spaces.
+// (CLI args arrive hyphenated like "cavaleiro-do-zodiaco" but some scrapers needs spaces)
+func normalizeQuery(query string) string {
+	query = strings.TrimSpace(query)
+	query = strings.ReplaceAll(query, "-", " ")
+	query = strings.ReplaceAll(query, "_", " ")
+	for strings.Contains(query, "  ") {
+		query = strings.ReplaceAll(query, "  ", " ")
+	}
+	return query
+}
+
+func resolveURL(base, ref string) string {
 	if strings.HasPrefix(ref, "http") {
 		return ref
 	}

--- a/internal/scraper/superflix_test.go
+++ b/internal/scraper/superflix_test.go
@@ -2115,8 +2115,8 @@ func TestEnsureJSONResponse_BlankBodyWithBadStatus_2026_04_30(t *testing.T) {
 // evening reproduced a 1-day-of-leak window. Pin two boundary cases on
 // a fixed clock so neither timezone nor wall-clock drift can hide a
 // regression:
-//   1. now=2026-05-02 03:30 UTC, ep.air_date=2026-05-03 → must be filtered
-//   2. now=2026-05-02 03:30 UTC, ep.air_date=2026-05-02 → must be kept
+//  1. now=2026-05-02 03:30 UTC, ep.air_date=2026-05-03 → must be filtered
+//  2. now=2026-05-02 03:30 UTC, ep.air_date=2026-05-02 → must be kept
 func TestFilterEpisodesByAirDate_TomorrowIsNotKept_2026_05_02(t *testing.T) {
 	t.Parallel()
 

--- a/internal/scraper/unified.go
+++ b/internal/scraper/unified.go
@@ -30,8 +30,9 @@ const (
 const (
 	AllAnimeType ScraperType = iota
 	AnimefireType
-	GoyabuType    // PT-BR anime source
-	SuperFlixType // SuperFlix PT-BR movies/series/animes/doramas
+	GoyabuType     // PT-BR anime source
+	SuperFlixType  // SuperFlix PT-BR movies/series/animes/doramas
+	AnimeWorldType // IT anime source
 )
 
 // UnifiedScraper provides a common interface for all scrapers
@@ -75,6 +76,7 @@ func NewScraperManager() *ScraperManager {
 		manager.scrapers[AnimefireType] = &AnimefireAdapter{client: NewAnimefireClient()}
 		manager.scrapers[GoyabuType] = &GoyabuAdapter{client: NewGoyabuClient()}
 		manager.scrapers[SuperFlixType] = &SuperFlixAdapter{client: NewSuperFlixClient()}
+		manager.scrapers[AnimeWorldType] = &AnimeWorldAdapter{client: NewAnimeWorldClient()}
 
 		globalScraperManager = manager
 	})
@@ -401,6 +403,7 @@ func (sm *ScraperManager) tagResults(results []*models.Anime, scraperType Scrape
 			strings.Contains(anime.Name, "[PT-BR]") ||
 			strings.Contains(anime.Name, "[Portuguese]") ||
 			strings.Contains(anime.Name, "[Português]") ||
+			strings.Contains(anime.Name, "[Italian]") ||
 			strings.Contains(anime.Name, "[Multilanguage]") ||
 			strings.Contains(anime.Name, "[Movie]") ||
 			strings.Contains(anime.Name, "[TV]")
@@ -462,6 +465,7 @@ func (sm *ScraperManager) logSearchSummary(results []*models.Anime) {
 		"9anime", counts["9Anime"],
 		"goyabu", counts["Goyabu"],
 		"superflix", counts["SuperFlix"],
+		"animeWorld", counts["AnimeWorld"],
 		"total", len(results))
 }
 
@@ -533,6 +537,8 @@ func (sm *ScraperManager) getScraperDisplayName(scraperType ScraperType) string 
 		return "Goyabu"
 	case SuperFlixType:
 		return "SuperFlix"
+	case AnimeWorldType:
+		return "AnimeWorld"
 	default:
 		return "Desconhecido"
 	}
@@ -549,6 +555,8 @@ func (sm *ScraperManager) getLanguageTag(scraperType ScraperType) string {
 		return "[PT-BR]"
 	case SuperFlixType:
 		return "[PT-BR]"
+	case AnimeWorldType:
+		return "[Italian]"
 	default:
 		return "[Unknown]"
 	}
@@ -763,4 +771,29 @@ func (a *SuperFlixAdapter) GetClient() *SuperFlixClient {
 // Useful for testing with mock servers.
 func NewSuperFlixAdapterWithClient(client *SuperFlixClient) *SuperFlixAdapter {
 	return &SuperFlixAdapter{client: client}
+}
+
+// AnimeWorldAdapter adapts AnimeWorldClient to UnifiedScraper interface
+type AnimeWorldAdapter struct {
+	client *AnimeWorldClient
+}
+
+func (a *AnimeWorldAdapter) SearchAnime(query string, options ...any) ([]*models.Anime, error) {
+	return a.client.SearchAnime(query)
+}
+
+func (a *AnimeWorldAdapter) GetAnimeEpisodes(animeURL string) ([]models.Episode, error) {
+	return a.client.GetAnimeEpisodes(animeURL)
+}
+
+func (a *AnimeWorldAdapter) GetStreamURL(episodeURL string, _ ...any) (string, map[string]string, error) {
+	streamURL, err := a.client.GetStreamURL(episodeURL)
+	if err != nil {
+		return "", nil, err
+	}
+	return streamURL, map[string]string{"source": "animeworld"}, nil
+}
+
+func (a *AnimeWorldAdapter) GetType() ScraperType {
+	return AnimeWorldType
 }

--- a/internal/scraper/unified.go
+++ b/internal/scraper/unified.go
@@ -797,3 +797,11 @@ func (a *AnimeWorldAdapter) GetStreamURL(episodeURL string, _ ...any) (string, m
 func (a *AnimeWorldAdapter) GetType() ScraperType {
 	return AnimeWorldType
 }
+
+func (a *AnimeWorldAdapter) GetClient() *AnimeWorldClient {
+	return a.client
+}
+
+func NewAnimeWorldAdapterWithClient(client *AnimeWorldClient) *AnimeWorldAdapter {
+	return &AnimeWorldAdapter{client: client}
+}

--- a/internal/tui/program_test.go
+++ b/internal/tui/program_test.go
@@ -11,7 +11,7 @@ import (
 // minimalModel is the simplest possible Bubble Tea model for construction tests.
 type minimalModel struct{}
 
-func (m minimalModel) Init() tea.Cmd                        { return nil }
+func (m minimalModel) Init() tea.Cmd                       { return nil }
 func (m minimalModel) Update(tea.Msg) (tea.Model, tea.Cmd) { return m, nil }
 func (m minimalModel) View() tea.View                      { return tea.NewView("") }
 

--- a/internal/upscaler/install_and_pipeline_test.go
+++ b/internal/upscaler/install_and_pipeline_test.go
@@ -85,14 +85,14 @@ func TestValidateShaderSourceURL_RejectsAttackerHosts(t *testing.T) {
 		"https://evil.example.com/payload.zip",
 		"https://attacker-controlled.io/shader",
 		"https://example.com.github.com.attacker.io/x",
-		"http://github.com/bloc97/Anime4K",        // http on non-loopback rejected
+		"http://github.com/bloc97/Anime4K",         // http on non-loopback rejected
 		"file:///etc/passwd",                       // wrong scheme
 		"ftp://github.com/x",                       // wrong scheme
 		"https://192.168.1.1/internal",             // private IP not in allowlist
 		"https://10.0.0.5/internal",                // private IP
 		"https://169.254.169.254/latest/meta-data", // AWS IMDS
-		"",                                          // empty
-		"not-a-url",                                // garbage
+		"",          // empty
+		"not-a-url", // garbage
 	} {
 		assert.Error(t, validateShaderSourceURL(u), u)
 	}
@@ -116,11 +116,11 @@ func TestInstallGANShaders_RejectsAttackerURL(t *testing.T) {
 
 func TestInstallShaders_Success(t *testing.T) {
 	zipBytes := buildGLSLZip(t, map[string]string{
-		"shaders/Anime4K_Clamp_Highlights.glsl":  "clamp",
-		"shaders/Anime4K_Restore_CNN_M.glsl":     "restore",
-		"shaders/Anime4K_Upscale_CNN_x2_M.glsl":  "upscale",
-		"shaders/Anime4K_Other_File.glsl":        "other",
-		"README.md":                              "ignored",
+		"shaders/Anime4K_Clamp_Highlights.glsl": "clamp",
+		"shaders/Anime4K_Restore_CNN_M.glsl":    "restore",
+		"shaders/Anime4K_Upscale_CNN_x2_M.glsl": "upscale",
+		"shaders/Anime4K_Other_File.glsl":       "other",
+		"README.md":                             "ignored",
 	})
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = w.Write(zipBytes)
@@ -588,9 +588,9 @@ func TestSSRFRegression_InstallGANShaders_AttackerServerNeverContacted(t *testin
 func TestSSRFRegression_InternalNetworkProbeBlocked(t *testing.T) {
 	t.Parallel()
 	dangerous := []string{
-		"https://169.254.169.254/latest/meta-data/iam/security-credentials/",   // AWS IMDS
+		"https://169.254.169.254/latest/meta-data/iam/security-credentials/",                          // AWS IMDS
 		"https://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token", // GCP
-		"http://169.254.169.254/metadata/instance?api-version=2021-02-01",      // Azure IMDS
+		"http://169.254.169.254/metadata/instance?api-version=2021-02-01",                             // Azure IMDS
 		"https://10.0.0.1/admin",
 		"https://172.16.0.1/admin",
 		"https://192.168.1.1/router",


### PR DESCRIPTION
## 🇮🇹 Italian community support 

I have added a new scraper source for animeworld.ac, which offers Italian-dubbed and subbed anime. This includes a new scraper implementation, updated scrapers, and metadata adaptations to support the new source.

Scraping is implemented via HTML scraping of both anime/episode data and video source URLs. Appropriate unit and integration tests were also added.

The application works  end-to-end with the new source.

### Testing and known issues
#### Tests
An issue was present when executing `go test ./...`: 
the tests proceed as normal, then suddenly the tui appears and the terminal freezes. 

Testing all packages one by one doesn't give any problem at all

---

This is my first contribution to a codebase of this size, so it's possible I missed some places where the new code should have been adapted or integrated — the codebase is large and I did my best to follow the existing patterns. Please let me know if anything needs adjusting.



