### PR TITLE
Corrigindo o link quebrado do instalador Windows nos READMEs

### DIFF
--- a/README_pt-br.md
+++ b/README_pt-br.md
@@ -121,7 +121,7 @@ sudo mv goanime-linux-amd64 /usr/local/bin/goanime
 
 **Recomendado:** Use o aplicativo de instalação para uma melhor experiência.
 
-1.  Baixe e execute o [Instalador do Windows](https://github.com/alvarorichard/GoAnime/releases/latest/download/GoAnimeInstaller.exe).
+1.  Baixe e execute o [Instalador do Windows](https://github.com/alvarorichard/GoAnime/releases/latest).
 2.  Lembre-se também de instalar o `mpv` e adicioná-lo ao PATH do seu sistema.
 
 ## Como usar


### PR DESCRIPTION
O README aponta para releases/latest/download/GoAnimeInstaller.exe, mas as releases recentes publicam o instalador com nome versionado (ex: GoAnime-Installer-1.8.3.exe), então o link retorna 404 a cada nova versão. Este PR troca o link direto pelo link da página de releases (releases/latest), que não quebra quando o nome do arquivo muda de versão.